### PR TITLE
Fixing typo of "clearInterval". 

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -76,7 +76,7 @@
       nativeKeys = Object.keys;
 
   /** Timer shortcuts */
-  var clearInteval = window.clearInterval,
+  var clearInterval = window.clearInterval,
       setTimeout = window.setTimeout;
 
   /** Compilation options for `_.difference` */


### PR DESCRIPTION
Worth noting though – this function isn't used elsewhere. Perhaps it should be removed.
