### PR TITLE
+ CDN & jsPerf links for the ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ In browsers:
 
 ~~~ html
 <script src="lodash.js"></script>
+
 or use the CDN:
 <script src="http://cdnjs.cloudflare.com/ajax/libs/lodash.js/0.3.2/lodash.min.js"></script>
 ~~~


### PR DESCRIPTION
Guess who cast the tipping vote for CDN hosting?  http://cdnjs.uservoice.com/forums/98277-general/suggestions/2860970-lodash-js
At first I thought it would be a too early version for CDNs, but I started to see lo-dash out in the wild more & more...
The CDN URL is mentioned 2 times in the ReadMe.

Also added a few links to encourage testing on jsPerf.  You may have heard what a great site that is ;)
