### PR TITLE
Custom sourceURL by passing an option to _.template

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3809,13 +3809,10 @@
 
     // use a sourceURL for easier debugging
     // http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/#toc-sourceurl
-    var sourceURL = ''
+    var sourceURL = '';
 
     if( useSourceURL ) {
-      sourceURL = '\n//@ sourceURL=' + (
-        options.sourceURL ? 
-        options.sourceURL 
-        : '/lodash/template/source' + '['+ (templateCounter++) +']' )
+      sourceURL = '\n//@ sourceURL=' + (options.sourceURL ? options.sourceURL : '/lodash/template/source' + '[' + (templateCounter++) + ']');
     } else {
       sourceURL = '';
     }


### PR DESCRIPTION
When building a large application with a build script it was hard to tell which template was being compiled and where the error was. This allows the user to specify the url to be used. So we build our templates into one file with grunt and the filename becomes the key in the object. So by being able to specify the sourceURL it actually maps directly to the file name not just the N template compiled.
