### PR TITLE
Optimization to shallow flatten

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2623,6 +2623,8 @@
         length = array ? array.length : 0,
         result;
 
+    //Shallow flatten optimization
+    //The 10K limit is due to the limit of arguments in a function call
     if (shallow && length <= 10000) {
         return Array.prototype.concat.apply([], array);
     }


### PR DESCRIPTION
When we are doing shallow flattening, using 

Array.prototype.concat.apply([], array);

is faster (see http://jsperf.com/fastest-way-to-merge-2-dimension-arrays)

The length <= 10000 is because there is a limit to the number of 
parameters passed to a function.

P.S.: I should probably have included lodash with no conflict, if it's a problem I can change that and run them again.
