### PR TITLE
Fix for jam dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "rhino"
   ],
   "jam": {
-    "main": "./lodash.js"
+    "main": "./lodash.js",
+    "dependencies": {}
   },
   "scripts": {
     "build": "node build",


### PR DESCRIPTION
jam install lodash is not working as it is thinking that tar is a dependency.
Just adding a empty dependencies object to the jam section fixes this.

After pulling this, could you republish to the jam repo? No need to bump the package version, just

```
jam publish -f
```

cheers
