### PR TITLE
fix the _.rest arguments definitions

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -496,7 +496,7 @@ The opposite of `_.initial`, this method gets all but the first value of `array`
 
 #### Arguments
 1. `array` *(Array)*: The array to query.
-2. `[n]` *(Number)*: The number of elements to return.
+2. `[n]` *(Number)*: The number of elements to exclude at the head of the `array`.
 
 #### Returns
 *(Array)*: Returns all but the first value or `n` values of `array`.


### PR DESCRIPTION
The argument list for `_.rest` was a copy paste of  `_.initial`. The `[n]` parameter is not the number of elements returned (as this depends on the length of the `array`), but it's actually, according to the doc string, the number of elements to skip at the head of the array.

Actually, it seems to be the pendent of `_.first` more than `_.initial` as:

```
var array = [1,2,3,4,5];
_.first(array, 2); // => [1, 2]
_.rest(array, 2); // => [3,4,5]
```

(I didn't change that bit in the doc though)
