### PR TITLE
Add an `args` argument to `_.result`.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3700,11 +3700,12 @@
    * _.result(object, 'stuff');
    * // => 'nonsense'
    */
-  function result(object, property) {
+  function result(object, property, args) {
     // based on Backbone's private `getValue` function
     // https://github.com/documentcloud/backbone/blob/0.9.2/backbone.js#L1419-1424
-    var value = object ? object[property] : null;
-    return isFunction(value) ? object[property]() : value;
+    return isFunction(object[property]) 
+      ? object[property].apply(object, toArray(args)) 
+      : value;
   }
 
   /**


### PR DESCRIPTION
I added 3rd argument "args" that is passed to method if it is a function:

``` js
_.result(console, 'log', 'param'); => window.log.apply(window, ['param']);
_.result(console, 'log', ['param', 'param2']); => window.log.apply(window, ['param', 'param2']);
```
