### PR TITLE
[].slice back to `_.toArray` yet test for NodeList in IE < 9

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2594,12 +2594,13 @@
    * // => [2, 3, 4]
    */
   function toArray(collection) {
-    var length = collection ? collection.length : 0;
-    return typeof length == 'number'
-      ? isString(collection)
-        ? collection.split('')
-        : toarr(collection)
-      : values(collection);
+    return collection
+      ? typeof collection.length == 'number'
+        ? isString(collection)
+          ? collection.split('')
+          : toarr(collection)
+        : values(collection)
+      : [];
   }
 
   /**


### PR DESCRIPTION
Added test: if `[].slice` can accept NodeList, use it, otherwise use `while` version in `_.toArray`
