### PR TITLE
Throttle trailing callback

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3591,6 +3591,7 @@
 
       if (remaining <= 0) {
         clearTimeout(timeoutId);
+        timeoutId = null;
         lastCalled = now;
         result = func.apply(thisArg, args);
       }

--- a/test/test.js
+++ b/test/test.js
@@ -1801,6 +1801,39 @@
         QUnit.start();
       }, 260);
     });
+
+    asyncTest('should call back immediatly only once when called once', function() {
+      var counter = 0,
+          throttled = _.throttle(function() { counter++; }, 20);
+
+      throttled();
+      equal(counter, 1);
+
+      setTimeout(function() {
+        equal(counter, 1);
+        QUnit.start();
+      }, 35);
+    });
+
+    asyncTest('should call back after the last time it is called when called constantly', function() {
+      var start = new Date,
+          counter = 0,
+          throttled = _.throttle(function() { counter++; }, 10);
+
+      while (new Date - start <= 25) {
+        throttled();
+      }
+
+      setTimeout(function () {
+        throttled();
+        throttled();
+      }, 35);
+
+      setTimeout(function () {
+        equal(counter, 6);
+        QUnit.start();
+      }, 50);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
If you bound a 1s throttle to the scroll bar, then scrolled for a few seconds, then wait a few seconds, then scroll more and stop.  The trailing callback won't be called.

I've included 2 tests.  The first tests this specific situation.  The second tests an assumption the first test makes which is that a leading callback will be called and no other calls will happen when the throttled function is called once.

I've also included the 1 line fix. :+1: 

Thanks!
