### PR TITLE
Timer drift bug in throttle

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3591,6 +3591,7 @@
 
       if (remaining <= 0) {
         clearTimeout(timeoutId);
+        timeoutId = null;
         lastCalled = now;
         result = func.apply(thisArg, args);
       }


### PR DESCRIPTION
The remaining <= 0 case does not set timeoutId to null, so it is possible for throttle to drop calls and stop setting new timeouts entirely if it gets just the right call timings.  Setting timeoutId to null after the clearTimeout call fixes this.
