### PR TITLE
Add "@license" to copyright header block

### DIFF
--- a/build/post-compile.js
+++ b/build/post-compile.js
@@ -9,8 +9,8 @@
   var licenseTemplate = {
     'lodash':
       '/*!\n' +
-      ' Lo-Dash @VERSION lodash.com/license\n' +
-      ' @license Underscore.js 1.4.3 underscorejs.org/LICENSE\n' +
+      ' @license Lo-Dash @VERSION lodash.com/license\n' +
+      ' Underscore.js 1.4.3 underscorejs.org/LICENSE\n' +
       '*/',
     'underscore':
       '/*! Underscore.js @VERSION underscorejs.org/LICENSE */'

--- a/lodash.min.js
+++ b/lodash.min.js
@@ -1,6 +1,6 @@
 /*!
- Lo-Dash 1.0.0-rc.2 lodash.com/license
- @license Underscore.js 1.4.3 underscorejs.org/LICENSE
+ @license Lo-Dash 1.0.0-rc.2 lodash.com/license
+ Underscore.js 1.4.3 underscorejs.org/LICENSE
 */
 ;(function(e,t){function s(e){if(e&&"object"==typeof e&&e.__wrapped__)return e;if(!(this instanceof s))return new s(e);this.__wrapped__=e}function o(e,t,n){t||(t=0);var r=e.length,i=r-t>=(n||it);if(i)for(var s={},n=t-1;++n<r;){var o=e[n]+"";(Tt.call(s,o)?s[o]:s[o]=[]).push(e[n])}return function(n){if(i){var r=n+"";return Tt.call(s,r)&&-1<W(s[r],n)}return-1<W(e,n,t)}}function u(e){return e.charCodeAt(0)}function a(e,t){var n=e.b,r=t.b,e=e.a,t=t.a;if(e!==t){if(e>t||"undefined"==typeof e)return 1;if(
 e<t||"undefined"==typeof t)return-1}return n<r?-1:1}function f(e,t,n){function i(){var a=arguments,f=o?this:t;return s||(e=t[u]),n.length&&(a=a.length?n.concat(m(a)):n),this instanceof i?(v.prototype=e.prototype,f=new v,v.prototype=r,a=e.apply(f,a),C(a)?a:f):e.apply(f,a)}var s=N(e),o=!n,u=t;return o&&(n=t),s||(t=e),i}function l(e,t,n){return e?"function"!=typeof e?function(t){return t[e]}:"undefined"!=typeof t?n?function(n,r,i,s){return e.call(t,n,r,i,s)}:function(n,r,i){return e.call(t,n,r,i)}:e

--- a/lodash.underscore.min.js
+++ b/lodash.underscore.min.js
@@ -1,7 +1,6 @@
 /*!
- Lo-Dash 1.0.0-rc.2 (Custom Build) lodash.com/license
- Build: `lodash underscore -m -o ./lodash.underscore.min.js`
- @license Underscore.js 1.4.3 underscorejs.org/LICENSE
+ @license Lo-Dash 1.0.0-rc.2 lodash.com/license
+ Underscore.js 1.4.3 underscorejs.org/LICENSE
 */
 ;(function(e,t){function n(e){if(e&&"object"==typeof e&&e.__wrapped__)return e;if(!(this instanceof n))return new n(e);this.__wrapped__=e}function r(e,t){var n=e.b,r=t.b,e=e.a,t=t.a;if(e!==t){if(e>t||"undefined"==typeof e)return 1;if(e<t||"undefined"==typeof t)return-1}return n<r?-1:1}function i(e,t,n){function r(){var i=arguments,s=t;return n.length&&(i=i.length?n.concat(f(i)):n),this instanceof r?(a.prototype=e.prototype,s=new a,a.prototype=null,i=e.apply(s,i),y(i)?i:s):e.apply(s,i)}return r}function s
 (e,t,n){return e?"function"!=typeof e?function(t){return t[e]}:"undefined"!=typeof t?n?function(n,r,i,s){return e.call(t,n,r,i,s)}:function(n,r,i){return e.call(t,n,r,i)}:e:q}function o(e){return"\\"+xt[e]}function u(e){return kt[e]}function a(){}function f(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,n=n-t||0,i=Array(0>n?0:n);++r<n;)i[r]=e[t+r];return i}function l(e){return Lt[e]}function c(e){if(!e)return e;for(var t=1,n=arguments.length;t<n;t++){var r=arguments[t];if(r)


### PR DESCRIPTION
This adds the JSDoc `@license` to ensure that the comment block is not removed by Closure Compiler, if Lo-Dash is being included as part of another library.

I'm not sure under what condition the "underscore" template is used, I was not able to reproduce it's use, and thus I left it alone.

I'm not sure if this is something you'll rather have as an option to lodash, but this is what I was thinking for the output.
