### PR TITLE
Need mkdir -p during --output build option

### DIFF
--- a/build.js
+++ b/build.js
@@ -1510,6 +1510,14 @@
     var outputPath = options.reduce(function(result, value, index) {
       if (/-o|--output/.test(value)) {
         result = options[index + 1];
+        var cwd = process.cwd();
+        path.dirname(result).split(path.sep).forEach(function(pathSegment){
+          try {
+            fs.mkdirSync(pathSegment);
+          } catch(err){}
+          process.chdir(pathSegment);
+        });
+        process.chdir(cwd);
         result = path.join(fs.realpathSync(path.dirname(result)), path.basename(result));
       }
       return result;

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -1073,9 +1073,11 @@
   QUnit.module('output options');
 
   (function() {
+    var nestedDir = 'test/mkdir/';
     var commands = [
       '-o a.js',
-      '--output a.js'
+      '--output a.js',
+      '-o ' + nestedDir + 'a.js'
     ];
 
     commands.forEach(function(command, index) {
@@ -1086,6 +1088,7 @@
         build(['-s'].concat(command.split(' ')), function(data) {
           equal(path.basename(data.outputPath, '.js'), (++counter ? 'a.min' : 'a'), command);
           start();
+          fs.existsSync(nestedDir) && fs.rmdirSync(nestedDir);
         });
       });
     });


### PR DESCRIPTION
This is a very basic implementation that doesn't handle any edge cases, but it implements a basic recursive mkdir when specifying directories that don't exist for the `--output` option
