### PR TITLE
Remove isJSC variable in mobile builds

### DIFF
--- a/build.js
+++ b/build.js
@@ -1109,6 +1109,7 @@
    * @returns {String} Returns the modified source.
    */
   function removeKeysOptimization(source) {
+    source = removeVar(source, 'isJSC');
     source = removeVar(source, 'isKeysFast');
 
     // remove optimized branch in `iteratorTemplate`

--- a/lodash.js
+++ b/lodash.js
@@ -172,8 +172,10 @@
 
     /** Detect various environments */
     var isIeOpera = !!context.attachEvent,
-        isJSC = !/\n{2,}/.test(Function()),
         isV8 = nativeBind && !/\n|true/.test(nativeBind + isIeOpera);
+
+    /* On its own line so it can be removed for mobile builds */
+    var isJSC = !/\n{2,}/.test(Function());
 
     /* Detect if `Function#bind` exists and is inferred to be fast (all but V8) */
     var isBindFast = nativeBind && !isV8;


### PR DESCRIPTION
Fixes a problem with content security errors related to `Function()` use (Issue #54).

Something controversial here would be the decision to remove the variable over say, set it to false.  But since it's only used currently in the test for `isKeysFast` which is also removed, I thought it best to move it to it's own line and remove it.
