### PR TITLE
isPlainObject calls undefined function in IE8

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -1625,7 +1625,7 @@
         return false;
       }
       var valueOf = value.valueOf,
-          objProto = typeof valueOf == 'function' && (objProto = getPrototypeOf(valueOf)) && getPrototypeOf(objProto);
+          objProto = typeof valueOf == 'function' && typeof getPrototypeOf == 'function' && (objProto = getPrototypeOf(valueOf)) && getPrototypeOf(objProto);
 
       return objProto
         ? (value == objProto || getPrototypeOf(value) == objProto)


### PR DESCRIPTION
The function is trying to run the function getPrototypeOf, when the function is false. (As it's not natively in the browser)

Added an extra check, causing it to revert to shim.
