### PR TITLE
AngularJS module definition

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5570,6 +5570,10 @@
       freeExports._ = _;
     }
   }
+  // AngularJS module definition (AngularJS discourages to keep anything in global window)
+  else if (typeof angular == 'object' && typeof angular.module == 'function') {
+    angular.module('lodash', []).constant('_', _);
+  }
   else {
     // in a browser or Rhino
     window._ = _;


### PR DESCRIPTION
I've added AngularJS module definition in the exposing code. It is suitable when used in AngularJS application to inject it via framework's dependency injection mechanics, and not keep it in global window object.

More info on DI in AngularJS: http://docs.angularjs.org/guide/di
