### PR TITLE
make node executable case insensitive when build

### DIFF
--- a/build.js
+++ b/build.js
@@ -30,7 +30,7 @@
   var multilineComment = '(?:\\n */\\*[^*]*\\*+(?:[^/][^*]*\\*+)*/)?\\n';
 
   /** Used to detect the Node.js executable in command-line arguments */
-  var reNode = RegExp('(?:^|' + path.sepEscaped + ')node(?:\\.exe)?$');
+  var reNode = RegExp('(?:^|' + path.sepEscaped + ')node(?:\\.exe)?$', 'i');
 
   /** Shortcut to the `stdout` object */
   var stdout = process.stdout;


### PR DESCRIPTION
sometimes, when i build lodash, my node executable is not lowercase, and then, the build will fail.

for example, when build lodash within grunt, "grunt.util.spawn" use "which (isaacs/node-which)" to get the path of node executable, the path will end with '.EXE' in windows platform. and then there is problems.
