### PR TITLE
var _ = require('lodash'); - this doesn't work in Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ var lodash = require('lodash');
 var lodash = require('lodash/dist/lodash.underscore');
 ```
 
-**Note:** You can't name a variable '''_''' in Node.js. See [REPL docs.](http://nodejs.org/api/repl.html#repl_repl_features)
+**Note:** You can't name a variable ```_``` in Node.js. See [REPL docs.](http://nodejs.org/api/repl.html#repl_repl_features)
 
 **Note:** If Lo-Dash is installed globally, run [`npm link lodash`](http://blog.nodejs.org/2011/03/23/npm-1-0-global-vs-local-installation/) in your project’s root directory before requiring it.
 


### PR DESCRIPTION
I suppose there is a misleading information in "Installation" section. If you try to do `var _ = require('lodash')` in Node, the variable `_` will be set to undefined. This is because `_` is the special variable in REPL (it contains the result of the last expression) and you can't assign it any value.

[See REPL docs.](http://nodejs.org/api/repl.html#repl_repl_features)
[Also see comments in this issue.](https://github.com/bestiejs/lodash/issues/88)
