### PR TITLE
Enable _.range() to accept a 0 for step

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4687,7 +4687,7 @@
      */
     function range(start, end, step) {
       start = +start || 0;
-      step = +step || 1;
+      step = isNumber(step) ? step : 1;
 
       if (end == null) {
         end = start;
@@ -4696,7 +4696,7 @@
       // use `Array(length)` so engines, like Chakra and V8, avoid slower modes
       // http://youtu.be/XAqIpGU8ZZk#t=17m25s
       var index = -1,
-          length = nativeMax(0, ceil((end - start) / step)),
+          length = nativeMax(0, ceil((end - start) / (step || 1))),
           result = Array(length);
 
       while (++index < length) {


### PR DESCRIPTION
Enable `_.range()` to accept a `0` for `step`, for initializing arrays such as `[0, 0, 0, 0, 0]`, `[-1, -1, -1, -1, -1]`, useful in many use cases where you need an array which defaults to a basic value.

I don't know how to write tests (bad... I know), but I have tested all of the function's behaviors and everything is still intact, including "negative direction" arrays.

Cheers.
