### PR TITLE
Add `_.append` and `_.prepend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The full changelog for this release is available on our [wiki](https://github.co
  * [_.merge](http://lodash.com/docs#merge) for a deep [_.extend](http://lodash.com/docs#extend)
  * [_.parseInt](http://lodash.com/docs#parseInt) for consistent behavior
  * [_.partialRight](http://lodash.com/docs#partialRight) for [partial application](http://lodash.com/docs#partial) from the right
- * [_.pull](http://lodash.com/docs#pull) & [_.remove](http://lodash.com/docs#remove) for mutating arrays
+ * [_.pull](http://lodash.com/docs#pull), [_.remove](http://lodash.com/docs#remove), [_.append](http://lodash.com/docs#append) & [_.prepend](http://lodash.com/docs#prepend) for mutating arrays
  * [_.random](http://lodash.com/docs#random) supports returning floating-point numbers
  * [_.runInContext](http://lodash.com/docs#runInContext) for easier mocking
  * [_.support](http://lodash.com/docs#support) for flagging environment features

--- a/lodash.js
+++ b/lodash.js
@@ -4993,6 +4993,75 @@
     }
 
     /**
+     * Appends an element or array of elements into `array`.
+     *
+     * @static
+     * @memberOf _
+     * @category Arrays
+     * @param {Array} array The array to modify.
+     * @param {Array|*} The element or array of elements to append into array.
+     * @returns {Array} Returns `array`.
+     * @example
+     *
+     * var array = [1, 2];
+     * _.append(array, 3);
+     *
+     *
+     * console.log(array);
+     * // => [1, 2, 3]
+     *
+     * _.append(array, [4, 5]);
+     *
+     * console.log();
+     * // => [1, 2, 3, 4, 5]]
+     */
+    function append(array, data) {
+      if (!(isArray(array) || isArguments(array))) {
+        return array;
+      } else if (isArray(data) || isArguments(data)) {
+        push.apply(array, data);
+      } else {
+        push.call(array, data);
+      }
+
+      return array;
+    }
+
+    /**
+     * Prepend an element or array of elements into `array`.
+     *
+     * @static
+     * @memberOf _
+     * @category Arrays
+     * @param {Array} array The array to modify.
+     * @param {Array|*} The element or array of elements to prepend into array.
+     * @returns {Array} Returns `array`.
+     * @example
+     *
+     * var array = [4, 5];
+     * _.prepend(array, 3);
+     *
+     * console.log(array);
+     * // => [3, 4, 5];
+     *
+     * _.prepend(array, [1, 2]);
+     *
+     * console.log(array);
+     * // => [1, 2, 3, 4, 5];
+     */
+    function prepend(array, data) {
+      if (!(isArray(array) || isArguments(array))) {
+        return array;
+      } else if (isArray(data) || isArguments(data)) {
+        unshift.apply(array, data);
+      } else {
+        unshift.call(array, data);
+      }
+
+      return array;
+    }
+
+    /**
      * The opposite of `_.initial` this method gets all but the first element or
      * first `n` elements of an array. If a callback function is provided elements
      * at the beginning of the array are excluded from the result as long as the
@@ -6633,6 +6702,8 @@
     lodash.range = range;
     lodash.reject = reject;
     lodash.remove = remove;
+    lodash.append = append;
+    lodash.prepend = prepend;
     lodash.rest = rest;
     lodash.shuffle = shuffle;
     lodash.sortBy = sortBy;

--- a/test/test.js
+++ b/test/test.js
@@ -4736,6 +4736,54 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.append');
+
+  (function () {
+    test('should append an element into the array', 2, function() {
+      var array = [1, 2];
+
+      var actual = _.append(array, 3);
+
+      equal(actual, array);
+      deepEqual(array, [1, 2, 3]);
+    });
+
+    test('should append multiple elements into the array', 2, function() {
+      var array = [1, 2];
+
+      var actual = _.append(array, [3, 4]);
+
+      equal(actual, array);
+      deepEqual(array, [1, 2, 3, 4]);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
+  QUnit.module('lodash.prepend');
+
+  (function () {
+    test('should prepend an element into the array', 2, function() {
+      var array = [2, 3];
+
+      var actual = _.prepend(array, 1);
+
+      equal(actual, array);
+      deepEqual(array, [1, 2, 3]);
+    });
+
+    test('should prepend multiple elements into the array', 2, function() {
+      var array = [3, 4];
+
+      var actual = _.prepend(array, [1, 2]);
+
+      equal(actual, array);
+      deepEqual(array, [1, 2, 3, 4]);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.result');
 
   (function() {
@@ -6636,9 +6684,10 @@
 
  (function() {
     var args = arguments,
-        array = [1, 2, 3, 4, 5, 6];
+        array = [1, 2, 3, 4, 5, 6],
+        array2 = [1];
 
-    test('should work with `arguments` objects', 23, function() {
+    test('should work with `arguments` objects', 27, function() {
       function message(methodName) {
         return '`_.' + methodName + '` should work with `arguments` objects';
       }
@@ -6673,6 +6722,16 @@
 
       _.remove(args, function(value) { return typeof value == 'number'; });
       ok(args.length == 1 && _.isEqual(args[0], [3]), message('remove'));
+
+      _.append(args, 1);
+      deepEqual([args[0], args[1]], [[3], 1], message('append'));
+      _.append(array2, args);
+      deepEqual(array2, [1, [3], 1], '_.append should work with `arguments` objects as secondary arguments');
+
+      _.prepend(args, 4);
+      deepEqual([args[0], args[1], args[2]], [4, [3], 1], message('prepend'));
+      _.prepend(array2, args);
+      deepEqual(array2, [4, [3], 1, 1, [3], 1], '_.prepend should work with `arguments` objects as secondary arguments');
     });
 
     test('should accept falsey primary arguments', 3, function() {
@@ -6753,7 +6812,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 148, function() {
+    test('should accept falsey arguments', 150, function() {
       var isExported = '_' in root,
           oldDash = root._;
 


### PR DESCRIPTION
As there is _.pull and _.remove to manipulate arrays, I thought it might be good idea to also offer functions to add new elements.

Use case with AngularJS/SocketIO

```
socket.on('list:init', _.partial(_.append, $scope.list)); // Multiple elements
socket.on('list:new', _.partial(_.append, $scope.list)); // Single element
```
