### PR TITLE
Fixed memory leak with debounce/throttle arguments and context

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5697,6 +5697,7 @@
           if (isCalled) {
             lastCalled = now();
             result = func.apply(thisArg, args);
+            args = thisArg = null;
           }
         } else {
           timeoutId = setTimeout(delayed, remaining);
@@ -5711,6 +5712,7 @@
         if (trailing || (maxWait !== wait)) {
           lastCalled = now();
           result = func.apply(thisArg, args);
+          args = thisArg = null;
         }
       };
 
@@ -5733,6 +5735,7 @@
             }
             lastCalled = stamp;
             result = func.apply(thisArg, args);
+            args = thisArg = null;
           }
           else if (!maxTimeoutId) {
             maxTimeoutId = setTimeout(maxDelayed, remaining);
@@ -5743,6 +5746,7 @@
         }
         if (leadingCall) {
           result = func.apply(thisArg, args);
+          args = thisArg = null;
         }
         return result;
       };


### PR DESCRIPTION
Noticed that both underscore and lodash hold onto the arguments and context of the last execution of a debounced/throttled function. This leak can be serious (as is was in my app, retaining a giant DOM tree)

underscore just merged my PR for this https://github.com/jashkenas/underscore/pull/1329

lodash's implementation is quite a bit more complex so let me know if I missed a case. As discussed in the underscore PR, there isn't really a way to test this. (Unless you want me to resort to _.debounce.toString().replace + eval trickery to inject some local scoped tests?)
