### PR TITLE
Add home link in docs. [ci skip]

### DIFF
--- a/doc/parse.php
+++ b/doc/parse.php
@@ -24,7 +24,7 @@
   // generate Markdown
   $markdown = docdown(array(
     'path'  => '../' . $filePath,
-    'title' => 'Lo-Dash <span>v' . $version . '</span>',
+    'title' => '<a href="http://lodash.com">Lo-Dash</a> <span>v' . $version . '</span>',
     'toc'   => 'categories',
     'url'   => 'https://github.com/lodash/lodash/blob/master/lodash.js'
   ));


### PR DESCRIPTION
There is no convenient way to go back to the main lodash site while reading the docs (online or offline).
This commit add a home link in the header.
