### PR TITLE
Ensure _.xor() returns new unique array.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5435,18 +5435,17 @@
      * // => [1, 4, 5]
      */
     function xor() {
-      var index = -1,
+      var result,
+          index = -1,
           length = arguments.length;
 
       while (++index < length) {
         var array = arguments[index];
         if (isArray(array) || isArguments(array)) {
-          var result = result
-            ? baseUniq(baseDifference(result, array).concat(baseDifference(array, result)))
-            : array;
+          result = result ? baseDifference(result, array).concat(baseDifference(array, result)) : array;
         }
       }
-      return result || [];
+      return result ? baseUniq(result) : [];
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -8108,9 +8108,10 @@
       deepEqual(actual, [1, 4, 5]);
     });
 
-    test('should return an array of unique values', 1, function() {
+    test('should return an array of unique values', 2, function() {
       var actual = _.xor([1, 1, 2, 5], [2, 2, 3, 5], [3, 4, 5, 5]);
       deepEqual(actual, [1, 4, 5]);
+      deepEqual(_.xor([1, 1]), [1]);
     });
 
     test('should return a wrapped value when chaining', 2, function() {


### PR DESCRIPTION
This ensures that `_.xor()` returns a new unique array regardless of the number of arrays it is given. Prior to this change passing one array like `_.xor([1, 1])` would return an unchanged reference.
