### PR TITLE
allow overriding Date.now

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -7114,7 +7114,7 @@
      * _.defer(function() { console.log(_.now() - stamp); });
      * // => logs the number of milliseconds it took for the deferred function to be called
      */
-    var now = isNative(now = Date.now) && now || function() {
+    var now = isNative(Date.now) ? function() {return Date.now();}  : function() {
       return new Date().getTime();
     };
 

--- a/test/test.js
+++ b/test/test.js
@@ -5637,6 +5637,13 @@
       	QUnit.start();
       }
     });
+
+    test('should allow overriding Date.now', 1, function() {
+      var _now = Date.now;
+      Date.now = function() {return -1;};
+      equal(_.now(), Date.now());
+      Date.now = _now;
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
This fixes sinon's useFakeTimers. See https://github.com/lodash/lodash/issues/304 .
