### PR TITLE
Test freeGlobal.self for browserified web workers.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -189,7 +189,7 @@
 
   /** Detect free variable `global` from Node.js or Browserified code and use it as `root` */
   var freeGlobal = objectTypes[typeof global] && global;
-  if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal)) {
+  if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal || freeGlobal.self === freeGlobal)) {
     root = freeGlobal;
   }
 


### PR DESCRIPTION
`self` is the global context name in web workers. So `freeGlobal.self === freeGlobal` is `true` in that environment when lodash is packaged in a library/site for use in web workers.
