### PR TITLE
use .apply for initial function call in compose then use .call in loop

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4672,14 +4672,17 @@
           throw new TypeError;
         }
       }
+      var funcsLength = funcs.length;
+      if (funcsLength === 1) {
+        return funcs[0];
+      }
       return function() {
-        var args = arguments,
-            length = funcs.length;
-
+        var length = funcsLength - 1,
+            result = funcs[length].apply(this, arguments);
         while (length--) {
-          args = [funcs[length].apply(this, args)];
+          result = funcs[length].call(this, result);
         }
-        return args[0];
+        return result;
       };
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1259,6 +1259,12 @@
       var welcome = _.compose(greet, format);
       equal(welcome('pebbles'), 'Hiya Penelope!');
     });
+    
+    test('should return original function if only one function passed', 1, function(){
+      var noop = function(){};
+      equal(_.compose(noop), noop);
+    });
+
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
As discussed in issue #463 and http://jsperf.com/compose-each/4 (simple compose impl) a big performance win can be had by using .apply only on the first function call and using .call in the loop. This maintains the current behavior of passing all the arguments into the first function call but passing the returned values into subsequent functions.

Additionally, there isn't a reason to do any of this logic if a single function is passed in so just return that function if length === 1.
