### PR TITLE
Add "browser" field for Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
       "test",
       "vendor"
     ]
-  }
+  },
+  "browser": "dist/lodash.compat.js"
 }


### PR DESCRIPTION
Browserify and other CJS builders will look for a "browser" field to use as an alternate "main" when targeting the browser environment.

https://github.com/substack/node-browserify#packagejson

Pointing it to the compat build would prevent issues like #288 happening out of the box, without any extra configuration.
