### PR TITLE
&#39; unescaped, but &#039; was not

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -164,7 +164,7 @@
     '&quot;': '"',
     '&#039;': "'",
     '&#39;': "'"
-};
+  };
 
   /** Used to determine if values are of the language type Object */
   var objectTypes = {


### PR DESCRIPTION
Some back-ends, such as PHP, have a trailing 0 in unicode HTML escape sequences. Seemed a simple enough thing to add support for. http://us1.php.net/manual/en/function.htmlspecialchars.php
