### PR TITLE
Add `_.iife` for immediately invoking functions.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -7956,6 +7956,40 @@
     }
 
     /**
+     * Takes a function and immediately invokes it. If any additional arguments
+     * are given, they will be passed along to the function being invoked.
+     * While this method can be used to conveniently wrap a function, it's also
+     * useful in tests when stubbing asynchronous functions.
+     *
+     * @static
+     * @memberOf _
+     * @category Utilities
+     * @param {Function} fn The function to invoke.
+     * @param {...*} args Any additional arguments to pass to `fn`.
+     * @returns {*} Whatever the return value from the invoked function was.
+     * @example
+     *
+     * function queueTask(taskFn) {
+     *   // setup task
+     *   var done = function() { queueNextTask(); };
+     *   taskFn(done);
+     * }
+     *
+     * asyncTest('queueTask should enqueue next task when one finishes', function() {
+     *   queueTask(_.iife);
+     *   queueTask(someOtherTask);
+     *   // assert someOtherTask was enqueued/executed.
+     * })
+     */
+    function iife(fn) {
+      var args;
+      if (typeof fn == 'function') {
+        args = slice(arguments, 1);
+        return fn.apply(null, args);
+      }
+    }
+
+    /**
      * Gets the number of milliseconds that have elapsed since the Unix epoch
      * (1 January 1970 00:00:00 UTC).
      *
@@ -8385,6 +8419,7 @@
     lodash.mixin = mixin;
     lodash.noConflict = noConflict;
     lodash.noop = noop;
+    lodash.iife = iife;
     lodash.now = now;
     lodash.pad = pad;
     lodash.padLeft = padLeft;

--- a/test/test.js
+++ b/test/test.js
@@ -6318,6 +6318,39 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.iife');
+
+  (function() {
+    test('should take a function given to it and immediately invoke it', 1, function() {
+      var pass = false;
+      var fnToInvoke = function() {
+        pass = true;
+      };
+
+      _.iife(fnToInvoke);
+      ok(pass);
+    });
+
+    test('should pass along additional positional args to the function', 1, function() {
+      var pass = false;
+      var fnToInvoke = function(a, b, c) {
+        if (a === 1 && b === 2 && c === 3) {
+          pass = true;
+        }
+      };
+
+      _.iife(fnToInvoke, 1, 2, 3);
+      ok(pass);
+    });
+
+    test('should return whatever the return value of the invoked function was', 1, function() {
+      var result = _.iife(function(a, b) { return a + b; }, 1, 2);
+      ok(result === 3);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.now');
 
   (function() {
@@ -10215,7 +10248,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 184, function() {
+    test('should accept falsey arguments', 185, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;


### PR DESCRIPTION
`_.iife` takes a function as its first argument and calls it immediately,
passing in any additional specified arguments to the function, and then returns
the value of whatever was returned from the called function. This is useful as a
semantic wrapper for IIFE's and/or mocking out asynchronous task-based functions
in tests, such as `setTimeout`.
#### Some background

On the Refinery29 mobile web team we like to stub out `setTimeout` in some of our tests and simply have it call the function given to it. We find that this reduces test complexity when the code under question is not dependent on that asynchronous behavior, and it also speeds up our suite by quite a lot. The way we usually go about this is by doing something like 

``` javascript
spyOn(window, 'setTimeout').and.callFake(function(fn) { fn(); });
```

But this looks ugly and get cumbersome to type. We wanted to be able to pass in a higher-order function that could be used as a default "call whatever your first argument is if it's callable" behavior (in the same way that `_.identity` provides a convenient iterator), and couldn't find a library function in lodash that did this. So rather than write it ourselves and have it never see the light of day, I thought that it could be a useful addition to lodash's utility function.

``` javascript
spyOn(window, 'setTimeout').and.callFake(_.iife);
```

Beyond just providing the utility described above, `_.iife` could also possibly be used in the classic IIFE way

``` javascript
_.iife(function(global) {
  // your module here
}, this);
```

To provide a more semantic indication of an IIFE than just `(function() { ... })();` which - while canonical - could stand to be more denotative of what it's actually doing. This is why I made the function be able to accept arguments.

Thank you very much for creating and maintaining lodash! It's an awesome library that we all love using.
