### PR TITLE
Pass the original index in the array into the function

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3029,12 +3029,13 @@
     function remove(array, predicate, thisArg) {
       var index = -1,
           length = array ? array.length : 0,
-          result = [];
+          result = [],
+          originalIndex = -1;
 
       predicate = lodash.createCallback(predicate, thisArg, 3);
       while (++index < length) {
         var value = array[index];
-        if (predicate(value, index, array)) {
+        if (predicate(value, ++originalIndex, array)) {
           result.push(value);
           splice.call(array, index--, 1);
           length--;

--- a/test/test.js
+++ b/test/test.js
@@ -7721,14 +7721,16 @@
       deepEqual(args, [1, 0, array]);
     });
 
-    test('should support the `thisArg` argument', 1, function() {
-      var array = [1, 2, 3];
+    test('should support the `thisArg` argument', 2, function() {
+      var args = [],
+          array = [1, 2, 3];
 
       var actual = _.remove(array, function(num, index) {
-        return this[index] < 3;
+        args.push(this[index]);
       }, array);
 
-      deepEqual(actual, [1, 2]);
+      deepEqual(actual, []);
+      deepEqual(args, [1, 2, 3]);
     });
 
     test('should preserve holes in arrays', 2, function() {
@@ -7747,6 +7749,18 @@
 
       _.remove(array, function(num) { return num == null; });
       deepEqual(array, [1, 3]);
+    });
+
+    test('should pass the original index into the callback', 2, function() {
+      var args = [],
+          array = [1, 2, 3];
+
+      var actual = _.remove(array, function(num, index) {
+        args.push(index);
+        return true;
+      });
+      deepEqual(actual, [1,2,3]);
+      deepEqual(args, [0,1,2]);
     });
   }());
 


### PR DESCRIPTION
I recently came into a situation where I needed to use the original array index in `_.remove`

Current functionality was passing in the current index in the modified array
So if you were removing every value in the array, index would always be 0

I have made the change to pass the original index instead of the currentIndex as I couldn't figure out what anyone would get out of using the currentIndex, most of the time you will just use the value instead of this[index]...but I might be missing something 
