### PR TITLE
Add `_.existy` to define objects existance.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3811,6 +3811,42 @@
     });
 
     /**
+     * Iterates over all arguments returning true if no argument is either equal to
+     * `undefined` or `null`, false otherwise.
+     *
+     * If no arguments are passed it returns false.
+     *
+     * @static
+     * @memberOf _
+     * @category Utilities
+     * @returns {boolean} Boolean representing the existance of the arguments.
+     * @example
+     *
+     * _.existy(0, false, '', []);
+     * // => true
+     *
+     * _.existy(1, 2, null);
+     * // => false
+     *
+     * _.existy(1, 2, undefined);
+     * // => false
+     *
+     * _.existy();
+     * // => false
+     *
+     */
+    function existy() {
+      var argsArray = _.toArray(arguments);
+      if (_.isEmpty(argsArray)) {
+        return false;
+      }
+      
+      return _.every(argsArray, function(arg) {
+        return arg != null;
+      });
+    }
+
+    /**
      * Checks if the predicate returns truthy for **all** elements of a collection.
      * The predicate is bound to `thisArg` and invoked with three arguments;
      * (value, index|key, collection).
@@ -8474,6 +8510,7 @@
     lodash.escape = escape;
     lodash.escapeRegExp = escapeRegExp;
     lodash.every = every;
+    lodash.existy = existy;
     lodash.find = find;
     lodash.findIndex = findIndex;
     lodash.findKey = findKey;

--- a/test/test.js
+++ b/test/test.js
@@ -2403,6 +2403,28 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.existy');
+
+  (function() {
+    test('should return `true` if all arguments are different from null and undefined', 1, function() {
+      ok(_.existy(0, false, '', []));
+    });
+
+    test('should return `false` if any of the arguments is `null` or `undefined`', 3, function() {
+      var sample = {};
+      ok(!_.existy(sample.notExisting));
+      ok(!_.existy(undefined));
+      ok(!_.existy(null));
+    });
+
+    test('should return `false` if called with no arguments', 1, function() {
+      ok(!_.existy());
+    });
+
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.every');
 
   (function() {
@@ -10618,7 +10640,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 187, function() {
+    test('should accept falsey arguments', 188, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;


### PR DESCRIPTION
`existy` checks if `arguments` contains `undefined` or `null` values, if so (or if no arguments are passed) it returns false, otherwise it returns true.

Example:

``` javascript
if (_.existy(iNeedToChekThis, andThis, andThat)) {
  // do something with those
}
```

I'm using lodash a lot both server and frontend side, I've created a small library to have `existy` and `truthy` as a help in some repetitive checks but I believe they belong in here. Credits to Michael Fogus for those two functions.

Please let me know if something is wrong in what I did or if it could be written in a better way.
If this is ok I would be happy to also add `truthy` to lodash.

Thanks for this project.
