### PR TITLE
support.ownLast is "false" in all but IE < 9

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -905,7 +905,7 @@
 
       /**
        * Detect if own properties are iterated after inherited properties
-       * (none but IE < 9).
+       * (IE < 9).
        *
        * @memberOf _.support
        * @type boolean


### PR DESCRIPTION
support.ownLast is "false" in all but IE < 9. I guess a short way to describe that is "none but IE < 9" but having "all but IE < 9" is misleading. As the rest of the support properties (e.g. funcNames) return "true" when you have a browser that fits in the "all" part.
