### PR TITLE
Add a `_.replicate` Array function

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -7823,6 +7823,37 @@
     }
 
     /**
+     * Repeats every element in the given array `n` times.
+     *
+     * @static
+     * @memberOf _
+     * @category Array
+     * @param {array} [array] The subject array.
+     * @param {number} [n=1] Number of times each element will be replicated.
+     * @returns {array} Returns the array with the replicated elements.
+     * @example
+     *
+     * _.replicate(['a', 2, 'c'], 3)
+     * // => ['a', 'a', 'a', 2, 2, 2, 'c', 'c', 'c']
+     */
+    function replicate(array, n) {
+      var len = array ? array.length : 0,
+          result = [],
+          i,
+          j;
+
+      if (!isArray(array) || n === 0) { return []; }
+
+      for (i = 0; i < len; i += 1) {
+        for (j = 0; j < n; j += 1) {
+          result.push(array[i]);
+        }
+      }
+
+      return result;
+    }
+
+    /**
      * Converts `string` to snake case.
      * See [Wikipedia](http://en.wikipedia.org/wiki/Snake_case) for more details.
      *
@@ -8959,6 +8990,7 @@
     lodash.reduce = reduce;
     lodash.reduceRight = reduceRight;
     lodash.repeat = repeat;
+    lodash.replicate = replicate;
     lodash.result = result;
     lodash.runInContext = runInContext;
     lodash.size = size;

--- a/test/test.js
+++ b/test/test.js
@@ -8405,6 +8405,45 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.replicate');
+
+  (function() {
+    var complexArray = [
+      [1, 2, 3],
+      [{a: 1, b: 2}, {c: 3}],
+      [[[1]]],
+      {obj: {ect: 0}}
+    ];
+
+    test('should repeat each element of an array `n` times', 3, function() {
+      deepEqual(_.replicate([1, 2], 2), [1, 1, 2, 2]);
+      deepEqual(_.replicate([{a: 1}, {b: 2}], 2), [{a: 1}, {a: 1}, {b: 2}, {b: 2}]);
+
+      var complexArrayReplicatedThreeTimes = [
+        [1, 2, 3], [1, 2, 3], [1, 2, 3],
+        [{a: 1, b: 2}, {c: 3}], [{a: 1, b: 2}, {c: 3}], [{a: 1, b: 2}, {c: 3}],
+        [[[1]]], [[[1]]], [[[1]]],
+        {obj: {ect: 0}}, {obj: {ect: 0}}, {obj: {ect: 0}}
+      ];
+
+      deepEqual(_.replicate(complexArray, 3), complexArrayReplicatedThreeTimes);
+    });
+
+    test('should return an empty array if `n` is 0', 3, function() {
+      deepEqual(_.replicate(['a', 2, 'c'], 0), []);
+      deepEqual(_.replicate([{a: 1}], 0), []);
+      deepEqual(_.replicate(complexArray, 0), []);
+    });
+
+    test('should return an empty array if the first argument is not an array', 3, function () {
+      deepEqual(_.replicate('hello', 3), []);
+      deepEqual(_.replicate({a: 1, b: 2}, 10), []);
+      deepEqual(_.replicate({_: [1, 2, 3]}, 3), []);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.result');
 
   (function() {
@@ -11247,7 +11286,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 190, function() {
+    test('should accept falsey arguments', 191, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;


### PR DESCRIPTION
This function replicates each element of an array `n` times:

```
_.replicate([1, 2, 3], 2) //=> [1, 1, 2, 2, 3, 3]
```

I find it useful for when you have to do something where two arrays have to match or have to be the same length or where each element of one should match each element of the other and so on. I don't know if it can be general enough to be merged into Lodash's core.
