### PR TITLE
Add support for RNG injection

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -694,7 +694,7 @@
         nativeNow = isNative(nativeNow = Date.now) && nativeNow,
         nativeNumIsFinite = isNative(nativeNumIsFinite = Number.isFinite) && nativeNumIsFinite,
         nativeParseInt = context.parseInt,
-        nativeRandom = Math.random;
+        nativeRandom = function() { return Math.random(); };
 
     /** Used as the size, in bytes, of each Float64Array element */
     var FLOAT64_BYTES_PER_ELEMENT = Float64Array && Float64Array.BYTES_PER_ELEMENT;

--- a/test/test.js
+++ b/test/test.js
@@ -8271,7 +8271,12 @@
 
   /*--------------------------------------------------------------------------*/
 
-  QUnit.module('lodash.random');
+  QUnit.module('lodash.random', {
+    nativeRandom: Math.random,
+    teardown: function() {
+      Math.random = this.nativeRandom;
+    },
+  });
 
   (function() {
     var array = Array(1000);
@@ -8325,6 +8330,15 @@
 
       actual = _.random(2, 4, true);
       ok(actual % 1 && actual >= 2 && actual <= 4);
+    });
+
+    test('supports RNG injection', 1, function() {
+      Math.random = function() { return 0; };
+      var expected = _.random(42);
+
+      ok(_.every(array, function() {
+        return _.random(42) === expected;
+      }));
     });
   }());
 


### PR DESCRIPTION
In the CodeCombat project, we replace `Math.random` with a deterministic pseudoRNG. This patch would allow us to get deterministic behavior out of `_.random` after we do the replacement.

Original issue here: https://github.com/codecombat/codecombat/issues/1210.
