### PR TITLE
If a constant value is given to zipObject, repeat it for each key

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4441,6 +4441,9 @@
      * either a single two dimensional array, e.g. `[[key1, value1], [key2, value2]]`
      * or two arrays, one of property names and one of corresponding values.
      *
+     * If a constant is provided for values it will be repeated for each element in
+     * keys.
+     *
      * @static
      * @memberOf _
      * @alias object
@@ -4456,15 +4459,21 @@
     function zipObject(props, vals) {
       var index = -1,
           length = props ? props.length : 0,
-          result = {};
+          result = {},
+          constant;
 
-      if (!vals && length && !isArray(props[0])) {
+      if (!isArrayLike(vals) && length && !isArray(props[0])) {
+        constant = vals;
         vals = [];
       }
       while (++index < length) {
         var key = props[index];
         if (vals) {
-          result[key] = vals[index];
+          var val = vals[index];
+          if (typeof val == 'undefined') {
+            val = constant;
+          }
+          result[key] = val;
         } else if (key) {
           result[key[0]] = key[1];
         }

--- a/test/test.js
+++ b/test/test.js
@@ -11613,6 +11613,16 @@
       deepEqual(_.zipObject(_.pairs(object)), object);
     });
 
+    test('should accept a boolean `values` argument', 1, function() {
+      var actual = _.zipObject(['barney', 'fred'], false);
+      deepEqual(actual, { 'barney': false, 'fred': false });
+    });
+
+    test('should accept a string `values` argument', 1, function() {
+      var actual = _.zipObject(['barney', 'fred'], 'asdf');
+      deepEqual(actual, { 'barney': 'asdf', 'fred': 'asdf' });
+    });
+
     test('should be aliased', 1, function() {
       strictEqual(_.object, _.zipObject);
     });


### PR DESCRIPTION
This makes it much easier to turn an array of values into a hash with
those values as keys, using `_.object(arr, true)` or similar.  This is
useful when you need to check whether lots of values are in the array.
