### PR TITLE
Support multiple arguments in memoize

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6306,7 +6306,8 @@
         throw new TypeError(FUNC_ERROR_TEXT);
       }
       var memoized = function() {
-        var key = resolver ? resolver.apply(this, arguments) : arguments[0];
+        var args = Array.prototype.slice.call(arguments),
+            key = resolver ? resolver.apply(this, arguments) : args.join();
         if (key == '__proto__') {
           return func.apply(this, arguments);
         }


### PR DESCRIPTION
Create a key based on all arguments passed to the memorized function.

Given:

``` javascript
var myJoin = _.memoize(function(x, y) {
    return [x, y];
});
```

Use Before:

``` javascript
myJoin('a', 'b'); // ['a', 'b']
myJoin('a', 'c'); // ['a', 'b']
```

Use After:

``` javascript
myJoin('a', 'b'); // ['a', 'b']
myJoin('a', 'c'); // ['a', 'c']
```
