### PR TITLE
todo comment about fixing _.forEach bug

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1104,6 +1104,14 @@
      * A specialized version of `_.forEach` for arrays without support for
      * callback shorthands or `this` binding.
      *
+     * TODO: Fix a bug that occurs when user changes the array that is being iterated through
+     * Example of bug:
+     * var elements = ['a', 'b', 'c', 'd', 'e', 'f'];
+     * _.forEach(elements, function eachElement(el) {
+     *   _.pull(elements, el);
+     * });  //  final `elements` array is ['b','d','f'] (intended outcome would be an empty array)
+     * // NOTE: this bug does not exist in underscore.js's equivalent function _.each
+     *
      * @private
      * @param {Array} array The array to iterate over.
      * @param {Function} iteratee The function called per iteration.


### PR DESCRIPTION
Discovered a bug that occurs when an array is altered by the callback function provided to _.forEach

Here is an example that will demonstrate the bug:

``` js
var elements = ['a', 'b', 'c', 'd', 'e', 'f'];
_.forEach(elements, function eachElement(el) {
    console.log(el + ': will now be removed from the array');
    _.pull(elements, el);
});
console.log('the final version of the array is: ' + elements);
```

The expected outcome is an empty array, but instead the elements array becomes `['b','d','f']`
