### PR TITLE
add additional check to see if thisArg is provided without an Accumulator

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5355,7 +5355,8 @@
      */
     function reduce(collection, iteratee, accumulator, thisArg) {
       var func = isArray(collection) ? arrayReduce : baseReduce;
-      return func(collection, getCallback(iteratee, thisArg, 4), accumulator, arguments.length < 3, baseEach);
+
+      return func(collection, getCallback(iteratee, thisArg, 4), accumulator, accumulator === undefined, baseEach);
     }
 
     /**
@@ -5379,7 +5380,8 @@
      */
     function reduceRight(collection, iteratee, accumulator, thisArg) {
       var func = isArray(collection) ? arrayReduceRight : baseReduce;
-      return func(collection, getCallback(iteratee, thisArg, 4), accumulator, arguments.length < 3, baseEachRight);
+      
+      return func(collection, getCallback(iteratee, thisArg, 4), accumulator, accumulator === undefined, baseEachRight);
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -8974,8 +8974,9 @@
   (function() {
     var array = [1, 2, 3];
 
-    test('should use the first element of a collection as the default `accumulator`', 1, function() {
+    test('should use the first element of a collection as the default `accumulator`', 2, function() {
       strictEqual(_.reduce(array), 1);
+      strictEqual(_.reduce(array, undefined, undefined, {}), 1);
     });
 
     test('should provide the correct `callback` arguments when iterating an array', 2, function() {
@@ -9053,8 +9054,9 @@
   (function() {
     var array = [1, 2, 3];
 
-    test('should use the last element of a collection as the default `accumulator`', 1, function() {
+    test('should use the last element of a collection as the default `accumulator`', 2, function() {
       strictEqual(_.reduceRight(array), 3);
+      strictEqual(_.reduceRight(array, undefined, undefined, {}), 3);
     });
 
     test('should provide the correct `callback` arguments when iterating an array', 2, function() {


### PR DESCRIPTION
I ran into this trying to set the `thisArg` while explicitly setting `accumulator`to  be `undefined`.

```
var result = _.reduce([1,2,3], callback, undefined, this)
```

The above results in the the first iteration of the callback to be called with index 0 and the result as undefined, instead of index 1 and `1` as the result value. I just did a strict check for `accumulator === undefined` which makes this change "broader" than my particular edge case, but it could also easily be `arguments.length < 3 || (arguments.length === 4 && accumulator === undefined)` if you want to still allow a specific case where you can intentionally set the accumulator to `undefined`. 

I realize this is sort of a toss up on which edge case makes the most sense, though right before 3.0.0 makes it a good time to alter this if it made sense.
