### PR TITLE
Add an `_.isPromise` function

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1062,7 +1062,7 @@
      * `findKey`, `findLast`, `findLastIndex`, `findLastKey`, `findWhere`, `first`,
      * `has`, `identity`, `indexOf`, `isArguments`, `isArray`, `isBoolean`, isDate`,
      * `isElement`, `isEmpty`, `isEqual`, `isError`, `isFinite`, `isFunction`,
-     * `isNative`, `isNaN`, `isNull`, `isNumber`, `isObject`, `isPlainObject`,
+     * `isNative`, `isNaN`, `isNull`, `isNumber`, `isObject`, `isPlainObject`, `isPromise`,
      * `isRegExp`, `isString`, `isUndefined`, `join`, `kebabCase`, `last`,
      * `lastIndexOf`, `max`, `min`, `noConflict`, `now`, `pad`, `padLeft`,
      * `padRight`, `parseInt`, `pop`, `random`, `reduce`, `reduceRight`, `repeat`,
@@ -7290,6 +7290,31 @@
     }
 
     /**
+     * Checks if `value` is a `Promise` object.
+     *
+     * **Note:** See the [Promises A+ Spec](https://promisesaplus.com/) for more details.
+     *
+     * @static
+     * @memberOf _
+     * @category Lang
+     * @param {*} value The value to check.
+     * @returns {boolean} Returns `true` if `value` is a Promise object, else `false`.
+     * @example
+     *
+     * _.isPromise({});
+     * // => false
+     *
+     * _.isPromise({then: function () {}});
+     * // => true
+     *
+     * _.isPromise(function () {});
+     * // => false
+     */
+    function isPromise(value) {
+      return isObject(value) && isFunction(value.then);
+    }
+
+    /**
      * Checks if `value` is `NaN`.
      *
      * **Note:** This method is not the same as native `isNaN` which returns `true`
@@ -9831,6 +9856,7 @@
     lodash.isNumber = isNumber;
     lodash.isObject = isObject;
     lodash.isPlainObject = isPlainObject;
+    lodash.isPromise = isPromise;
     lodash.isRegExp = isRegExp;
     lodash.isString = isString;
     lodash.isUndefined = isUndefined;

--- a/test/test.js
+++ b/test/test.js
@@ -354,6 +354,7 @@
         "'_null': null,",
         "'_number': Object(0),",
         "'_object': { 'a': 1, 'b': 2, 'c': 3 },",
+        "'_promise': { 'then': function () {} },",
         "'_regexp': /x/,",
         "'_string': Object('a'),",
         "'_undefined': undefined",
@@ -556,6 +557,7 @@
       'parent._._null = null;',
       'parent._._number = Object(0);',
       "parent._._object = { 'a': 1, 'b': 2, 'c': 3 };",
+      "parent._._promise = { 'then': function () {} },",
       'parent._._regexp = /x/;',
       "parent._._string = Object('a');",
       'parent._._undefined = undefined;',
@@ -6640,6 +6642,49 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.isPromise');
+
+  (function() {
+    var args = arguments;
+
+    test('should return `true` for Promises', 1, function() {
+      strictEqual(_.isPromise({ 'then': function () {} }), true);
+    });
+
+    test('should return `false` for non Promises', 12, function() {
+      var expected = _.map(falsey, _.constant(false));
+
+      var actual = _.map(falsey, function(value, index) {
+        return index ? _.isPromise(value) : _.isPromise();
+      });
+
+      deepEqual(actual, expected);
+
+      strictEqual(_.isPromise(args), false);
+      strictEqual(_.isPromise([1, 2, 3]), false);
+      strictEqual(_.isPromise(true), false);
+      strictEqual(_.isPromise(new Date), false);
+      strictEqual(_.isPromise(new Error), false);
+      strictEqual(_.isPromise(_), false);
+      strictEqual(_.isPromise(slice), false);
+      strictEqual(_.isPromise({ 'a': 1 }), false);
+      strictEqual(_.isPromise(1), false);
+      strictEqual(_.isPromise(/x/), false);
+      strictEqual(_.isPromise('a'), false);
+    });
+
+    test('should work with Promises from another realm', 1, function() {
+      if (_._object) {
+        strictEqual(_.isPromise(_._promise), true);
+      }
+      else {
+        skipTest();
+      }
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.isRegExp');
 
   (function() {
@@ -12660,7 +12705,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 197, function() {
+    test('should accept falsey arguments', 198, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;


### PR DESCRIPTION
This PR adds the `_.isPromise` function that returns a boolean which indicates if the argument is a `Promise` object, per the [Promises A+ spec](https://promisesaplus.com/).

`_.isPromise({}); // => false`
`_.isPromise({then: function () {}}); // => true`
`_.isPromise(function () {}); // => false`

Since different libraries implement promises differently, this is the truest way to check whether a value is a promise object.
