### PR TITLE
Release func in _.before and _.once

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6076,7 +6076,8 @@
       return function() {
         if (--n > 0) {
           result = func.apply(this, arguments);
-        } else {
+        }
+        if (n <= 1) {
           func = null;
         }
         return result;


### PR DESCRIPTION
`func` isn't released until the _before_ function is called n times, when it's possible to release it after n-1 times. Since `_.once` uses `_.before`, this means that a _onced_ function isn't released until the 2nd time you call it.

(submitted a CLA on 2014-10-18 19:38:02)
