### PR TITLE
Adding support for `where` style callbacks in _.pick

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8239,9 +8239,12 @@
      * @memberOf _
      * @category Object
      * @param {Object} object The source object.
-     * @param {Function|...(string|string[])} [predicate] The function invoked per
+     * @param {Object|Function|...(string|string[])} [predicate] The function invoked per
      *  iteration or property names to pick, specified as individual property
      *  names or arrays of property names.
+     * If an object is provided for `predicate` a "_.where" style callback
+     * is created and returns `true` for elements that have the properties of the given object,
+     * else `false`.
      * @param {*} [thisArg] The `this` binding of `predicate`.
      * @returns {Object} Returns the new object.
      * @example
@@ -8258,6 +8261,8 @@
       if (object == null) {
         return {};
       }
+
+      predicate = isPlainObject(predicate) ? matches(predicate) : predicate;
       return typeof predicate == 'function'
         ? pickByCallback(object, getCallback(predicate, thisArg, 3))
         : pickByArray(object, baseFlatten(arguments, false, false, 1));

--- a/test/test.js
+++ b/test/test.js
@@ -9087,6 +9087,18 @@
     test('should coerce property names to strings', 1, function() {
       deepEqual(_.pick({ '0': 'a', '1': 'b' }, 0), { '0': 'a' });
     });
+
+    test('should support picking using a where style callback', 2, function() {
+      var collection = {
+        'obj1': {'a': 1, 'b': 2},
+        'obj2': {'a': 5, 'b': 2, 'c': 3},
+        'obj3': {'a': 1, 'b': 2, 'c': 3},
+        'obj4': {'a': 1, 'b': 4, 'c': 3}
+      };
+
+      deepEqual(_.pick(collection, {'a': 1}), _.pick(collection, ['obj1', 'obj3', 'obj4']));
+      deepEqual(_.pick(collection, {'a': 1, 'c': 3}), _.pick(collection, ['obj3', 'obj4']));
+    });
   }('a', 'c'));
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
I often find that I want to pick items from an object-collection (hashmap), which contain specific properties.
_.where would work except that it returns an array, and then I lose the key (hash) from the key:value pairs I was comparing.

For example (this is the test I added):

```
var collection = {
        'obj1': {'a': 1, 'b': 2},
        'obj2': {'a': 5, 'b': 2, 'c': 3},
        'obj3': {'a': 1, 'b': 2, 'c': 3},
        'obj4': {'a': 1, 'b': 4, 'c': 3}
      };

      deepEqual(_.pick(collection, {'a': 1}), _.pick(collection, ['obj1', 'obj3', 'obj4']));
      deepEqual(_.pick(collection, {'a': 1, 'c': 3}), _.pick(collection, ['obj3', 'obj4']));
```

This is aligned with the rest of the lodash API for collections, which usually support the _.where style callback. 
I find that it is also useful when chaining, in conjunction with other functions which work on object-collections, and supports better composability. 

For example, with mapValues:

```
_(linksData)
  .pick({dataType: 'AnchorLink'})
  .mapValues(function(obj){
 return doSomething(obj);
}).value();
//returns mapped values of only 'AnchorLink' type.
```

What do you think?
