### PR TITLE
Add support for custom random number generator to shuffle()

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2251,10 +2251,12 @@
      * @private
      * @param {number} min The minimum possible value.
      * @param {number} max The maximum possible value.
+     * @param {Function} [random=Math.random] The random number generator to use.
      * @returns {number} Returns the random number.
      */
-    function baseRandom(min, max) {
-      return min + floor(nativeRandom() * (max - min + 1));
+    function baseRandom(min, max, random) {
+      random = random || nativeRandom;
+      return min + floor(random() * (max - min + 1));
     }
 
     /**
@@ -5825,13 +5827,14 @@
      * @memberOf _
      * @category Collection
      * @param {Array|Object|string} collection The collection to shuffle.
+     * @param {Function} [random=Math.random] The random number generator to use.
      * @returns {Array} Returns the new shuffled array.
      * @example
      *
      * _.shuffle([1, 2, 3, 4]);
      * // => [4, 1, 3, 2]
      */
-    function shuffle(collection) {
+    function shuffle(collection, random) {
       collection = toIterable(collection);
 
       var index = -1,
@@ -5839,7 +5842,7 @@
           result = Array(length);
 
       while (++index < length) {
-        var rand = baseRandom(0, index);
+        var rand = baseRandom(0, index, random);
         if (index != rand) {
           result[index] = result[rand];
         }

--- a/test/test.js
+++ b/test/test.js
@@ -10317,6 +10317,11 @@
       deepEqual(_.shuffle(1), []);
     });
 
+    test('should work with random number generator', 1, function() {
+      var actual = _.shuffle([1, 2, 3, 4, 5], function() { return 0.5; });
+      deepEqual(actual, [1, 3, 5, 2, 4]);
+    });
+
     _.each({
       'literal': 'abc',
       'object': Object('abc')


### PR DESCRIPTION
I added support for specifying a custom random generator function to shuffle(). This is useful if you want to make functions that use shuffle testable (by passing in a stable/predictable generator), if you want to have predictable results, ...
