### PR TITLE
Improve `_.pull` docs

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4201,6 +4201,7 @@
      *
      * **Notes:**
      *  - Unlike `_.without`, this method mutates `array`.
+     *    However, when in a chain, it creates a new array.
      *  - `SameValueZero` comparisons are like strict equality comparisons,
      *    e.g. `===`, except that `NaN` matches `NaN`. See the
      *    [ES6 spec](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-samevaluezero)


### PR DESCRIPTION
It's kinda surprising for newcomers that:

```
var arr = [1, 2, 3];
_.pull(arr, 1) === arr; // true;
_(arr).pull(2) === arr; // false;
```

After all, mutating current array is what differentiates `pull` from `without`. So I think it's worth including this in the docs.
