### PR TITLE
Fix broken lazy reverse

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4982,6 +4982,12 @@
      * // => [3, 2, 1]
      */
     function wrapperReverse() {
+      var wrapped = this.__wrapped__;
+
+      if(wrapped instanceof LazyWrapper) {
+        return wrapped.reverse();
+      }
+
       return this.thru(function(value) {
         return value.reverse();
       });

--- a/test/test.js
+++ b/test/test.js
@@ -12941,6 +12941,27 @@
         skipTest(2);
       }
     });
+
+
+    test('should be lazy when in a lazy chain sequence', 1, function() {
+      if (!isNpm) {
+        var spy = {
+          toString: function () {
+            throw new Error("Spy was revealed");
+          }
+        };
+
+        var actual = _(["a", spy])
+          .map(String)
+          .reverse()
+          .last();
+
+        strictEqual(actual, "a");
+      }
+      else {
+        skipTest(1);
+      }
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Lazy `reverse` was never called. E.g. here: `_(arr).map().reverse()` normal `reverse` was called, breaking a lazy chain.
