### PR TITLE
Created `concatAll` alias for `flatten`

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4126,6 +4126,7 @@
      *
      * @static
      * @memberOf _
+     * @alias concatAll
      * @category Array
      * @param {Array} array The array to flatten.
      * @param {boolean} [isDeep=false] Specify a deep flatten.
@@ -10262,6 +10263,7 @@
     // Add aliases.
     lodash.backflow = flowRight;
     lodash.collect = map;
+    lodash.concatAll = flatten;
     lodash.compose = flowRight;
     lodash.each = forEach;
     lodash.eachRight = forEachRight;

--- a/test/test.js
+++ b/test/test.js
@@ -4260,6 +4260,10 @@
         skipTest(6);
       }
     });
+
+    test('should be aliased', 1, function() {
+      strictEqual(_.concatAll, _.flatten);
+    });
   }(1, 2, 3));
 
   /*--------------------------------------------------------------------------*/
@@ -13777,7 +13781,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 202, function() {
+    test('should accept falsey arguments', 203, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;


### PR DESCRIPTION
RxJS used the method `concatAll` instead of `flatten`. See https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/concatall.md

It would be convenient to have this alias.
