### PR TITLE
Fixed documentation for debounce

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6947,13 +6947,13 @@
      * jQuery('#postbox').on('click', _.debounce(sendMail, 300, {
      *   'leading': true,
      *   'trailing': false
-     * });
+     * }));
      *
      * // ensure `batchLog` is invoked once after 1 second of debounced calls
      * var source = new EventSource('/stream');
      * jQuery(source).on('message', _.debounce(batchLog, 250, {
      *   'maxWait': 1000
-     * }, false);
+     * }));
      *
      * // cancel a debounced call
      * var todoChanges = _.debounce(batchLog, 1000);


### PR DESCRIPTION
This PR fixes two syntax errors in the documentation. 
- Added missing parenthesis
- Since `on` has no boolean param after the handler and the 4th param of `debounce` defaults to `false` this looks like some relict of the previous `addEventListener` version.
