### PR TITLE
Fixes unnecessary single quote in documentation.

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -4588,7 +4588,7 @@
      * // => 2
      *
      * // using the `_.matches` callback shorthand
-     * _.findLastIndex(users, { user': 'barney', 'active': true });
+     * _.findLastIndex(users, { user: 'barney', 'active': true });
      * // => 0
      *
      * // using the `_.matchesProperty` callback shorthand

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -6835,12 +6835,12 @@
      * // => true
      *
      * var users = [
-     *   { 'user': 'barney', 'active': true },
-     *   { 'user': 'fred',   'active': false }
+     *   { user: 'barney', active: true },
+     *   { user: 'fred',   active: false }
      * ];
      *
      * // using the `_.matches` callback shorthand
-     * _.some(users, { user': 'barney', 'active': false });
+     * _.some(users, { user: 'barney', 'active': false });
      * // => false
      *
      * // using the `_.matchesProperty` callback shorthand


### PR DESCRIPTION
There's a bad single quote in the docs. This fixes it.

![screen shot 2015-02-20 at 5 55 04 pm](https://cloud.githubusercontent.com/assets/135242/6310906/aa270092-b929-11e4-9060-fa574ea1aff9.png)
