### PR TITLE
Let `createAssigner` get correct customizer

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -3167,6 +3167,9 @@
           return object;
         }
         if (length > 3 && isIterateeCall(arguments[1], arguments[2], arguments[3])) {
+          if (typeof arguments[length - 1] == 'function') {
+            customizer = arguments[--length];
+          }
           length = 2;
         }
         // Juggle arguments.


### PR DESCRIPTION
When `_.defaults` is invoked using `_.reduce` / `_.reduceRight`
`createAssigner` discards the customizer, so the effect is
`_.assign` but not `_.defaults`

```
_.reduce([{ 'user': 'barney' }, { 'user': 'fred' }], _.defaults)
// -> {user: "fred"}
_.reduceRight([{ 'user': 'barney' }, { 'user': 'fred' }], _.defaults)
// -> {user: "barney"}

// Fixed
_.reduce([{ 'user': 'barney' }, { 'user': 'fred' }], _.defaults)
// -> {user: "barney"}
_.reduceRight([{ 'user': 'barney' }, { 'user': 'fred' }], _.defaults)
// -> {user: "fred"}
```