### PR TITLE
Add an example of the alternative zipObject syntax

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -5636,10 +5636,10 @@
      * @returns {Object} Returns the new object.
      * @example
      *
-     * _.zipObject(['fred', 'barney'], [30, 40]);
+     * _.zipObject([['fred', 30], ['barney', 40]]);
      * // => { 'fred': 30, 'barney': 40 }
-     * 
-     * _.zipObject([ ['fred', 30], ['barney', 40] ]);
+     *
+     * _.zipObject(['fred', 'barney'], [30, 40]);
      * // => { 'fred': 30, 'barney': 40 }
      */
     function zipObject(props, values) {

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -5638,6 +5638,9 @@
      *
      * _.zipObject(['fred', 'barney'], [30, 40]);
      * // => { 'fred': 30, 'barney': 40 }
+     * 
+     * _.zipObject([ ['fred', 30], ['barney', 40] ]);
+     * // => { 'fred': 30, 'barney': 40 }
      */
     function zipObject(props, values) {
       var index = -1,


### PR DESCRIPTION
I usually glance at the examples before the actual blurb, and a number of times I've assumed zipObject doesn't do what I need because there's no example.

This is a tiny doc change to add an example of the two dimensional array usage.