### PR TITLE
fix _.zipObject docs to more clearly demonstrate it as _.pairs' inverse

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1588,9 +1588,12 @@ _.zip(['fred', 'barney'], [30, 40], [true, false]);
 ### <a id="_zipobjectprops-values"></a>`_.zipObject(props, [values=[]])`
 <a href="#_zipobjectprops-values">#</a> [&#x24C8;](https://github.com/lodash/lodash/blob/3.5.0/lodash.src.js#L5648 "View in source") [&#x24C9;][1] [&#x24C3;](https://www.npmjs.com/package/lodash.zipobject "See the npm package")
 
-Creates an object composed from arrays of property names and values. Provide
-either a single two dimensional array, e.g. `[[key1, value1], [key2, value2]]`
-or two arrays, one of property names and one of corresponding values.
+The opposite of `_.pairs`; this method returns an object composed from arrays
+of property names and values.
+
+Provide either a single two dimensional array, e.g.
+`[[key1, value1], [key2, value2]]` or two arrays, one of property names and one
+of corresponding values.
 
 #### Arguments
 1. `props` *(Array)*: The property names.
@@ -1602,6 +1605,9 @@ or two arrays, one of property names and one of corresponding values.
 #### Example
 ```js
 _.zipObject(['fred', 'barney'], [30, 40]);
+// => { 'fred': 30, 'barney': 40 }
+
+_.zipObject([['fred', 30], ['barney', 40]]);
 // => { 'fred': 30, 'barney': 40 }
 ```
 * * *


### PR DESCRIPTION
I spent a while today attempting to look for a method that was effectively the inverse of `_.pairs`. Although the docs do point out that `_.zipObject` does this, it's hard to find with Ctrl+F and there are no actual examples of it which is what I usually scan through when looking for things. This just clears that up. :)