### PR TITLE
exposed createAggregator as _.createAggregator

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -11329,6 +11329,9 @@
     lodash.include = includes;
     lodash.inject = reduce;
 
+    // expose createAggregator so people can make their own aggregators
+    lodash.createAggregator = createAggregator;
+
     mixin(lodash, (function() {
       var source = {};
       baseForOwn(lodash, function(func, methodName) {


### PR DESCRIPTION
I wanted to make my own aggregator. Specifically, a groupBy that would group on array fields and allow records to appear in multiple groups.

```
var multiValuedGroupBy = _.createAggregator(function(result, value, keys) {
    _.each(keys, function(key) {
    if (_.has(result, key)) {
        result[key].push(value);
    } else {
        result[key] = [value];
    }
    });
})
```
So, `multiValuedGroupBy([{A:[1,2],B:0},{A:[1,3],B:0}], 'A')` produces:

    {
         "1":[{"A":[1,2],"B":0},{"A":[1,3],"B":0}],
         "2":[{"A":[1,2],"B":0}],
         "3":[{"A":[1,3],"B":0}]
     }

I couldn't just make a `multiValuedGroupBy` mixin because I needed access to createAggregator.