### PR TITLE
Adding _.resultDeep() to resolve #1060, #700, et al.

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -11224,6 +11224,31 @@
     }
 
     /**
+     * Creates a function which returns the property value of `key` on a given object.
+     *
+     * @static
+     * @memberOf _
+     * @category Utility
+     * @param {array} keyPath The key path of the property to get.
+     * @returns {Function} Returns the new function.
+     * @example
+     *
+     * var highScores = [
+     *   { user: 'fred', score: 850 },
+     *   { user: 'barney', score: 630 }
+     * ];
+     *
+     * var getHighestScore = _.propertyDeep([0, 'score']);
+     * getHighestScore(highScores);
+     * // => 850
+     */
+    function propertyDeep(keyPath) {
+      return function(object) {
+        return resultDeep(object, keyPath);
+      };
+    }
+
+    /**
      * The opposite of `_.property`; this method creates a function which returns
      * the property value of a given key on `object`.
      *
@@ -11245,6 +11270,36 @@
     function propertyOf(object) {
       return function(key) {
         return object == null ? undefined : object[key];
+      };
+    }
+
+    /**
+     * The opposite of `_.propertyDeep`; this method creates a function which returns
+     * the property value of a given key path on `object`.
+     *
+     * @static
+     * @memberOf _
+     * @category Utility
+     * @param {Object} object The object to inspect.
+     * @returns {Function} Returns the new function.
+     * @example
+     *
+     * var users = [
+     *   { user: 'fredrick', nickname: 'fred' },
+     *   { user: 'bernard', nickname: 'barney' }
+     * ];
+     *
+     * var propertyOfUsers = _.propertyDeepOf(users);
+     *
+     * propertyOfusers([0, 'nickname']);
+     * // => 'fred'
+     *
+     * propertyOfusers([1, 'name']);
+     * // => 'bernard'
+     */
+    function propertyDeepOf(object) {
+      return function(keyPath) {
+        return resultDeep(object, keyPath);
       };
     }
 
@@ -11631,7 +11686,9 @@
     lodash.pick = pick;
     lodash.pluck = pluck;
     lodash.property = property;
+    lodash.propertyDeep = propertyDeep;
     lodash.propertyOf = propertyOf;
+    lodash.propertyDeepOf = propertyDeepOf;
     lodash.pull = pull;
     lodash.pullAt = pullAt;
     lodash.range = range;

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -9798,13 +9798,13 @@
      *  'dates': { 'birthdate': '03/17/1988', anniversary: '07/29/2012' }
      * };
      *
-     * _.result(object, ['user']);
+     * _.resultDeep(object, ['user']);
      * // => 'fred'
      *
-     * _.result(object, ['user', 'dates', 'anniversary']);
+     * _.resultDeep(object, ['user', 'dates', 'anniversary']);
      * // => '07/29/2012'
      *
-     * _.result(object, ['status', 'timestamp'], _.constant('busy'));
+     * _.resultDeep(object, ['status', 'timestamp'], _.constant('busy'));
      * // => 'busy'
      */
     function resultDeep(object, keyPath, defaultValue) {

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -11291,10 +11291,10 @@
      *
      * var propertyOfUsers = _.propertyDeepOf(users);
      *
-     * propertyOfusers([0, 'nickname']);
+     * propertyOfUsers([0, 'nickname']);
      * // => 'fred'
      *
-     * propertyOfusers([1, 'name']);
+     * propertyOfUsers([1, 'name']);
      * // => 'bernard'
      */
     function propertyDeepOf(object) {

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -9809,7 +9809,8 @@
      */
     function resultDeep(object, keyPath, defaultValue) {
       arrayEach(dropRight(keyPath), function(key) {
-        return object = result(object, key);
+        object = result(object, key);
+        return object != null;
       });
       return result(object, last(keyPath), defaultValue);
     }

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -9777,6 +9777,44 @@
     }
 
     /**
+     * Resolves the value of `keyPath` on `object`. If any values along `keyPath`
+     * is a function it is invoked with the `this` binding of `object` and its
+     * result is used to resolve the remainder of the `keyPath` rather than the
+     * function itself. If at any point along the `keyPath` the value is
+     * `undefined` the `defaultValue` is returned.
+     *
+     * @static
+     * @memberOf _
+     * @category Object
+     * @param {Object} object The object to query.
+     * @param {array} keyPath The key path of the properties to resolve.
+     * @param {*} [defaultValue] The value returned if the property value
+     *  resolves to `undefined`.
+     * @returns {*} Returns the resolved value.
+     * @example
+     *
+     * var object = {
+     *  'user': 'fred',
+     *  'dates': { 'birthdate': '03/17/1988', anniversary: '07/29/2012' }
+     * };
+     *
+     * _.result(object, ['user']);
+     * // => 'fred'
+     *
+     * _.result(object, ['user', 'dates', 'anniversary']);
+     * // => '07/29/2012'
+     *
+     * _.result(object, ['status', 'timestamp'], _.constant('busy'));
+     * // => 'busy'
+     */
+    function resultDeep(object, keyPath, defaultValue) {
+      arrayEach(dropRight(keyPath), function(key) {
+        return object = result(object, key);
+      });
+      return result(object, last(keyPath), defaultValue);
+    }
+
+    /**
      * An alternative to `_.reduce`; this method transforms `object` to a new
      * `accumulator` object which is the result of running each of its own enumerable
      * properties through `iteratee`, with each invocation potentially mutating
@@ -11712,6 +11750,7 @@
     lodash.reduceRight = reduceRight;
     lodash.repeat = repeat;
     lodash.result = result;
+    lodash.resultDeep = resultDeep;
     lodash.runInContext = runInContext;
     lodash.size = size;
     lodash.snakeCase = snakeCase;

--- a/test/test.js
+++ b/test/test.js
@@ -12491,6 +12491,52 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.resultDeep');
+
+  (function() {
+    var object = {
+      'a': { d: 1 },
+      'b': null,
+      'c': function() { return this.a; }
+    };
+
+    test('should resolve property values', 4, function() {
+      strictEqual(_.resultDeep(object, ['a', 'd']), 1);
+      strictEqual(_.resultDeep(object, ['b']), null);
+      strictEqual(_.resultDeep(object, ['c', 'd']), 1);
+      strictEqual(_.resultDeep(object, ['d']), undefined);
+    });
+
+    test('should return `undefined` when `object` is nullish', 2, function() {
+      strictEqual(_.resultDeep(null, ['a']), undefined);
+      strictEqual(_.resultDeep(undefined, ['a']), undefined);
+    });
+
+    test('should return the specified default value for undefined properties', 1, function() {
+      var values = empties.concat(true, new Date, 1, /x/, 'a');
+
+      var expected = _.transform(values, function(result, value) {
+        result.push(value, value);
+      });
+
+      var actual = _.transform(values, function(result, value) {
+        result.push(
+          _.resultDeep(object, ['d'], value),
+          _.resultDeep(null, ['d'], value)
+        );
+      });
+
+      deepEqual(actual, expected);
+    });
+
+    test('should execute default function values', 1, function() {
+      var actual = _.resultDeep(object, ['d'], object.c);
+      strictEqual(actual, object.a);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.rest');
 
   (function() {
@@ -16525,7 +16571,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 213, function() {
+    test('should accept falsey arguments', 214, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;

--- a/test/test.js
+++ b/test/test.js
@@ -11588,6 +11588,63 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.propertyDeep');
+
+  (function() {
+    test('should create a function that plucks a property value of a given object', 3, function() {
+      var object = { 'a': [1, 2], 'b': 3 },
+          prop = _.propertyDeep(['a', 1]);
+
+      strictEqual(prop.length, 1);
+      strictEqual(prop(object), 2);
+
+      prop = _.propertyDeep(['b']);
+      strictEqual(prop(object), 3);
+    });
+
+    test('should work with non-string `prop` arguments', 1, function() {
+      var prop = _.propertyDeep([1]);
+      strictEqual(prop([1, 2, 3]), 2);
+    });
+
+    test('should coerce key to a string', 1, function() {
+      function fn() {}
+      fn.toString = _.constant('fn');
+
+      var objects = [{ 'null': 1 }, { 'undefined': 2 }, { 'fn': 3 }, { '[object Object]': 4 }],
+          values = [null, undefined, fn, {}]
+
+      var actual = _.map(objects, function(object, index) {
+        var prop = _.propertyDeep([values[index]]);
+        return prop(object);
+      });
+
+      deepEqual(actual, [1, 2, 3, 4]);
+    });
+
+    test('should pluck inherited property values', 1, function() {
+      function Foo() { this.a = 1; }
+      Foo.prototype.b = 2;
+
+      var prop = _.propertyDeep(['b']);
+      strictEqual(prop(new Foo), 2);
+    });
+
+    test('should work when `object` is nullish', 1, function() {
+      var values = [, null, undefined],
+          expected = _.map(values, _.constant(undefined));
+
+      var actual = _.map(values, function(value, index) {
+        var prop = _.propertyDeep(['a']);
+        return index ? prop(value) : prop();
+      });
+
+      deepEqual(actual, expected);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.propertyOf');
 
   (function() {
@@ -11615,6 +11672,41 @@
       var actual = _.map(values, function(value, index) {
         var propOf = index ? _.propertyOf(value) : _.propertyOf();
         return propOf('a');
+      });
+
+      deepEqual(actual, expected);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
+  QUnit.module('lodash.propertyDeepOf');
+
+  (function() {
+    test('should create a function that plucks a property value of a given key', 3, function() {
+      var object = { 'a': 1, 'b': 2 },
+          propOf = _.propertyDeepOf(object);
+
+      strictEqual(propOf.length, 1);
+      strictEqual(propOf(['a']), 1);
+      strictEqual(propOf(['b']), 2);
+    });
+
+    test('should pluck inherited property values', 1, function() {
+      function Foo() { this.a = 1; }
+      Foo.prototype.b = 2;
+
+      var propOf = _.propertyDeepOf(new Foo);
+      strictEqual(propOf(['b']), 2);
+    });
+
+    test('should work when `object` is nullish', 1, function() {
+      var values = [, null, undefined],
+          expected = _.map(values, _.constant(undefined));
+
+      var actual = _.map(values, function(value, index) {
+        var propOf = index ? _.propertyDeepOf(value) : _.propertyDeepOf();
+        return propOf(['a']);
       });
 
       deepEqual(actual, expected);
@@ -16571,7 +16663,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 214, function() {
+    test('should accept falsey arguments', 216, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;


### PR DESCRIPTION
I saw that #1060 had lost momentum so thought I'd revive it with a PR.

I choose to create a new `_.resultDeep()` since the functionality seemed to me like an extension of what `_.result()` does. Not sure if anyone has strong feelings about the naming or arguments but at least now we have some code in front of us to hash this out.

I'm also hoping for suggestions to tidy up the `dropRight()` + `last()` combo. I had originally used a for-loop but ended up trading the performance gains for fewer bytes and better maintainability. Thoughts?