### PR TITLE
Error when an  anonymous define() is called outside of a loader request.

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -12030,9 +12030,14 @@
     // more details.
     root._ = _;
 
-    // Define as an anonymous module so, through path mapping, it can be
-    // referenced as the "underscore" module.
-    define(function() {
+    // AMD registration happens at the end for compatibility with AMD loaders
+    // that may not enforce next-turn semantics on modules. Even though general
+    // practice for AMD registration is to be anonymous, underscore registers
+    // as a named module because, like jQuery, it is a base library that is
+    // popular enough to be bundled in a third party lib, but not be part of
+    // an AMD load request. Those cases could generate an error when an
+    // anonymous define() is called outside of a loader request.
+    define('lodash', [], function() {
       return _;
     });
   }


### PR DESCRIPTION
I discovered this issue when I was [trying to help someone on stack overflow](http://stackoverflow.com/questions/29248881/anonymous-define-module-in-librarys-dependencies-causes-breakage-for-library/).

Looks like the guys from `underscore.js` have already faced this issue:

From the [underscore source code](https://github.com/jashkenas/underscore/blob/master/underscore.js#L1534-L1544):

```
  // AMD registration happens at the end for compatibility with AMD loaders
  // that may not enforce next-turn semantics on modules. Even though general
  // practice for AMD registration is to be anonymous, underscore registers
  // as a named module because, like jQuery, it is a base library that is
  // popular enough to be bundled in a third party lib, but not be part of
  // an AMD load request. Those cases could generate an error when an
  // anonymous define() is called outside of a loader request.
  if (typeof define === 'function' && define.amd) {
    define('underscore', [], function() {
      return _;
    });
  }
```

From the [lodash source code](https://github.com/lodash/lodash/blob/master/lodash.js#L11782-L11787):
```
  // Some AMD build optimizers like r.js check for condition patterns like the following:
  if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
    // Expose lodash to the global object when an AMD loader is present to avoid
    // errors in cases where lodash is loaded by a script tag and not intended
    // as an AMD module. See http://requirejs.org/docs/errors.html#mismatch for
    // more details.
    root._ = _;

    // Define as an anonymous module so, through path mapping, it can be
    // referenced as the "underscore" module.
    define(function() {
      return _;
    });
  }
```