### PR TITLE
Inconsistent results from _.propertyDeep and _.propertyDeepOf

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -2599,28 +2599,28 @@
     }
 
     /**
-     * The base implementation of `_.propertyDeep` which does not coerce `keys` to strings.
+     * The base implementation of `_.propertyDeep` and `_.propertyDeepOf` which
+     * does not coerce `keys` to strings and takes `object` as a parameter.
      *
      * @private
+     * @param {object} object Object to look for keys.
      * @param {string[]} keys Keys that specify the property to get.
-     * @returns {Function} Returns the new function.
+     * @returns {Function} Returns value at the end of the key path or undefined.
      */
-    function basePropertyDeep(keys) {
-      return function(object) {
+    function basePropertyDeep(object, keys) {
+      if (object == null) {
+        return undefined;
+      }
+      var index = -1,
+          length = keys.length;
+
+      while (++index < length) {
+        object = object[keys[index]];
         if (object == null) {
           return undefined;
         }
-        var index = -1,
-            length = keys.length;
-
-        while (++index < length) {
-          object = object[keys[index]];
-          if (object == null) {
-            return undefined;
-          }
-        }
-        return object;
-      };
+      }
+      return object;
     }
 
     /**
@@ -11292,7 +11292,9 @@
      * // => [undefined, 36]
      */
     function propertyDeep(keys) {
-      return basePropertyDeep(arrayMap(keys || [], baseToString));
+      return function(object) {
+        return basePropertyDeep(object, arrayMap(keys || [], baseToString));
+      };
     }
 
     /**
@@ -11345,8 +11347,8 @@
      * // => 'bernard'
      */
     function propertyDeepOf(object) {
-      return function(keyPath) {
-        return resultDeep(object, keyPath);
+      return function(keys) {
+        return basePropertyDeep(object, arrayMap(keys || [], baseToString));
       };
     }
 


### PR DESCRIPTION
I noticed some inconsistencies in methods newly added to the API. `_.propertyDeepOf()` internally uses `resultDeep()` while `_.propertyDeep()` uses `basePropertyDeep()`. One implementation calls function encountered in the key path, passing the result as the object of subsequent key lookups. The other returns the reference to functions it encounters.

```javascript
var object = Object,
  keys = ['prototype', 'toString'];
_.propertyDeep(keys)(object);
// => function toString() { [native code] }
_.propertyDeepOf(object)(keys);
// => "[object Object]"
```

After looking at `_.property()`, I'm guessing the intended behavior is to **not** invoke encountered functions. To reconcile the results of these methods I generalized `basePropertyDeep()` to suit both methods by returning the property at the end of the key path rather than a function. This allows the method to be used by both `_.propertyDeep` & `_.propertyDeepOf` which each create their own functions.