### PR TITLE
Minor change to `once` to avoid extra var swap

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -8070,7 +8070,7 @@
      * // `initialize` invokes `createApplication` once
      */
     function once(func) {
-      return before(func, 2);
+      return before(2, func);
     }
 
     /**


### PR DESCRIPTION
The way `once` uses `before` causes the inputs to always be swapped as `before` expects them in a different order.

Here is the [before definition](https://github.com/lodash/lodash/blob/master/lodash.src.js#L7452) and the [once usage](https://github.com/lodash/lodash/blob/master/lodash.src.js#L8073) for a quick reference.