### PR TITLE
Modify add() to parseFloat() variables passed

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -11559,7 +11559,7 @@
      * // => 10
      */
     function add(augend, addend) {
-      return parseFloat(augend) + parseFloat(addend);
+      return Number(augend) + Number(addend);
     }
 
     /**

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -11559,7 +11559,7 @@
      * // => 10
      */
     function add(augend, addend) {
-      return augend + addend;
+      return parseFloat(augend) + parseFloat(addend);
     }
 
     /**


### PR DESCRIPTION
Now `_.add('6', '4');` will output 10 instead of 64.