### PR TITLE
Add .npmignore to exclude unnecessary development files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.DS_Store
+*.custom.*
+*.log
+*.map
+lodash.compat.min.js
+
+# Development files
+/test/
+/perf/
+/vendor/
+/.travis.yml
+/.editorconfig


### PR DESCRIPTION
I copied .gitignore as .npmignore and added a few development files and folders to be excluded from the npm package as they're unnecessary. Also removed node_modules from .npmignore as it's unnecessary as per npm's documentation.