### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+/doc/
+/perf/
+/vendor/
+/test/
+.*
+lodash.js
+lodash.min.js
+


### PR DESCRIPTION
Greatly reduces npm tarball size from `3.6mb` to `450kb` and `134` files to `7` (Without losing any functionality). It simply blacklists dev related files when publishing to `npm`.

Fixes #1149 