### PR TITLE
removing manual array length change in baseFlatten for perf bonus

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -2191,7 +2191,6 @@
           var valIndex = -1,
               valLength = value.length;
 
-          result.length += valLength;
           while (++valIndex < valLength) {
             result[++resIndex] = value[valIndex];
           }


### PR DESCRIPTION
For iojs / node 0.12, manually updating the array length has a significant performance reduction:

```javascript
var _ = require("./lodash.src");

var arr = [
  [ {id:1}, {id:2}, {id:3}, {id:4}  ],
  [ {id:5}, {id:6}, {id:7}, {id:8}  ],
  [ {id:9}, {id:10},{id:11},{id:12} ],
  [ {id:13},{id:14},{id:15},{id:16} ]
];

var start = process.hrtime();
for(var i=0; i<10000; i++) {
  var foo = _.flatten(arr);
}
var end = process.hrtime(start);

console.log(end[1]/1000000);
```

For this sample program, the performance improves from taking 15ms to 5ms when removing the array length change.