### PR TITLE
Add `_.pascalCase`

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -942,11 +942,11 @@
      * `isFunction`, `isMatch`, `isNative`, `isNaN`, `isNull`, `isNumber`, `isObject`,
      * `isPlainObject`, `isRegExp`, `isString`, `isUndefined`, `isTypedArray`,
      * `join`, `kebabCase`, `last`, `lastIndexOf`, `max`, `min`, `noConflict`,
-     * `noop`, `now`, `pad`, `padLeft`, `padRight`, `parseInt`, `pop`, `random`,
-     * `reduce`, `reduceRight`, `repeat`, `result`, `runInContext`, `shift`, `size`,
-     * `snakeCase`, `some`, `sortedIndex`, `sortedLastIndex`, `startCase`, `startsWith`,
-     * `sum`, `template`, `trim`, `trimLeft`, `trimRight`, `trunc`, `unescape`,
-     * `uniqueId`, `value`, and `words`
+     * `noop`, `now`, `pad`, `padLeft`, `padRight`, `parseInt`, `pascalCase`,
+     * `pop`, `random`, `reduce`, `reduceRight`, `repeat`, `result`, `runInContext`,
+     * `shift`, `size`, `snakeCase`, `some`, `sortedIndex`, `sortedLastIndex`,
+     * `startCase`, `startsWith`, `sum`, `template`, `trim`, `trimLeft`, `trimRight`,
+     * `trunc`, `unescape`, `uniqueId`, `value`, and `words`
      *
      * The wrapper method `sample` will return a wrapped value when `n` is provided,
      * otherwise an unwrapped value is returned.
@@ -10534,6 +10534,29 @@
     });
 
     /**
+     * Converts `string` to [pascal case](https://en.wikipedia.org/wiki/PascalCase).
+     *
+     * @static
+     * @memberOf _
+     * @category String
+     * @param {string} [string=''] The string to convert.
+     * @returns {string} Returns the pascal cased string.
+     * @example
+     *
+     * _.pascalCase('Foo Bar');
+     * // => 'FooBar'
+     *
+     * _.pascalCase('--foo-bar');
+     * // => 'FooBar'
+     *
+     * _.pascalCase('__foo_bar__');
+     * // => 'FooBar'
+     */
+    var pascalCase = createCompounder(function(result, word, index) {
+      return result + word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    });
+
+    /**
      * Pads `string` on the left and right sides if it is shorter than `length`.
      * Padding characters are truncated if they can't be evenly divided by `length`.
      *
@@ -12131,6 +12154,7 @@
     lodash.padLeft = padLeft;
     lodash.padRight = padRight;
     lodash.parseInt = parseInt;
+    lodash.pascalCase = pascalCase;
     lodash.random = random;
     lodash.reduce = reduce;
     lodash.reduceRight = reduceRight;

--- a/test/test.js
+++ b/test/test.js
@@ -1655,7 +1655,7 @@
 
   QUnit.module('case methods');
 
-  _.each(['camel', 'kebab', 'snake', 'start'], function(caseName) {
+  _.each(['camel', 'kebab', 'pascal', 'snake', 'start'], function(caseName) {
     var methodName = caseName + 'Case',
         func = _[methodName];
 
@@ -1668,6 +1668,7 @@
       switch (caseName) {
         case 'camel': return 'fooBar';
         case 'kebab': return 'foo-bar';
+        case 'pascal': return 'FooBar';
         case 'snake': return 'foo_bar';
         case 'start': return 'Foo Bar';
       }
@@ -1694,7 +1695,11 @@
     test('`_.' + methodName + '` should deburr letters', 1, function() {
       var actual = _.map(burredLetters, function(burred, index) {
         var letter = deburredLetters[index];
-        letter = caseName == 'start' ? _.capitalize(letter) : letter.toLowerCase();
+        if (caseName == 'pascal' || caseName == 'start') {
+          letter = _.capitalize(letter);
+        } else {
+          letter = letter.toLowerCase();
+        }
         return func(burred) === letter;
       });
 
@@ -1733,7 +1738,7 @@
 
   (function() {
     test('should get the original value after cycling through all case methods', 1, function() {
-      var funcs = [_.camelCase, _.kebabCase, _.snakeCase, _.startCase, _.camelCase];
+      var funcs = [_.camelCase, _.kebabCase, _.pascalCase, _.snakeCase, _.startCase, _.camelCase];
 
       var actual = _.reduce(funcs, function(result, func) {
         return func(result);
@@ -17668,6 +17673,7 @@
       'pad',
       'padLeft',
       'padRight',
+      'pascalCase',
       'repeat',
       'snakeCase',
       'trim',


### PR DESCRIPTION
This pull request contains `_.pascalCase` static function.

```js
_.pascalCase('Foo Bar');
// => 'FooBar'

_.pascalCase('--foo-bar');
// => 'FooBar'

_.pascalCase('__foo_bar__');
// => 'FooBar'
```

I have signed the CLA.