### PR TITLE
Fixed typo on comments and docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2656,7 +2656,7 @@ callback returns `true` for elements that have the properties of the given
 object, else `false`.
 <br>
 <br>
-Many lodash methods are guarded to work as interatees for methods like
+Many lodash methods are guarded to work as iteratees for methods like
 `_.every`, `_.filter`, `_.map`, `_.mapValues`, `_.reject`, and `_.some`.
 <br>
 <br>
@@ -2818,7 +2818,7 @@ value. The `iteratee` is bound to `thisArg` and invoked with four arguments:<br>
 (accumulator, value, index|key, collection).
 <br>
 <br>
-Many lodash methods are guarded to work as interatees for methods like
+Many lodash methods are guarded to work as iteratees for methods like
 `_.reduce`, `_.reduceRight`, and `_.transform`.
 <br>
 <br>

--- a/lodash.js
+++ b/lodash.js
@@ -6723,7 +6723,7 @@
      * callback returns `true` for elements that have the properties of the given
      * object, else `false`.
      *
-     * Many lodash methods are guarded to work as interatees for methods like
+     * Many lodash methods are guarded to work as iteratees for methods like
      * `_.every`, `_.filter`, `_.map`, `_.mapValues`, `_.reject`, and `_.some`.
      *
      * The guarded methods are:
@@ -6867,7 +6867,7 @@
      * value. The `iteratee` is bound to `thisArg` and invoked with four arguments:
      * (accumulator, value, index|key, collection).
      *
-     * Many lodash methods are guarded to work as interatees for methods like
+     * Many lodash methods are guarded to work as iteratees for methods like
      * `_.reduce`, `_.reduceRight`, and `_.transform`.
      *
      * The guarded methods are:

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -6895,7 +6895,7 @@
      * callback returns `true` for elements that have the properties of the given
      * object, else `false`.
      *
-     * Many lodash methods are guarded to work as interatees for methods like
+     * Many lodash methods are guarded to work as iteratees for methods like
      * `_.every`, `_.filter`, `_.map`, `_.mapValues`, `_.reject`, and `_.some`.
      *
      * The guarded methods are:
@@ -7039,7 +7039,7 @@
      * value. The `iteratee` is bound to `thisArg` and invoked with four arguments:
      * (accumulator, value, index|key, collection).
      *
-     * Many lodash methods are guarded to work as interatees for methods like
+     * Many lodash methods are guarded to work as iteratees for methods like
      * `_.reduce`, `_.reduceRight`, and `_.transform`.
      *
      * The guarded methods are:


### PR DESCRIPTION
Fixed typo "interatees" in a couple of places in the comments and docs.