### PR TITLE
Addition of _.next, _.previous and _.placeInRange

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -928,8 +928,8 @@
      * `isFinite` `isFunction`, `isMatch`, `isNative`, `isNaN`, `isNull`, `isNumber`,
      * `isObject`, `isPlainObject`, `isRegExp`, `isString`, `isUndefined`,
      * `isTypedArray`, `join`, `kebabCase`, `last`, `lastIndexOf`, `lt`, `lte`,
-     * `max`, `min`, `noConflict`, `noop`, `now`, `pad`, `padLeft`, `padRight`,
-     * `parseInt`, `pop`, `random`, `reduce`, `reduceRight`, `repeat`, `result`,
+     * `max`, `min`, `next`, `noConflict`, `noop`, `now`, `pad`, `padLeft`, `padRight`,
+     * `parseInt`, `placeInRange`, `pop`, `previous`, `random`, `reduce`, `reduceRight`, `repeat`, `result`,
      * `runInContext`, `shift`, `size`, `snakeCase`, `some`, `sortedIndex`,
      * `sortedLastIndex`, `startCase`, `startsWith`, `sum`, `template`, `trim`,
      * `trimLeft`, `trimRight`, `trunc`, `unescape`, `uniqueId`, `value`, and `words`
@@ -11560,6 +11560,25 @@
     }
 
     /**
+     * Gets the next element in the array after the one provided.
+     * Returns undefined if the current element is the last of the array.
+     * @static
+     * @memberOf _
+     * @category Array
+     * @param {Array} array The array to query.
+     * @param {*} current The current element of the array.
+     * @returns {*} Returns the next element of `array`.
+     * @example
+     *
+     * _.next([1, 2, 3], 2);
+     * // => 3
+     */
+    function next(array, current) {
+      var indexOfCurrent = indexOf(array, current);
+      return indexOfCurrent === -1 ? undefined : array[indexOfCurrent + 1];
+    }
+
+    /**
      * Reverts the `_` variable to its previous value and returns a reference to
      * the `lodash` function.
      *
@@ -11592,6 +11611,55 @@
      */
     function noop() {
       // No operation performed.
+    }
+
+    /*
+     * Ensures that the value provided falls within the range.
+     * If the value exceeds or falls short of the range, then set to the appropriate
+     * `start` or `end`. Otherwise, we return the value as provided.
+     * @static
+     * @memberOf -
+     * @category Number
+     * @param {number} value The number to check.
+     * @param {number} start The start of the range.
+     * @param {number} end The end of the range.
+     * @returns {number} Returns the number, restricted to the range provided
+     * @example
+     *
+     * _.placeInRange(2, 5, 10);
+     * // => 5
+     *
+     * _.placeInRange(15, 5, 10);
+     * // => 10
+     *
+     * _.placeInRange(8, 5, 10);
+     * // => 8
+     */
+    function placeInRange(value, start, end) {
+      if(inRange(value, start, end)) {
+        return value;
+      } else {
+        return value < start ? start : end;
+      }
+    }
+
+    /**
+     * Gets the previous element in the array after the one provided
+     * Returns undefined if the current element is the last of the array.
+     * @static
+     * @memberOf _
+     * @category Array
+     * @param {Array} array The array to query.
+     * @param {*} current The current element of the array.
+     * @returns {*} Returns the previous element of `array`.
+     * @example
+     *
+     * _.previous([1, 2, 2]);
+     * // => 1
+     */
+    function previous(array, current) {
+      var indexOfCurrent = indexOf(array, current);
+      return array[indexOfCurrent - 1];
     }
 
     /**
@@ -12023,6 +12091,7 @@
     lodash.methodOf = methodOf;
     lodash.mixin = mixin;
     lodash.negate = negate;
+    lodash.next = next;
     lodash.omit = omit;
     lodash.once = once;
     lodash.pairs = pairs;
@@ -12030,7 +12099,9 @@
     lodash.partialRight = partialRight;
     lodash.partition = partition;
     lodash.pick = pick;
+    lodash.placeInRange = placeInRange;
     lodash.pluck = pluck;
+    lodash.previous = previous;
     lodash.property = property;
     lodash.propertyOf = propertyOf;
     lodash.pull = pull;
@@ -12489,3 +12560,4 @@
     root._ = _;
   }
 }.call(this));
+

--- a/test/test.js
+++ b/test/test.js
@@ -11334,6 +11334,34 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.next');
+
+  (function() {
+    var animals = ['a', 'b', 'c', 'd'];
+
+    test('should return the next element from the current in a given array', 1, function() {
+      var next = _.next(animals, 'c');
+      strictEqual(next, 'd');
+    });
+
+    test('should return `undefined` if there is no next element', 1, function() {
+      var next = _.next(animals, 'd');
+      strictEqual(next, undefined);
+    });
+
+    test('should return `undefined` when passed an empty array', 1, function() {
+      var next = _.next([], 'b');
+      strictEqual(next, undefined);
+    });
+
+    test('should returned `undefined` when current value does not exist in array', 1, function() {
+      var next = _.next(animals, 'e');
+      strictEqual(next, undefined);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.noop');
 
   (function() {
@@ -12213,6 +12241,27 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.placeInRange');
+
+  (function() {
+    test('should return the start value when the current value is less than the range', 1, function() {
+      var placed = _.placeInRange(2, 5, 10);
+      strictEqual(placed, 5);
+    });
+
+    test('should return the end value when the current value is greater than the range', 1, function() {
+      var placed = _.placeInRange(15, 5, 10);
+      strictEqual(placed, 10);
+    });
+
+    test('should return the current value if it falls within the range', 1, function() {
+      var placed = _.placeInRange(8, 5, 10);
+      strictEqual(placed, 8);
+    });
+  })();
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.pluck');
 
   (function() {
@@ -12272,6 +12321,34 @@
       else {
         skipTest(2);
       }
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
+  QUnit.module('lodash.previous');
+
+  (function() {
+    var animals = ['a', 'b', 'c', 'd'];
+
+    test('should return the previous element from the current in a given array', 1, function() {
+      var previous = _.previous(animals, 'c');
+      strictEqual(previous, 'b');
+    });
+
+    test('should return `undefined` if there is no previous element', 1, function() {
+      var previous = _.previous(animals, 'a');
+      strictEqual(previous, undefined);
+    });
+
+    test('should return `undefined` when passed an empty array', 1, function() {
+      var previous = _.previous([], 'c');
+      strictEqual(previous, undefined);
+    });
+
+    test('should returned `undefined` when current value does not exist in array', 1, function() {
+      var previous = _.previous(animals, 'e');
+      strictEqual(previous, undefined);
     });
   }());
 
@@ -17986,3 +18063,4 @@
     QUnit.load();
   }
 }.call(this));
+


### PR DESCRIPTION
While working on a recent project, I found the addition of the following three simple methods could prove both helpful to a large number of lodash users, and that they feel inline with the existing methods available:

`_.next` - Given an array and one of it's elements, return the next element.
`_.previous` - Similar, but returning the previous element of the array.

`_.placeInRange` - Ensures that a value falls within a range, returning the start or end value if the value provided happens to exceed or fall short of the range.

Have submitted this as a pull request, but it's more an example implementation to trigger discussion. My most recent use case is building a dynamic Grid composed of resizable columns, where I'm wanting to enforce min/max resize limits, and easily obtain the preceding or subsequent column.

(random note: have been inspired to contribute towards lodash after listening to the awesome JSJabber episode with John-David Dalton - love the unrelenting push for improvement).
