### PR TITLE
Improve remove performance

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -5457,7 +5457,12 @@
           indexes.push(index);
         }
       }
-      basePullAt(array, indexes);
+
+      length = indexes.length;
+      while (length--) {
+        index = indexes[length];
+        splice.call(array, index, 1);
+      }
       return result;
     }
 


### PR DESCRIPTION
When profiling our application, I saw a significant amount of time spent in our calls to _.remove().
When looking at the current code, I saw that it builds an array of indices to remove from the source array, and then uses basePullAt to remove the elements.

basePullAt for some reason allows to use anything as index, which is why it uses parseFloat().

So I decided to inline a specialized version which knows that the passed arguments are valid integer indices.

PS: I filled out the CLA (submitted a CLA on 2015-05-15 12:50:41)
PPS: I could not figure out if I need to change the es branch as well.