### PR TITLE
Reset resIndex after recursive baseFlatten

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -2048,6 +2048,7 @@
           if (isDeep) {
             // Recursively flatten arrays (susceptible to call stack limits).
             baseFlatten(value, isDeep, isStrict, result);
+            resIndex = result.length - 1;
           } else {
             var valIndex = -1,
                 valLength = value.length;

--- a/test/test.js
+++ b/test/test.js
@@ -5215,12 +5215,12 @@
     });
 
     test('should support flattening of nested arrays', 3, function() {
-      var array = [1, [2], [3, [4]]],
-          expected = [1, 2, 3, [4]];
+      var array = [1, [2, 3], 4, [[5]]],
+          expected = [1, 2, 3, 4, [5]];
 
       deepEqual(_.flatten(array), expected);
 
-      expected = [1, 2, 3, 4];
+      expected = [1, 2, 3, 4, 5];
       deepEqual(_.flatten(array, true), expected);
       deepEqual(_.flattenDeep(array), expected);
     });


### PR DESCRIPTION
Since the `value` array can have multiple elements, we need to set `resIndex` to be the last index after the recursive call.