### PR TITLE
_.ary can create wrappers with exact arity.

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -7404,19 +7404,34 @@
      * @category Function
      * @param {Function} func The function to cap arguments for.
      * @param {number} [n=func.length] The arity cap.
+     * @param {boolean} [exact] Create a function with matching arity.
      * @param- {Object} [guard] Enables use as a callback for functions like `_.map`.
      * @returns {Function} Returns the new function.
      * @example
      *
      * _.map(['6', '8', '10'], _.ary(parseInt, 1));
      * // => [6, 8, 10]
+     *
+     * _.ary(parseInt, 1, true).length;
+     * // => 1
      */
     function ary(func, n, guard) {
+      var exact = false;
       if (guard && isIterateeCall(func, n, guard)) {
         n = undefined;
       }
+      else {
+        exact = guard;
+      }
       n = (func && n == null) ? func.length : nativeMax(+n || 0, 0);
-      return createWrapper(func, ARY_FLAG, undefined, undefined, undefined, undefined, n);
+      var wrapper = createWrapper(func, ARY_FLAG, undefined, undefined, undefined, undefined, n);
+      if (exact) {
+        var plist = [];
+        for (var i = 0; i < n; i++) { plist.push('p' + i); }
+        var params = plist.join(',');
+        wrapper = Function('fn', 'return function(' + params + ') { return fn.apply(this, arguments); }')(wrapper);
+      }
+      return wrapper;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -1016,6 +1016,10 @@
         skipTest();
       }
     });
+
+    test('should produce a function with matching arity', 1, function() {
+      strictEqual(_.ary(fn, 3, true).length, 3);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
This pull request allows `_.ary` to take an extra argument, which when true, creates a wrapper function that has the exact right arity.

```js
_.ary(fn, 5).length === 5
```

There's are a couple of JS libraries where function arity is important (Express, for instance).