### PR TITLE
Adding lodash.interleave

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -5067,6 +5067,54 @@
     }
 
     /**
+     * Creates an array from given arrays and consisting of all the first elements from
+     * said arrays then the second elements etc.
+     *
+     * @static
+     * @memberOf _
+     * @category Array
+     * @param {...Array} [arrays] The arrays to interleave.
+     * @returns {Array} Returns the interleaved array.
+     * @example
+     *
+     * _.interleave([1, 2, 3], [4, 5, 6]);
+     * // => [1, 4, 2, 5, 3, 6]
+     *
+     * // using more than two arrays
+     * _.interleave([1, 2], [3, 4], [5, 6]);
+     * // => [1, 3, 5, 2, 4, 6]
+     *
+     * // the shortest array will stop interleave
+     * _.interleave([1, 2], [3, 4, 5]);
+     * // => [1, 3, 2, 4]
+     */
+    var interleave = restParam(function(arrays) {
+      arrays = compact(arrays);
+
+      var minLength = (arrays[0] || []).length,
+          othLength = arrays.length,
+          othIndex = 0;
+
+      // Retrieving the minimum length of given arrays
+      while (++othIndex < othLength) {
+        minLength = nativeMin(minLength, arrays[othIndex].length);
+      }
+
+      // Interleaving
+      var index = -1,
+          result = Array(othLength * minLength);
+
+      while (++index < minLength) {
+        othIndex = -1;
+        while (++othIndex < othLength) {
+          result[(index * othLength) + othIndex] = arrays[othIndex][index];
+        }
+      }
+
+      return result;
+    });
+
+    /**
      * Creates an array of unique values that are included in all of the provided
      * arrays using [`SameValueZero`](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-samevaluezero)
      * for equality comparisons.
@@ -11926,6 +11974,7 @@
     lodash.groupBy = groupBy;
     lodash.indexBy = indexBy;
     lodash.initial = initial;
+    lodash.interleave = interleave;
     lodash.intersection = intersection;
     lodash.invert = invert;
     lodash.invoke = invoke;

--- a/test/test.js
+++ b/test/test.js
@@ -6758,6 +6758,30 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.interleave');
+
+  (function() {
+    test('should interleave two arrays.', 1, function() {
+      var interleaved = _.interleave([1, 2, 3], [4, 5, 6]);
+      deepEqual(interleaved, [1, 4, 2, 5, 3, 6]);
+    });
+
+    test('should interleave multiple arrays.', 1, function() {
+      var interleaved = _.interleave([1, 2], [3, 4], [5, 6], [7, 8]);
+      deepEqual(interleaved, [1, 3, 5, 7, 2, 4, 6, 8]);
+    });
+
+    test('should stop at the shortest array.', 2, function() {
+      var interleaved1 = _.interleave([1, 2], [3, 4, 5]),
+          interleaved2 = _.interleave([1, 2, 3], [4, 5]);
+
+      deepEqual(interleaved1, [1, 3, 2, 4]);
+      deepEqual(interleaved2, [1, 4, 2, 5]);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.intersection');
 
   (function() {
@@ -17766,7 +17790,7 @@
     var args = arguments,
         array = [1, 2, 3, 4, 5, 6];
 
-    test('should work with `arguments` objects', 27, function() {
+    test('should work with `arguments` objects', 28, function() {
       function message(methodName) {
         return '`_.' + methodName + '` should work with `arguments` objects';
       }
@@ -17788,6 +17812,7 @@
       deepEqual(_.flatten(args), [1, null, 3, null, 5], message('flatten'));
       deepEqual(_.indexOf(args, 5), 4, message('indexOf'));
       deepEqual(_.initial(args), [1, null, [3], null], message('initial'));
+      deepEqual(_.interleave(args), [1, null, [3], null, 5], message('interleave'));
       deepEqual(_.intersection(args, [1]), [1], message('intersection'));
       deepEqual(_.last(args), 5, message('last'));
       deepEqual(_.lastIndexOf(args, 1), 0, message('lastIndexOf'));
@@ -17907,6 +17932,7 @@
       'flatten',
       'functions',
       'initial',
+      'interleave',
       'intersection',
       'invoke',
       'keys',
@@ -17938,7 +17964,7 @@
 
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
-    test('should accept falsey arguments', 226, function() {
+    test('should accept falsey arguments', 228, function() {
       var emptyArrays = _.map(falsey, _.constant([])),
           isExposed = '_' in root,
           oldDash = root._;
@@ -17980,7 +18006,7 @@
       });
     });
 
-    test('should return an array', 72, function() {
+    test('should return an array', 74, function() {
       var array = [1, 2, 3];
 
       _.each(returnArrays, function(methodName) {


### PR DESCRIPTION
The aim of this PR is to add the `interleave` function to lodash. The aim of this method, whose name comes directly from Clojure, is to "interleave" the given arrays' items likewise:

```js
_.interleave([1, 2, 3], [4, 5, 6]);
// => [1, 4, 2, 5, 3, 6]

// using more than two arrays
_.interleave([1, 2], [3, 4], [5, 6]);
// => [1, 3, 5, 2, 4, 6]

// the shortest array will stop interleave
_.interleave([1, 2], [3, 4, 5]);
// => [1, 3, 2, 4]
```

**Couple of notes:**

* If this method is already existing in lodash but under another name which I wouldn't have found in the docs, then sorry for the useless PR :-).
* This PR is merely a discussion opener about `interleave`. I don't know whether lodash's community would need this method.
* A similar result to this function might be obtained through `_.flatten(_.zip(array1, array2))` but I guess it would be less performant.
* A similar result to `_.zip(array1, array2)` might be obtained through `_.chunk(_.interleave(array1, array2), 2)`.
* I use `compact` to filter the given arrays but I am not sure this is the way it is done in the library's internal. What are usually the means of making the array methods accept falsey and invalid values?