### PR TITLE
Ensure `_.get` and `_.result` return the same given object for empty paths.

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -2215,7 +2215,7 @@
       while (object != null && index < length) {
         object = toObject(object)[path[index++]];
       }
-      return (index && index == length) ? object : undefined;
+      return (index == length) ? object : undefined;
     }
 
     /**
@@ -10058,12 +10058,12 @@
      * // => 'default'
      */
     function result(object, path, defaultValue) {
-      var result = object == null ? undefined : toObject(object)[path];
+      var result = object == null ? defaultValue : toObject(object)[path];
       if (result === undefined) {
-        if (object != null && !isKey(path, object)) {
+        if (object != null && (!isKey(path, object) || !hasOwnProperty.call(object, path))) {
           path = toPath(path);
-          object = path.length == 1 ? object : baseGet(object, baseSlice(path, 0, -1));
-          result = object == null ? undefined : toObject(object)[last(path)];
+          object = path.length <= 1 ? object : baseGet(object, baseSlice(path, 0, -1));
+          result = object == null ? defaultValue : baseGet(object, path.length ? [last(path)] : []);
         }
         result = result === undefined ? defaultValue : result;
       }

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -9604,9 +9604,20 @@
      * // => 'default'
      */
     function get(object, path, defaultValue) {
-      var pathKey = isArray(path) && path.length == 0 ? undefined : path + '';
-      var result = object == null ? defaultValue : baseGet(object, toPath(path), pathKey);
-      return result === undefined ? defaultValue : result;
+      var result = (object == null || isArray(path) && path.length == 0) ? undefined : toObject(object)[path];
+      if (result === undefined) {
+        var resolved = object != null && hasOwnProperty.call(object, path);
+        if (object != null && (!isKey(path, object) || !resolved)) {
+          path = toPath(path);
+          object = path.length <= 1 ? object : baseGet(object, baseSlice(path, 0, -1));
+          result = object == null ? defaultValue :
+            path.length ? toObject(object)[last(path)] :
+            object;
+          resolved = object != null && path.length && hasOwnProperty.call(object, last(path));
+        }
+        result = result === undefined && !resolved ? defaultValue : result;
+      }
+      return result;
     }
 
     /**
@@ -10061,14 +10072,16 @@
     function result(object, path, defaultValue) {
       var result = (object == null || isArray(path) && path.length == 0) ? undefined : toObject(object)[path];
       if (result === undefined) {
-        if (object != null && (!isKey(path, object) || !hasOwnProperty.call(object, path))) {
+        var resolved = object != null && hasOwnProperty.call(object, path);
+        if (object != null && (!isKey(path, object) || !resolved)) {
           path = toPath(path);
           object = path.length <= 1 ? object : baseGet(object, baseSlice(path, 0, -1));
           result = object == null ? defaultValue :
-            path.length ? baseGet(object, [last(path)]) :
+            path.length ? toObject(object)[last(path)] :
             object;
+          resolved = object != null && path.length && hasOwnProperty.call(object, last(path));
         }
-        result = result === undefined ? defaultValue : result;
+        result = result === undefined && !resolved ? defaultValue : result;
       }
       return isFunction(result) ? result.call(object) : result;
     }

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -9604,7 +9604,8 @@
      * // => 'default'
      */
     function get(object, path, defaultValue) {
-      var result = object == null ? undefined : baseGet(object, toPath(path), path + '');
+      var pathKey = isArray(path) && path.length == 0 ? undefined : path + '';
+      var result = object == null ? defaultValue : baseGet(object, toPath(path), pathKey);
       return result === undefined ? defaultValue : result;
     }
 
@@ -10058,12 +10059,14 @@
      * // => 'default'
      */
     function result(object, path, defaultValue) {
-      var result = object == null ? defaultValue : toObject(object)[path];
+      var result = (object == null || isArray(path) && path.length == 0) ? undefined : toObject(object)[path];
       if (result === undefined) {
         if (object != null && (!isKey(path, object) || !hasOwnProperty.call(object, path))) {
           path = toPath(path);
           object = path.length <= 1 ? object : baseGet(object, baseSlice(path, 0, -1));
-          result = object == null ? defaultValue : baseGet(object, path.length ? [last(path)] : []);
+          result = object == null ? defaultValue :
+            path.length ? baseGet(object, [last(path)]) :
+            object;
         }
         result = result === undefined ? defaultValue : result;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -13442,9 +13442,10 @@
       strictEqual(func(object, 'a[]'), 1);
     });
 
-    test('`_.' + methodName + '` should handle empty paths', 4, function() {
-      _.each([['', ''], [[], ['']]], function(pair) {
-        strictEqual(func({}, pair[0]), undefined);
+    test('`_.' + methodName + '` should handle empty paths', 6, function() {
+      _.each([['', ''], [[], []], [[''], ['']]], function(pair, index) {
+        var object = {};
+        strictEqual(func(object, pair[0]), index == 2 ? undefined : object);
         strictEqual(func({ '': 3 }, pair[1]), 3);
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -13451,6 +13451,11 @@
       });
     });
 
+    test('`_.' + methodName + '` should return value when path exists', 1, function() {
+      var object = { 'a': undefined };
+      strictEqual(func(object, 'a', {}), undefined);
+    });
+
     test('`_.' + methodName + '` should handle complex paths', 2, function() {
       var object = { 'a': { '-1.23': { '["b"]': { 'c': { "['d']": { 'e': { 'f': 6 } } } } } } };
 

--- a/test/test.js
+++ b/test/test.js
@@ -13443,10 +13443,11 @@
     });
 
     test('`_.' + methodName + '` should handle empty paths', 6, function() {
-      _.each([['', ''], [[], []], [[''], ['']]], function(pair, index) {
+      _.each([['', ''], [[], ['']], [[''], []]], function(pair, index) {
         var object = {};
+        var object2 = { '': 3 };
         strictEqual(func(object, pair[0]), index == 2 ? undefined : object);
-        strictEqual(func({ '': 3 }, pair[1]), 3);
+        strictEqual(func(object2, pair[1]), index == 2 ? object2 : 3);
       });
     });
 


### PR DESCRIPTION
This PR changes behaviour to consider `[]` and `''` to be empty paths, and thus `_.get` would return the same given object:

```js
const NOT_SET = {};
const obj = {foo: 'bar'};

assert(_.get(obj, [], NOT_SET) === obj); // => previously returned defaultValue for v3.9.3
assert(_.get(obj, '', NOT_SET) === obj); // => previously returned defaultValue for v3.9.3
```

This affects `_.result`:

```js
const obj = {foo: 'bar'};
assert(_.result(obj, [], NOT_SET) === obj); // => previously returned defaultValue for v3.9.3
assert(_.result(obj, '', NOT_SET) === obj); // => previously returned defaultValue for v3.9.3

// as a consequence, something like this would now work

function foo() {
    return this.bar;
}
foo.bar = 'bar';

assert(_.result(foo, '', NOT_SET) === 'bar');
assert(_.result(foo, [], NOT_SET) === 'bar');
```


