### PR TITLE
Refactor debounce & test wrapper re-entrance

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -7821,38 +7821,31 @@
         maxTimeoutId = timeoutId = trailingCall = undefined;
       }
 
-      function delayed() {
-        var remaining = wait - (now() - stamp);
-        if (remaining <= 0 || remaining > wait) {
-          if (maxTimeoutId) {
-            clearTimeout(maxTimeoutId);
-          }
-          var isCalled = trailingCall;
-          maxTimeoutId = timeoutId = trailingCall = undefined;
-          if (isCalled) {
-            lastCalled = now();
-            result = func.apply(thisArg, args);
-            if (!timeoutId && !maxTimeoutId) {
-              args = thisArg = undefined;
-            }
-          }
-        } else {
-          timeoutId = setTimeout(delayed, remaining);
-        }
-      }
-
-      function maxDelayed() {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
+      function executeBoundFunction(shouldExecute, clearTimeoutId) {
+        if (clearTimeoutId) {
+          clearTimeout(clearTimeoutId);
         }
         maxTimeoutId = timeoutId = trailingCall = undefined;
-        if (trailing || (maxWait !== wait)) {
+        if (shouldExecute) {
           lastCalled = now();
           result = func.apply(thisArg, args);
           if (!timeoutId && !maxTimeoutId) {
             args = thisArg = undefined;
           }
         }
+      }
+
+      function delayed() {
+        var remaining = wait - (now() - stamp);
+        if (remaining <= 0 || remaining > wait) {
+          executeBoundFunction(trailingCall, maxTimeoutId);
+        } else {
+          timeoutId = setTimeout(delayed, remaining);
+        }
+      }
+
+      function maxDelayed() {
+        executeBoundFunction(trailing || (maxWait !== wait), timeoutId);
       }
 
       function debounced() {

--- a/test/test.js
+++ b/test/test.js
@@ -15953,6 +15953,35 @@
         QUnit.start();
       }
     });
+
+    asyncTest('_.' + methodName + ' should support re-entrant calls', 2, function() {
+      if (!(isRhino && isModularize)) {
+        var sequence = [
+          ['b1', 'b2']
+        ];
+        var value = '';
+        var append = function(arg){
+          value += this + arg;
+          var args = sequence.pop();
+          if (args) {
+            debouncedAppend.call(args[0], args[1]);
+          }
+        };
+        
+        var debouncedAppend = _.debounce(append, 32);
+        debouncedAppend.call('a1', 'a2');
+        equal(value, '');
+        
+        setTimeout(function(){
+          equal(value, 'a1a2b1b2', 'append was debounced successfully');
+          QUnit.start();
+        }, 100);
+      }
+      else {
+        skipTest(2);
+        QUnit.start();
+      }
+    });
   });
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Kills some redundant code and adds test coverage (ported from Underscore's test suite) for re-entrant debounced functions