### PR TITLE
Save 1 millisecond!

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -7203,7 +7203,7 @@
      * // logs 'deferred' after one or more milliseconds
      */
     var defer = restParam(function(func, args) {
-      return baseDelay(func, 1, args);
+      return baseDelay(func, 0, args);
     });
 
     /**


### PR DESCRIPTION
The default action of setTimeout will move the function to the end of the call stack. No need to wait one millisecond.