### PR TITLE
Make sure root is the global object. Fix lodash in Firefox extensions

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -279,9 +279,7 @@
    * The `this` value is used if it's the global object to avoid Greasemonkey's
    * restricted `window` object, otherwise the `window` object is used.
    */
-  var freeRoot = freeGlobal || ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) || freeSelf || thisGlobal;
-  
-  var root = freeRoot.Math === Math ? freeRoot : Function('return this')();
+  var root = freeGlobal || ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) || freeSelf || thisGlobal || Function('return this')();
 
   /*--------------------------------------------------------------------------*/
 
@@ -431,7 +429,7 @@
    * @returns {null|Object} Returns `value` if it's a global object, else `null`.
    */
   function checkGlobal(value) {
-    return (value && value.Object) ? value : null;
+    return (value && value.Object === Object) ? value : null;
   }
 
   /**

--- a/lodash.src.js
+++ b/lodash.src.js
@@ -279,7 +279,9 @@
    * The `this` value is used if it's the global object to avoid Greasemonkey's
    * restricted `window` object, otherwise the `window` object is used.
    */
-  var root = freeGlobal || ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) || freeSelf || thisGlobal;
+  var freeRoot = freeGlobal || ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) || freeSelf || thisGlobal;
+  
+  var root = freeRoot.Math === Math ? freeRoot : Function('return this')();
 
   /*--------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Lodash does not run within the content script of a Firefox Bootstraped extensions. Firefox add-on SDK extensions are not affected.

The basic problem is to get the correct `global` object.

Within the content script sandbox properties like `window` and `self` are available and refer to the current window/tab. Unfortunately `window` and `self` are not the global object inside the sandbox.

For example: 

```js
window.Math === Math // false
self.Math === Math   // false
```

https://github.com/lodash/lodash/blob/3.10.0/lodash.js#L274

At this point `root` has a reference to the wrong object. A working solution can be found here: https://github.com/zloirock/core-js/blob/master/modules/%24.js#L2

For more information and discussion, see: 

https://github.com/zloirock/core-js/pull/91
https://github.com/zloirock/core-js/issues/86