### PR TITLE
Added example of_.isString()

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8972,6 +8972,9 @@
      * _.isString('abc');
      * // => true
      *
+     * _.isString('');
+     * // => true
+     *
      * _.isString(1);
      * // => false
      */


### PR DESCRIPTION
I thought it would be appropriate to add another example of the _.isString() function. An empty string is usually considered a falsy value but, of course, not when it comes to _.isString().

Just stumbled upon this in the codebase I was working on as it caused a bug.