### PR TITLE
Re-word _.merge docs for clarity

### DIFF
--- a/lodash.src.js
+++ b/lodash.src.js
@@ -9127,9 +9127,9 @@
     }
 
     /**
-     * Recursively merges own enumerable properties of the source object(s), that
-     * don't resolve to `undefined` into the destination object. Subsequent sources
-     * overwrite property assignments of previous sources.
+     * Recursively merges own enumerable properties of the source object(s) into the
+     * destination object, for source properties which don't resolve to `undefined`.
+     * Subsequent sources overwrite property assignments of previous sources.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
Previously, when scanning the docs, it could easily be accidentally read as:

'...that don't resolve to 'undefined' **in** the destination object.'

(i.e. "in" instead of "into")

Both myself and a collegue read it this way, until we looked at it more closely.

I've attempted re-pharsing it here to remove any ambiguity, although it's a bit more verbose.

Alternatively, we could just put a comma after 'undefined', which would help to separate it from "into the destination object".