### PR TITLE
Add String to valid includes parameters [ci skip]

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5990,7 +5990,7 @@
      * @static
      * @memberOf _
      * @category Collection
-     * @param {Array|Object} collection The collection to search.
+     * @param {Array|Object|string} collection The collection to search.
      * @param {*} target The value to search for.
      * @param {number} [fromIndex=0] The index to search from.
      * @param- {Object} [guard] Enables use as an iteratee for functions like `_.reduce`.


### PR DESCRIPTION
There is still an example for includes with a string, as discussed in gitter this should be here if the behaviour is sticking around