### PR TITLE
Add npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
       "test",
       "vendor"
     ]
+  },
+  "scripts": {
+    "test": "node test/test"
   }
 }


### PR DESCRIPTION
Adds the npm test script to package.json.
The tests themselves do not need to be published to npm.

(This is all that's needed to get lodash working well with the http://github.com/nodejs/citgm tool)