### PR TITLE
Modify zipObject function. When there is a repeat props, create and a…

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5416,7 +5416,8 @@
      * The inverse of `_.pairs`; this method returns an object composed from arrays
      * of property names and values. Provide either a single two dimensional array,
      * e.g. `[[key1, value1], [key2, value2]]` or two arrays, one of property names
-     * and one of corresponding values.
+     * and one of corresponding values. If key is repeated, value of property is an
+     * array with values of the repeat keys.
      *
      * @static
      * @memberOf _
@@ -5440,14 +5441,23 @@
       if (length && !values && !isArray(props[0])) {
         values = [];
       }
+
       while (++index < length) {
-        var key = props[index];
-        if (values) {
-          result[key] = values[index];
-        } else if (key) {
-          result[key[0]] = key[1];
+        var key = props[index],
+            resultProp,
+            resultValue;
+
+        resultProp = values ? key: key[0];
+        resultValue = values ? values[index]: key[1];
+
+        if (result[resultProp]) {
+          result[resultProp] = Array.isArray(result[resultProp]) ? result[resultProp]: [result[resultProp]];
+          result[resultProp].push(resultValue);
+        } else {
+          result[resultProp] = resultValue;
         }
       }
+
       return result;
     }
 


### PR DESCRIPTION
Hi Lodash community!!

I've had an idea to improve `zipObject` function. My English level is very low, sorry, but I can show and example of my idea.
```js
[ ['test', 1], ['test', 2], ['test4': 3] ] => // before returns {test: 2, test4: 3}
```
I think would be useful that when a prop array is repeated, the result return a property with an array values.
```js
[ ['test', 1], ['test', 2], ['test4': 3] ] => // now returns {test: [1,2], test4: 3}
```
With this commit, I've modified code to work this.

I hope that my contribution will be useful.