### PR TITLE
Remove keys when use `_.set` with `undefined` values

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2518,7 +2518,11 @@
               newValue = oldValue == null ? (isIndex(path[index + 1]) ? [] : {}) : oldValue;
             }
           }
-          assignValue(nested, key, newValue);
+          if (newValue === undefined) {
+            delete nested[key];
+          } else {
+            assignValue(nested, key, newValue);
+          }
         }
         nested = nested[key];
       }

--- a/test/test.js
+++ b/test/test.js
@@ -13608,6 +13608,17 @@
         }
       });
     });
+
+    test('`_.' + methodName + '` should delete the key if the value is undefined', 4, function() {
+      var object = { 'a': 1 };
+
+      _.each(['a', ['a']], function(path) {
+        var actual = func(object, path, undefined);
+        strictEqual(actual, object);
+        strictEqual("a" in object, false);
+        object.a = 1;
+      });
+    });
   });
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
The `_.set` and `_.get` (or `_.result`) works very well to "eval" some expressions. With this PR, it's possible to delete some keys: just set them to `undefined`