### PR TITLE
WIP - #1370 Add support for negative indices

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1978,10 +1978,16 @@
       path = isKey(path, object) ? [path + ''] : toPath(path);
 
       var index = 0,
+          part,
           length = path.length;
 
       while (object != null && index < length) {
-        object = object[path[index++]];
+        part = path[index++];
+        if (isArrayLike(object) && /^-\d+$/.test(part)) {
+          part = object.length + (+part);
+        }
+
+        object = object[part];
       }
       return (index && index == length) ? object : undefined;
     }
@@ -9381,13 +9387,13 @@
      */
     function result(object, path, defaultValue) {
       var isPath = !isKey(path, object),
-          result = (isPath || object == null) ? undefined : object[path];
+          result = (isPath || object == null) ? undefined : baseGet(object, [path]);
 
       if (result === undefined) {
         if (object != null && isPath) {
           path = toPath(path);
           object = path.length == 1 ? object : baseGet(object, baseSlice(path, 0, -1));
-          result = object == null ? undefined : object[last(path)];
+          result = object == null ? undefined : baseGet(object,[last(path)]);
         }
         result = result === undefined ? defaultValue : result;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -1031,6 +1031,11 @@
     var args = arguments,
         array = ['a', 'b', 'c'];
 
+    test('should find elements in reverse order with negative keys', 1, function() {
+      var actual = _.at(array, -1);
+      deepEqual(actual, ['c']);
+    });
+
     test('should return the elements corresponding to the specified keys', 1, function() {
       var actual = _.at(array, [0, 2]);
       deepEqual(actual, ['a', 'c']);
@@ -12924,6 +12929,14 @@
 
       _.each(['a', ['a']], function(path) {
         strictEqual(func(object, path), 1);
+      });
+    });
+
+    test('`_.' + methodName + '` should get negative indices', 2, function() {
+      var array = ['a','b','c']
+
+      _.each([-1, -2], function(path) {
+        strictEqual(func(array, path), array[array.length + path]);
       });
     });
 


### PR DESCRIPTION
This is a POC implementation for supporting negative indices. There are several performance regressions and shortcuts.

Negative indices are a common pattern that make it easy for developers to get the last, 2nd-last, value in an array.

The way the implementation was added, it'd have far reaching implications.

```js
_.result(['a','b','c'], -3) //=> 'a'
_.get(['a','b','c'], -2) //=> 'b'
_.at(['a','b','c'], -1) //=> ['c']
```

It's also possible to support a path push notation where `a[-0]` could indicate the array location after the last location. This was brought up by #1315.

```js
_.set({ a: [1] }, 'a[-0]', 2) //=> { a: [1, 2] }
```

@jridgewell and I paired on this.