### PR TITLE
The underscore(1.8.3) has method _.all which is  _.every 's alias,but not in lodash

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -11508,6 +11508,7 @@
     lodash.escape = escape;
     lodash.escapeRegExp = escapeRegExp;
     lodash.every = every;
+    lodash.all = every;
     lodash.find = find;
     lodash.findIndex = findIndex;
     lodash.findKey = findKey;


### PR DESCRIPTION
i try to use lodash.js to replace underscore.js
but throw a error , _.all is undefined
http://devdocs.io/lodash/index#every
The doc of lodash said lodash has all too ,but i cant find in code
so i add the _.all method  .
just direct to every