### PR TITLE
Add ES2015 compliant lodash(..).next() iterator

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1492,6 +1492,8 @@
       this.__wrapped__ = value;
       this.__actions__ = actions || [];
       this.__chain__ = !!chainAll;
+      this.__value__ = null;
+      this.__index__ = 0;
     }
 
     /**
@@ -5866,6 +5868,42 @@
         return arrayConcat(isArray(array) ? array : [Object(array)], values);
       });
     });
+
+    /**
+     * Gets the next value on a wrapped object in ES2015 iterator
+     * format (<link>). Useful for `for..of` loops and using with
+     * some ES2015 features.
+     *
+     * @name next
+     * @memberOf _
+     * @category Chain
+     * @returns {*} Returns the next value.
+     * @example
+     *
+     * var array = [1, 2];
+     * var wrapped = _(array);
+     *
+     * console.log(wrapped.next());
+     * // => {done: false, value: 1}
+     *
+     * console.log(wrapped.next());
+     * // => {done: false, value: 2}
+     *
+     * console.log(wrapped.next());
+     * // => {done: true, value: undefined}
+     *
+     * var array = [1, 2];
+     * var wrapped = _(array);
+     *
+     * // Use with an ES6 methods which accept an iterable
+     * console.log(Array.from(wrapped))
+     * // => [1, 2]
+     */
+    function wrapperNext() {
+      if (this.__value__ == null) this.__value__ = this.value();
+      var done = this.__index__ >= this.__value__.length;
+      return {done: done, value: done ? undefined : this.__value__[this.__index__++]};
+    }
 
     /**
      * Creates a clone of the chained sequence planting `value` as the wrapped value.
@@ -11958,6 +11996,7 @@
     lodash.prototype.chain = wrapperChain;
     lodash.prototype.commit = wrapperCommit;
     lodash.prototype.concat = wrapperConcat;
+    lodash.prototype.next = wrapperNext;
     lodash.prototype.plant = wrapperPlant;
     lodash.prototype.reverse = wrapperReverse;
     lodash.prototype.toString = wrapperToString;

--- a/test/test.js
+++ b/test/test.js
@@ -16580,6 +16580,85 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash(...).next');
+
+  _.each([true, false], function(implict) {
+    function arrayFrom(iter) {
+      var item;
+      var result = [];
+      while (!(item = iter.next()).done) {
+        result.push(item.value);
+      }
+      return result;
+    }
+
+    function chain(obj) {
+      return implict ? _(obj) : _.chain(obj);
+    }
+
+    var chainType = ' in an ' + (implict ? 'implict' : 'explict') + ' chain';
+
+    test('should produce an ES6 compliant object' + chainType, 7, function() {
+      var array = [0, 1, 1, 2, 3],
+          chained = chain(array);
+
+      deepEqual(chained.next(), {done: false, value: 0});
+      deepEqual(chained.next(), {done: false, value: 1});
+      deepEqual(chained.next(), {done: false, value: 1});
+      deepEqual(chained.next(), {done: false, value: 2});
+      deepEqual(chained.next(), {done: false, value: 3});
+      deepEqual(chained.next(), {done: true, value: undefined});
+      deepEqual(chained.next(), {done: true, value: undefined});
+    });
+
+    test('should make a lodash instance act as an iterable' + chainType, 1, function() {
+      var array = [0, 1, 1, 2, 3, 5, 8, 13, 21],
+          chained = chain(array);
+
+      deepEqual(arrayFrom(chained), array);
+    });
+
+    test('should reset the iterator upon forking (adding an action to the chain)' + chainType, 5, function() {
+      var array = [0, 1, 1, 2, 3, 5, 8, 13, 21],
+          chained = chain(array);
+
+      deepEqual(arrayFrom(chained), array);
+      // before reset produces empty array as iterator is exhausted
+      deepEqual(arrayFrom(chained), []);
+
+      var newChain = chained.filter(_.constant(true));
+      deepEqual(arrayFrom(newChain), array);
+
+      // original chain is still exhausted
+      deepEqual(arrayFrom(chained), []);
+
+      newChain = chained.slice();
+      deepEqual(arrayFrom(newChain), array);
+    });
+
+    test('should work in a lazy sequence' + chainType, 3, function() {
+      if (true) {
+        var array = _.range(1, LARGE_ARRAY_SIZE + 1),
+            values = [],
+            predicate = function(value) { values.push(value); return value > 99; },
+            chained = chain(array);
+
+        deepEqual(arrayFrom(chained), array);
+
+        // resets index & supports lazy array
+        chained = chained.filter(predicate);
+        deepEqual(arrayFrom(chained), array.slice(99));
+        // Doesn't recompute everything each time
+        deepEqual(values, array);
+      }
+      else {
+        skipTest(3);
+      }
+    });
+  });
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash(...).plant');
 
   (function() {


### PR DESCRIPTION
As previously discussed this adds the opportunity for users to use a lodash instance in a `for...of` loop or in any native/non-native JS interface which accepts an iterator.

Further, as we've discussed, I'd like to see this as a stepping stone to implementing lodash chains through iterators (https://github.com/megawac/lodash/commit/22e7beb36382dab224ea091cdcd0f9218039d1bc#commitcomment-12960941)