### PR TITLE
Addition of jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -33,7 +33,7 @@
     "disallowTrailingWhitespace": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowMultipleVarDecl": false,
-    "disallowKeywordsOnNewLine": ["else"],
+    "disallowKeywordsOnNewLine": false,
 
     "requireSpaceAfterKeywords": [
       "if",

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,88 @@
+{
+    "maxErrors": "2000",
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ],
+    "requireOperatorBeforeLineBreak": [
+        "=",
+        "+",
+        "-",
+        "/",
+        "*",
+        "==",
+        "===",
+        "!=",
+        "!==",
+        ">",
+        ">=",
+        "<",
+        "<="
+    ],
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "maximumLineLength": false,
+    "validateIndentation": 2,
+
+    "disallowMultipleLineStrings": true,
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowMultipleVarDecl": false,
+    "disallowKeywordsOnNewLine": ["else"],
+
+    "requireSpaceAfterKeywords": [
+      "if",
+      "else",
+      "for",
+      "while",
+      "do",
+      "switch",
+      "return",
+      "try",
+      "catch"
+    ],
+    "requireSpaceBeforeBinaryOperators": [
+        "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+        "&=", "|=", "^=", "+=",
+
+        "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+        "|", "^", "&&", "||", "===", "==", ">=",
+        "<=", "<", ">", "!=", "!=="
+    ],
+    "requireSpaceAfterBinaryOperators": true,
+    "requireSpacesInConditionalExpression": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "requireSpacesInForStatement": true,
+    "requireLineFeedAtFileEnd": true,
+    "requireSpacesInFunctionExpression": {
+        "beforeOpeningCurlyBrace": true
+    },
+    "disallowSpacesInAnonymousFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInsideObjectBrackets": false,
+    "disallowSpacesInsideArrayBrackets": "all",
+    "disallowSpacesInsideParentheses": true,
+
+    "disallowMultipleLineBreaks": true,
+    "disallowNewlineBeforeBlockStatements": true,
+    "disallowKeywords": ["with"],
+    "disallowSpacesInFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInCallExpression": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "requireSpaceBeforeObjectValues": true,
+    "requireCapitalizedConstructors": false,
+    "requireDotNotation": false,
+    "requireSemicolons": true,
+    "validateParameterSeparator": ", "
+}

--- a/lodash.js
+++ b/lodash.js
@@ -1913,7 +1913,7 @@
       return function(prototype) {
         if (isObject(prototype)) {
           object.prototype = prototype;
-          var result = new Object;
+          var result = new object;
           object.prototype = undefined;
         }
         return result || {};

--- a/lodash.js
+++ b/lodash.js
@@ -1976,7 +1976,8 @@
             }
           }
           result.push(value);
-        } else if (indexOf(values, value, 0) < 0) {
+        }
+        else if (indexOf(values, value, 0) < 0) {
           result.push(value);
         }
       }
@@ -2520,7 +2521,8 @@
           stackA || (stackA = []);
           stackB || (stackB = []);
           baseMergeDeep(object, source, key, baseMerge, customizer, stackA, stackB);
-        } else {
+        }
+        else {
           var newValue = customizer ? customizer(object[key], srcValue, (key + ''), object, source, stackA, stackB) : undefined;
           if (newValue === undefined) {
             newValue = srcValue;
@@ -2565,11 +2567,13 @@
           newValue = isArray(oldValue)
             ? oldValue
             : ((isObject(oldValue) && isArrayLike(oldValue)) ? copyArray(oldValue) : []);
-        } else if (isPlainObject(srcValue) || isArguments(srcValue)) {
+        }
+        else if (isPlainObject(srcValue) || isArguments(srcValue)) {
           newValue = isArguments(oldValue)
             ? toPlainObject(oldValue)
             : (isObject(oldValue) ? oldValue : {});
-        } else {
+        }
+        else {
           isCommon = isFunction(srcValue);
         }
       }
@@ -2667,14 +2671,16 @@
           var previous = index;
           if (isIndex(index)) {
             splice.call(array, index, 1);
-          } else if (!isKey(index, array)) {
+          }
+          else if (!isKey(index, array)) {
             var path = toPath(index),
                 object = parent(array, path);
 
             if (object != null) {
               delete object[last(path)];
             }
-          } else {
+          }
+          else {
             delete array[index];
           }
         }
@@ -2865,7 +2871,8 @@
             seen = computed;
             result[++resIndex] = value;
           }
-        } else if (indexOf(seen, computed, 0) < 0) {
+        }
+        else if (indexOf(seen, computed, 0) < 0) {
           seen[++resIndex] = computed;
           result[resIndex] = value;
         }
@@ -7326,7 +7333,8 @@
         }
         if (isCalled && timeoutId) {
           timeoutId = clearTimeout(timeoutId);
-        } else if (!timeoutId && wait !== maxWait) {
+        }
+        else if (!timeoutId && wait !== maxWait) {
           timeoutId = setTimeout(delayed, wait);
         }
         if (leadingCall) {
@@ -9308,7 +9316,8 @@
           } else {
             result[value] = [key];
           }
-        } else {
+        }
+        else {
           result[value] = key;
         }
         return result;
@@ -9933,7 +9942,8 @@
         if (noMax && typeof min == 'boolean') {
           floating = min;
           min = 1;
-        } else if (typeof max == 'boolean') {
+        }
+        else if (typeof max == 'boolean') {
           floating = max;
           noMax = true;
         }
@@ -12055,11 +12065,13 @@
     // Export for Node.js or RingoJS.
     if (moduleExports) {
       (freeModule.exports = _)._ = _;
-    } else {
+    }
+    else {
       // Export for Rhino with CommonJS support.
       freeExports._ = _;
     }
-  } else {
+  }
+  else {
     // Export for a browser or Rhino.
     root._ = _;
   }

--- a/lodash.js
+++ b/lodash.js
@@ -757,7 +757,7 @@
    * @returns {Array} Returns the array of results.
    */
   function baseTimes(n, iteratee) {
-     var index = -1,
+    var index = -1,
          result = Array(n);
 
     while (++index < n) {
@@ -1072,7 +1072,7 @@
     if (value != null && typeof value.toString != 'function') {
       try {
         result = !!(value + '');
-      } catch(e) {}
+      } catch (e) {}
     }
     return result;
   }
@@ -1824,7 +1824,7 @@
           length = paths.length,
           result = Array(length);
 
-      while(++index < length) {
+      while (++index < length) {
         result[index] = isNil ? undefined : get(object, paths[index]);
       }
       return result;
@@ -1913,7 +1913,7 @@
       return function(prototype) {
         if (isObject(prototype)) {
           object.prototype = prototype;
-          var result = new object;
+          var result = new Object;
           object.prototype = undefined;
         }
         return result || {};
@@ -1976,8 +1976,7 @@
             }
           }
           result.push(value);
-        }
-        else if (indexOf(values, value, 0) < 0) {
+        } else if (indexOf(values, value, 0) < 0) {
           result.push(value);
         }
       }
@@ -2521,8 +2520,7 @@
           stackA || (stackA = []);
           stackB || (stackB = []);
           baseMergeDeep(object, source, key, baseMerge, customizer, stackA, stackB);
-        }
-        else {
+        } else {
           var newValue = customizer ? customizer(object[key], srcValue, (key + ''), object, source, stackA, stackB) : undefined;
           if (newValue === undefined) {
             newValue = srcValue;
@@ -2567,13 +2565,11 @@
           newValue = isArray(oldValue)
             ? oldValue
             : ((isObject(oldValue) && isArrayLike(oldValue)) ? copyArray(oldValue) : []);
-        }
-        else if (isPlainObject(srcValue) || isArguments(srcValue)) {
+        } else if (isPlainObject(srcValue) || isArguments(srcValue)) {
           newValue = isArguments(oldValue)
             ? toPlainObject(oldValue)
             : (isObject(oldValue) ? oldValue : {});
-        }
-        else {
+        } else {
           isCommon = isFunction(srcValue);
         }
       }
@@ -2671,16 +2667,14 @@
           var previous = index;
           if (isIndex(index)) {
             splice.call(array, index, 1);
-          }
-          else if (!isKey(index, array)) {
+          } else if (!isKey(index, array)) {
             var path = toPath(index),
                 object = parent(array, path);
 
             if (object != null) {
               delete object[last(path)];
             }
-          }
-          else {
+          } else {
             delete array[index];
           }
         }
@@ -2871,8 +2865,7 @@
             seen = computed;
             result[++resIndex] = value;
           }
-        }
-        else if (indexOf(seen, computed, 0) < 0) {
+        } else if (indexOf(seen, computed, 0) < 0) {
           seen[++resIndex] = computed;
           result[resIndex] = value;
         }
@@ -2932,8 +2925,7 @@
             seen.push(computed);
           }
           result.push(value);
-        }
-        else if (indexOf(seen, computed, 0) < 0) {
+        } else if (indexOf(seen, computed, 0) < 0) {
           if (iteratee || isLarge) {
             seen.push(computed);
           }
@@ -7328,15 +7320,13 @@
             }
             lastCalled = stamp;
             result = func.apply(thisArg, args);
-          }
-          else if (!maxTimeoutId) {
+          } else if (!maxTimeoutId) {
             maxTimeoutId = setTimeout(maxDelayed, remaining);
           }
         }
         if (isCalled && timeoutId) {
           timeoutId = clearTimeout(timeoutId);
-        }
-        else if (!timeoutId && wait !== maxWait) {
+        } else if (!timeoutId && wait !== maxWait) {
           timeoutId = setTimeout(delayed, wait);
         }
         if (leadingCall) {
@@ -9318,8 +9308,7 @@
           } else {
             result[value] = [key];
           }
-        }
-        else {
+        } else {
           result[value] = key;
         }
         return result;
@@ -9944,8 +9933,7 @@
         if (noMax && typeof min == 'boolean') {
           floating = min;
           min = 1;
-        }
-        else if (typeof max == 'boolean') {
+        } else if (typeof max == 'boolean') {
           floating = max;
           noMax = true;
         }
@@ -10842,7 +10830,7 @@
     var attempt = restParam(function(func, args) {
       try {
         return func.apply(undefined, args);
-      } catch(e) {
+      } catch (e) {
         return isError(e) ? e : new Error(e);
       }
     });
@@ -12067,13 +12055,11 @@
     // Export for Node.js or RingoJS.
     if (moduleExports) {
       (freeModule.exports = _)._ = _;
-    }
-    // Export for Rhino with CommonJS support.
-    else {
+    } else {
+      // Export for Rhino with CommonJS support.
       freeExports._ = _;
     }
-  }
-  else {
+  } else {
     // Export for a browser or Rhino.
     root._ = _;
   }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "curl-amd": "0.8.12",
     "dojo": "~1.10.0",
     "jquery": "~1.11.0",
+    "jscs": "^2.1.1",
     "platform": "~1.3.0",
     "qunit-extras": "~1.4.0",
     "qunitjs": "~1.18.0",
     "requirejs": "~2.1.0"
   },
-  "scripts": { "test": "node test/test" },
+  "scripts": {
+    "test": "node test/test",
+    "lint": "jscs lodash.js"
+  },
   "volo": {
     "type": "directory",
     "ignore": [


### PR DESCRIPTION
Added JSCS to the project (http://jscs.info/)  Initially imported the google code style preset (https://github.com/jscs-dev/node-jscs/blob/master/presets/google.json) and modified to suite the current code style.  This should enforce such gems as the automation of tabs equating to 2 spaces, missing semi-colons, curly braces enforment etc.

To automate or run manually one can execute "npm run lint"
