### PR TITLE
Clarify `_.merge` description.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9708,9 +9708,11 @@
     }
 
     /**
-     * Recursively merges own enumerable properties of the source object(s) into the
-     * destination object, for source properties which don't resolve to `undefined`.
-     * Subsequent sources overwrite property assignments of previous sources.
+     * Recursively merges own enumerable properties of the source object(s) into
+     * the destination object, skipping source properties that resolve to
+     * `undefined`. Plain object properties are merged recursively. Other
+     * objects and value types are overriden by assignment. Subsequent sources
+     * overwrite property assignments of previous sources.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
Mention behaviour difference between merging plain objects and objects with non-Object prototypes. As discussed in #1455.