### PR TITLE
Add `_.isJSON` function

### DIFF
--- a/lodash.core.js
+++ b/lodash.core.js
@@ -537,7 +537,7 @@
    * `findLastIndex`, `findLastKey`, `first`, `floor`, `get`, `gt`, `gte`,
    * `has`, `hasIn`, `identity`, `includes`, `indexOf`, `inRange`, `isArguments`,
    * `isArray`, `isArrayLike`, `isBoolean`, `isDate`, `isElement`, `isEmpty`,
-   * `isEqual`, `isEqualWith`, `isError`, `isFinite` `isFunction`, `isMatch`,
+   * `isEqual`, `isEqualWith`, `isError`, `isFinite` `isFunction`, `isJSON`, `isMatch`,
    * `isMatchWith`, `isNaN`, `isNative`, `isNil`, `isNull`, `isNumber`, `isObject`,
    * `isObjectLike`, `isPlainObject`, `isRegExp`, `isString`, `isUndefined`,
    * `isTypedArray`, `join`, `kebabCase`, `last`, `lastIndexOf`, `lt`, `lte`,

--- a/lodash.js
+++ b/lodash.js
@@ -1435,7 +1435,7 @@
      * `findLastIndex`, `findLastKey`, `first`, `floor`, `get`, `gt`, `gte`,
      * `has`, `hasIn`, `identity`, `includes`, `indexOf`, `inRange`, `isArguments`,
      * `isArray`, `isArrayLike`, `isBoolean`, `isDate`, `isElement`, `isEmpty`,
-     * `isEqual`, `isEqualWith`, `isError`, `isFinite` `isFunction`, `isInteger`,
+     * `isEqual`, `isEqualWith`, `isError`, `isFinite` `isFunction`, `isInteger`, `isJSON`,
      * `isMatch`, `isMatchWith`, `isNaN`, `isNative`, `isNil`, `isNull`, `isNumber`,
      * `isObject`, `isObjectLike`, `isPlainObject`, `isRegExp`, `isSafeInteger`,
      * `isString`, `isUndefined`, `isTypedArray`, `join`, `kebabCase`, `last`,
@@ -8579,6 +8579,38 @@
     }
 
     /**
+     * Checks if `value` is a valid JSON string.
+     *
+     * @static
+     * @memberOf _
+     * @category Lang
+     * @param {*} value The value to check.
+     * @returns {boolean} Returns `true` if `value` is a valid JSON string, else `false`.
+     * @example
+     *
+     * _.isJSON('"foo"');
+     * // => true
+     *
+     * _.isJSON('{"foo": "bar"}');
+     * // => true
+     *
+     * _.isJSON(42);
+     * // => false
+     *
+     * _.isJSON([1, 2, 3]);
+     * // => false
+     */
+    function isJSON(value) {
+      if (!isString(value)) return false;
+      try {
+        JSON.parse(value);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+
+    /**
      * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
      * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
      *
@@ -12170,6 +12202,7 @@
     lodash.isFinite = isFinite;
     lodash.isFunction = isFunction;
     lodash.isInteger = isInteger;
+    lodash.isJSON = isJSON;
     lodash.isMatch = isMatch;
     lodash.isMatchWith = isMatchWith;
     lodash.isNaN = isNaN;

--- a/test/test.js
+++ b/test/test.js
@@ -8490,6 +8490,55 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.isJSON');
+
+  (function() {
+    QUnit.test('should return `false` for non-string values', function(assert) {
+      var values = [ undefined, null, '', 42, 3.14, [], [1,2], {}, {foo:'bar'}, true ];
+      assert.expect(values.length);
+
+      _.each(values, function(value) {
+        assert.strictEqual(_.isJSON(value), false, '' + value);
+      });
+    });
+    QUnit.test('should return `false` for invalid JSON', function(assert) {
+      var values = [
+        '',
+        'undefined',
+        'foo',
+        '[',
+        '{foo: "bar"}',
+        '"foo',
+        '{'
+      ];
+      assert.expect(values.length);
+
+      _.each(values, function(value) {
+        assert.strictEqual(_.isJSON(value), false, value);
+      });
+    });
+    QUnit.test('should return `true` for valid JSON', function(assert) {
+      var values = [
+        'null',
+        '42',
+        '3.14',
+        '[]',
+        '{}',
+        '[1,2,3]',
+        '"foo"',
+        '{"foo": "bar"}',
+        'false'
+      ];
+      assert.expect(values.length);
+
+      _.each(values, function(value) {
+        assert.strictEqual(_.isJSON(value), true, value);
+      });
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.isMatch');
 
   (function() {
@@ -20625,6 +20674,7 @@
       'isFinite',
       'isFunction',
       'isInteger',
+      'isJSON',
       'isNaN',
       'isNative',
       'isNil',
@@ -20889,7 +20939,7 @@
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(235);
+      assert.expect(236);
 
       var emptyArrays = _.map(falsey, _.constant([]));
 


### PR DESCRIPTION
Here's an `_.isJSON` function to help clean up code that would otherwise be littered with `try { JSON.parse(...); } catch (e) { }`.

I'm pretty sure that the performance of this function could be improved, but this is a simple first cut.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>