### PR TITLE
Add `_.consists`.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6264,7 +6264,7 @@
     /*------------------------------------------------------------------------*/
 
     /**
-     * Tests if the members of two or more collections are equal. Uses
+     * Tests if two or more collections have the same members. Uses
      * [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero).
      *
      * @static

--- a/lodash.js
+++ b/lodash.js
@@ -1447,16 +1447,16 @@
      *
      * The wrapper methods that are **not** chainable by default are:
      * `add`, `attempt`, `camelCase`, `capitalize`, `ceil`, `clone`, `cloneDeep`,
-     * `cloneDeepWith`, `cloneWith`, `deburr`, `endsWith`, `eq`, `escape`,
-     * `escapeRegExp`, `every`, `find`, `findIndex`, `findKey`, `findLast`,
-     * `findLastIndex`, `findLastKey`, `first`, `floor`, `get`, `gt`, `gte`,
-     * `has`, `hasIn`, `identity`, `includes`, `indexOf`, `inRange`, `isArguments`,
-     * `isArray`, `isArrayLike`, `isBoolean`, `isDate`, `isElement`, `isEmpty`,
-     * `isEqual`, `isEqualWith`, `isError`, `isFinite` `isFunction`, `isInteger`,
-     * `isMatch`, `isMatchWith`, `isNaN`, `isNative`, `isNil`, `isNull`, `isNumber`,
-     * `isObject`, `isObjectLike`, `isPlainObject`, `isRegExp`, `isSafeInteger`,
-     * `isString`, `isUndefined`, `isTypedArray`, `join`, `kebabCase`, `last`,
-     * `lastIndexOf`, `lt`, `lte`, `max`, `min`, `noConflict`, `noop`, `now`,
+     * `cloneDeepWith`, `cloneWith`, `consists`, `deburr`, `endsWith`, `eq`,
+     * `escape`, `escapeRegExp`, `every`, `find`, `findIndex`, `findKey`,
+     * `findLast`, `findLastIndex`, `findLastKey`, `first`, `floor`, `get`, `gt`,
+     * `gte`, `has`, `hasIn`, `identity`, `includes`, `indexOf`, `inRange`,
+     * `isArguments`, `isArray`, `isArrayLike`, `isBoolean`, `isDate`, `isElement`,
+     * `isEmpty`, `isEqual`, `isEqualWith`, `isError`, `isFinite` `isFunction`,
+     * `isInteger`, `isMatch`, `isMatchWith`, `isNaN`, `isNative`, `isNil`, `isNull`,
+     * `isNumber`, `isObject`, `isObjectLike`, `isPlainObject`, `isRegExp`,
+     * `isSafeInteger`, `isString`, `isUndefined`, `isTypedArray`, `join`, `kebabCase`,
+     * `last`, `lastIndexOf`, `lt`, `lte`, `max`, `min`, `noConflict`, `noop`, `now`,
      * `pad`, `padLeft`, `padRight`, `parseInt`, `pop`, `random`, `reduce`,
      * `reduceRight`, `repeat`, `result`, `round`, `runInContext`, `shift`, `size`,
      * `snakeCase`, `some`, `sortedIndex`, `sortedIndexBy`, `sortedLastIndex`,
@@ -1952,6 +1952,39 @@
         return result || {};
       };
     }());
+
+    /**
+     * The base implementation of `_.consists`.
+     *
+     * @private
+     * @param {Array} collections The collections to compare.
+     * @returns {boolean} Returns `true` if all collections contain the same members, else `false`.
+     */
+    function baseConsists(collections) {
+      collections = map(collections, function(collection) {
+        return isArray(collection) ? collection : values(collection);
+      });
+
+      var value,
+          firstCollection = first(collections),
+          others = rest(collections),
+          length = firstCollection.length,
+          lengthsEqual = every(others, function(other) { return length === other.length; });
+
+      if (!lengthsEqual) { return false; }
+
+      while (length > 0) {
+        firstCollection = without(firstCollection, value = first(firstCollection));
+        length = firstCollection.length;
+
+        lengthsEqual = every(others, function(other, index) {
+          return length === (others[index] = without(other, value)).length;
+        });
+
+        if (!lengthsEqual) { return false; }
+      }
+      return true;
+    }
 
     /**
      * The base implementation of `_.delay` and `_.defer` which accepts an array
@@ -6229,6 +6262,44 @@
     }
 
     /*------------------------------------------------------------------------*/
+
+    /**
+     * Tests if the members of two or more collections are equal. Uses
+     * [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero).
+     *
+     * @static
+     * @memberOf _
+     * @category Collection
+     * @param {...(Array|Object)} collections The collections to compare.
+     * @returns {boolean} Returns `true` if all collections contain the same members, else `false`.
+     * @example
+     *
+     * _.consists([1,1,2,3], [3,1,2,1], [2,1,3,1]);
+     * // => true
+     *
+     * _.consists([1,1,2,3], [3,1,2]);
+     * // => false
+     *
+     * _.consists('hello', 'loleh', ['o','l','l','e','h'], { a:'l', b:'h', c:'e', d:'o', e:'l' });
+     * // => true
+     *
+     * var a = { a: 'a' };
+     * var b = { b: 'b' };
+     * var b2 = { b: 'b' };
+     *
+     * _.consists([a, a, b], [b, a, a]);
+     * // => true
+     *
+     * _.consists([a, b, b], [a, b, b2]);
+     * // => false
+     *
+     */
+    var consists = restParam(function(collections) {
+      return !collections.length ? true :
+        collections.length === 1 ? false :
+        !every(collections, function(collection) { return isObject(collection) || isArrayLike(collection); }) ? false :
+        baseConsists(collections);
+    });
 
     /**
      * Creates an object composed of keys generated from the results of running
@@ -12235,6 +12306,7 @@
     lodash.cloneDeep = cloneDeep;
     lodash.cloneDeepWith = cloneDeepWith;
     lodash.cloneWith = cloneWith;
+    lodash.consists = consists;
     lodash.deburr = deburr;
     lodash.endsWith = endsWith;
     lodash.eq = eq;

--- a/test/test.js
+++ b/test/test.js
@@ -2449,6 +2449,118 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.consists');
+
+  (function() {
+    
+    var consists = _.consists,
+        a = { a: 'a' },
+        b = { a: 'a' },
+        c = ['a','b'],
+        d = function () {},
+        e = function () {},
+        f = new Date(),
+        g = [],
+        h = [];
+
+    QUnit.test('should return `true` for no arguments', function(assert) {
+      assert.expect(1);
+      assert.ok(consists());
+    });
+
+    QUnit.test('should return `false` for one argument', function(assert) {
+      assert.expect(4);
+      assert.notOk(consists(1));
+      assert.notOk(consists('asdf'));
+      assert.notOk(consists([1]));
+      assert.notOk(consists({a:'a'}));
+    });
+
+    QUnit.test('should return `true` for empty collections', function(assert) {
+      assert.expect(3);
+      assert.ok(consists([], []));
+      assert.ok(consists({}, {}));
+      assert.ok(consists('', ''));
+    });
+
+    QUnit.test('should work on arrays', function(assert) {
+      assert.expect(2);
+      assert.ok(consists([1,2,3], [3,1,2]));
+      assert.notOk(consists([1,2,3], [1,2,4]));
+    });
+
+    QUnit.test('should work on strings', function(assert) {
+      assert.expect(2);
+      assert.ok(consists('abc', 'cab'));
+      assert.notOk(consists('abc', 'abcd'));
+    });
+
+    QUnit.test('should work on objects', function(assert) {
+      assert.expect(2);
+      assert.ok(consists({ a: 1, b: 2, c: 3 }, { b: 3, a: 2, c: 1 }));
+      assert.notOk(consists({ a: 1, b: 2, c: 3, d: 4 }, { b: 3, a: 2, c: 1, d: 1 }));
+    });
+
+    QUnit.test('should return `true` equivalent collections with primitives', function(assert) {
+      assert.expect(3);
+      assert.ok(consists([1,1,2,3], [3,1,2,1], [2,1,3,1]));
+      assert.ok(consists(['a','a','b','c'], ['b','a','a','c']));
+      assert.ok(consists(
+        [true,'a',false,'c',0,true, undefined,0,-0,NaN,'a',1,2,-1,false],
+        [0,2,undefined,true,-1,0,NaN,'a',1,-0,false,true,false,'c','a']
+      ));
+    });
+
+    QUnit.test('should return `false` inequivalent collections with primitives', function(assert) {
+      assert.expect(3);
+      assert.notOk(consists([1,1,2,3], [1,2,3,3]));
+      assert.notOk(consists(['a','a','b','c'], ['a','b','c']));
+      assert.notOk(consists(
+        [true,'a',undefined,false,'c',0,true,0,-0,NaN,'a',1,2,-1,false],
+        [0,2,true,-1,0,NaN,'a',1,-0,false,false,'c','a',undefined]
+      ));
+    });
+
+    QUnit.test('should return `true` equivalent collections with non-primitives', function(assert) {
+      assert.expect(3);
+      assert.ok(consists([a,b,c,d,e,f,g,h], [h,a,g,c,b,f,e,d]));
+      assert.ok(consists([a,a,b], [a,b,a]));
+      assert.ok(consists([a,h,h], [h,a,h]));
+    });
+
+    QUnit.test('should return `false` inequivalent collections with non-primitives', function(assert) {
+      assert.expect(3);
+      assert.notOk(consists([a,a,b,c,d,e,f,g,h], [h,a,g,c,b,b,f,e,d]));
+      assert.notOk(consists([d,e], [d,d]));
+      assert.notOk(consists([g,h], [g,g]));
+    });
+
+    QUnit.test('should return an unwrapped value when implicitly chaining', function(assert) {
+      assert.expect(1);
+
+      if (!isNpm) {
+        assert.strictEqual(_([1,2,3]).consists([3,1,2]), true);
+      }
+      else {
+        skipTest(assert);
+      }
+    });
+
+    QUnit.test('should return a wrapped value when explicitly chaining', function(assert) {
+      assert.expect(1);
+
+      if (!isNpm) {
+        assert.ok(_([1,2,3]).chain().consists([3,1,2]) instanceof _);
+      }
+      else {
+        skipTest(assert);
+      }
+    });
+
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.constant');
 
   (function() {
@@ -20950,7 +21062,7 @@
     var acceptFalsey = _.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(240);
+      assert.expect(241);
 
       var emptyArrays = _.map(falsey, _.constant([]));
 


### PR DESCRIPTION
Hello!

I often find myself using this mixin to test if collections consist of the same members:

```javascript
_.consists([1,1,2,3], [3,1,2,1]);
// => true

_.consists([1,1,2,3], [3,1,2]);
// => false

_.consists('hello', ['o','l','l','e','h'], { a:'l', b:'h', c:'e', d:'o', e:'l' });
// => true
```

The common use case is to simply test if two arrays are equivalent ignoring order.  I've yet to find a terse way accomplish this using any combination of existing methods like `_.difference`, `_.intersection`, or `_.union` while handling:
 - collections with duplicate values
 - collections with non-primitive values

A couple more examples:

```javascript
var a = { a: 'a' };
var b = { b: 'b' };
var b2 = { b: 'b' };

_.consists([a, b, b], [b, a, b]);
// => true

_.consists([a, b, b], [a, b, b2]);
// => false
```

Not sure if there's interest in this, but thought I'd share it nonetheless.

[Here's a more real-world example of how `consists` might be useful.](https://gist.github.com/jshanson7/98083803bddd66d21a90)