### PR TITLE
Ensure capitalization works for all-caps text

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -10504,6 +10504,7 @@
       if (!string) {
         return string;
       }
+      string = string.toLowerCase();
       if (reAdvSymbol.test(string)) {
         var strSymbols = stringToArray(string);
         return strSymbols[0].toUpperCase() + strSymbols.slice(1).join('');


### PR DESCRIPTION
.startCase() does not give the expected result with all caps input:

```
_.startCase("TEST"); // TEST, expected Test
```

Technically you could do the same conversion to your input in the call, but considering this is so computationally minimal and the result now aligns with all other inputs ... figured it was valuable.