### PR TITLE
perf.js: changed references to `{lodash,_}`.`include` to `includes`

### DIFF
--- a/perf/perf.js
+++ b/perf/perf.js
@@ -1086,31 +1086,31 @@
   suites.push(
     Benchmark.Suite('`_.includes` searching an array')
       .add(buildName, '\
-        lodash.include(numbers, limit - 1)'
+        lodash.includes(numbers, limit - 1)'
       )
       .add(otherName, '\
-        _.include(numbers, limit - 1)'
+        _.includes(numbers, limit - 1)'
       )
   );
 
   suites.push(
     Benchmark.Suite('`_.includes` searching an object')
       .add(buildName, '\
-        lodash.include(object, limit - 1)'
+        lodash.includes(object, limit - 1)'
       )
       .add(otherName, '\
-        _.include(object, limit - 1)'
+        _.includes(object, limit - 1)'
       )
   );
 
-  if (lodash.include('ab', 'ab') && _.include('ab', 'ab')) {
+  if (lodash.includes('ab', 'ab') && _.includes('ab', 'ab')) {
     suites.push(
       Benchmark.Suite('`_.includes` searching a string')
         .add(buildName, '\
-          lodash.include(strNumbers, "," + (limit - 1))'
+          lodash.includes(strNumbers, "," + (limit - 1))'
         )
         .add(otherName, '\
-          _.include(strNumbers, "," + (limit - 1))'
+          _.includes(strNumbers, "," + (limit - 1))'
         )
     );
   }


### PR DESCRIPTION
```
lodash/perf $ ack '_\.include'
perf.js
1087:    Benchmark.Suite('`_.includes` searching an array')
1092:        _.include(numbers, limit - 1)'
1097:    Benchmark.Suite('`_.includes` searching an object')
1102:        _.include(object, limit - 1)'
1106:  if (lodash.include('ab', 'ab') && _.include('ab', 'ab')) {
1108:      Benchmark.Suite('`_.includes` searching a string')
1113:          _.include(strNumbers, "," + (limit - 1))'
```

now reads

```
perf.js
1087:    Benchmark.Suite('`_.includes` searching an array')
1092:        _.includes(numbers, limit - 1)'
1097:    Benchmark.Suite('`_.includes` searching an object')
1102:        _.includes(object, limit - 1)'
1106:  if (lodash.includes('ab', 'ab') && _.includes('ab', 'ab')) {
1108:      Benchmark.Suite('`_.includes` searching a string')
1113:          _.includes(strNumbers, "," + (limit - 1))'
```