### PR TITLE
range: Produce more exact fractional results

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -12497,7 +12497,7 @@
         }
       }
       return baseTimes(n, function(index) {
-        return index ? (start + index * step) / factor : start;
+        return (index ? (start + index * step) : start) / factor;
       });
     }
 

--- a/lodash.js
+++ b/lodash.js
@@ -12480,8 +12480,24 @@
         end = +end || 0;
       }
       var n = nativeMax(nativeCeil((end - start) / (step || 1)), 0);
+      var factor = 1;
+      // Only do extra work for fractional `step` values.
+      if (step % 1 !== 0) {
+        var exponentParts = step.toExponential().split('e');
+        // If the step looks inexact already, and would result in a very large
+        // `factor`, don't even attempt to get more exact results.
+        if (exponentParts[0].length < 16) {
+          var integerStep = +(exponentParts[0].replace('.', ''));
+          // We know `factor` should be a power of ten. Do we need to potentially
+          // use `round` or `floor` here to ensure this float division doesn't
+          // screw that up?
+          factor = integerStep / step;
+          step = integerStep;
+          start *= factor;
+        }
+      }
       return baseTimes(n, function(index) {
-        return index ? (start += step) : start;
+        return index ? (start + index * step) / factor : start;
       });
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -14922,10 +14922,11 @@
     });
 
     QUnit.test('should produce exact fractional results when possible', function(assert) {
-      assert.expect(2);
+      assert.expect(3);
 
       assert.deepEqual(_.range(0, 0.6, 0.1), [0, 0.1, 0.2, 0.3, 0.4, 0.5]);
       assert.deepEqual(_.range(0, -4/3, -1/3), [0, -1/3, -2/3, -1]);
+      assert.deepEqual(_.range(1, 3, 0.72), [1, 1.72, 2.44]);
     });
 
     QUnit.test('should treat falsey `start` arguments as `0`', function(assert) {

--- a/test/test.js
+++ b/test/test.js
@@ -14921,6 +14921,13 @@
       assert.strictEqual(1 / actual[0], -Infinity);
     });
 
+    QUnit.test('should produce exact fractional results when possible', function(assert) {
+      assert.expect(2);
+
+      assert.deepEqual(_.range(0, 0.6, 0.1), [0, 0.1, 0.2, 0.3, 0.4, 0.5]);
+      assert.deepEqual(_.range(0, -4/3, -1/3), [0, -1/3, -2/3, -1]);
+    });
+
     QUnit.test('should treat falsey `start` arguments as `0`', function(assert) {
       assert.expect(13);
 

--- a/test/test.js
+++ b/test/test.js
@@ -14926,7 +14926,7 @@
 
       assert.deepEqual(_.range(0, 0.6, 0.1), [0, 0.1, 0.2, 0.3, 0.4, 0.5]);
       assert.deepEqual(_.range(0, -4/3, -1/3), [0, -1/3, -2/3, -1]);
-      assert.deepEqual(_.range(1, 3, 0.72), [1, 1.72, 2.44]);
+      assert.deepEqual(_.range(3, 6, 0.72), [3, 3.72, 4.44, 5.16, 5.88]);
     });
 
     QUnit.test('should treat falsey `start` arguments as `0`', function(assert) {

--- a/test/test.js
+++ b/test/test.js
@@ -14922,11 +14922,13 @@
     });
 
     QUnit.test('should produce exact fractional results when possible', function(assert) {
-      assert.expect(3);
+      assert.expect(5);
 
       assert.deepEqual(_.range(0, 0.6, 0.1), [0, 0.1, 0.2, 0.3, 0.4, 0.5]);
       assert.deepEqual(_.range(0, -4/3, -1/3), [0, -1/3, -2/3, -1]);
       assert.deepEqual(_.range(3, 6, 0.72), [3, 3.72, 4.44, 5.16, 5.88]);
+      assert.deepEqual(_.range(0, 1e-30, 1e-30), [0]);
+      assert.deepEqual(_.range(0, 5e-30, 1e-30), [0, 1e-30, 2e-30, 3e-30, 4e-30]);
     });
 
     QUnit.test('should treat falsey `start` arguments as `0`', function(assert) {


### PR DESCRIPTION
Previously, `range` performed naïve summation, accumulating a larger and larger error on each iteration. This produced some annoying inexact values in the resulting array, but it also led to the final values of the array possibly being off by a significant amount.

This new method checks for fractional `step` values and attempts to generate the most exact results possible.

Fixes #1539.

/cc @zachhale @jdalton @jridgewell 

NOTE for anyone who didn't read the whole #1539 thread: the method used here provides *significantly* better results than attempting error compensation using Kahan's method or any others attempted (unless I just implemented error compensation incorrectly several times).