### PR TITLE
Do not define an anonymous module

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -13377,9 +13377,7 @@
 
   // Some AMD build optimizers like r.js check for condition patterns like the following:
   if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
-    // Define as an anonymous module so, through path mapping, it can be
-    // referenced as the "underscore" module.
-    define(function() {
+    define('underscore', function() {
       return _;
     });
   }


### PR DESCRIPTION
Some [AMD loaders like almond don't support anonymous modules][almond].

To make lodash work on these environments it is needed to give the module a name.

I could use requirejs optimizer in my build tool to fix this problem, or just include lodash before almond but I could not see a reason to not have this working out-of-box without needs for changing the build tool.

I'm not sure if this is the right fix, neither if this will broke any other AMD loader but I'm opening the pull request for discussion.

cc @tessalt

[almond]: https://github.com/jrburke/almond#incorrect-module-build-no-module-name