### PR TITLE
Add function to make chains callable with a new value

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6736,6 +6736,39 @@
       return baseWrapperValue(this.__wrapped__, this.__actions__);
     }
 
+    /**
+     * Creates a function which executes the chained sequence on its argument.
+     * The original wrapped value of the chain is ignored.
+     *
+     * **Note:** Many `lodash` methods (`sum`, `first`, etc...) are not chainable by default. 
+     * It's good practice to always use `_.prototype.chain` with `_.prototype.callable`,
+     * as it explicity enables chaining for all methods.
+     *
+     * @name callable
+     * @memberOf _
+     * @category Chain
+     * @returns {Function} Returns the callable chain function.
+     * @example
+     *
+     * _.chain([10, 20]).map(Math.floor).sum().callable()([1.5, 2.5]);
+     * // => 3
+     *
+     * _.map([[1.5,2.5], [3.5,4.5]], _.chain().map(Math.floor).sum().callable());
+     * // => [3,7]
+     */
+    function wrapperCallable() {
+      var self = this;
+      return function(operand) {
+        var clone = wrapperClone(self);
+        var deepest = clone;
+        while (deepest.__wrapped__ instanceof baseLodash) {
+          deepest = deepest.__wrapped__;
+        }
+        deepest.__wrapped__ = operand;
+        return clone.value();
+      }
+    }
+
     /*------------------------------------------------------------------------*/
 
     /**
@@ -13351,6 +13384,7 @@
     LazyWrapper.prototype.value = lazyValue;
 
     // Add chaining functions to the `lodash` wrapper.
+    lodash.prototype.callable = wrapperCallable;
     lodash.prototype.chain = wrapperChain;
     lodash.prototype.commit = wrapperCommit;
     lodash.prototype.concat = wrapperConcat;

--- a/lodash.js
+++ b/lodash.js
@@ -6757,13 +6757,13 @@
      * // => [3,7]
      */
     function wrapperCallable() {
-      var self = this;
+      var clone = wrapperClone(this);
+      var deepest = clone;
+      while (deepest.__wrapped__ instanceof baseLodash) {
+        deepest = deepest.__wrapped__;
+      }
+      
       return function(operand) {
-        var clone = wrapperClone(self);
-        var deepest = clone;
-        while (deepest.__wrapped__ instanceof baseLodash) {
-          deepest = deepest.__wrapped__;
-        }
         deepest.__wrapped__ = operand;
         return clone.value();
       }

--- a/test/test.js
+++ b/test/test.js
@@ -21374,6 +21374,70 @@
     });
   }());
 
+  QUnit.module('loading(...).callable');
+
+  (function() {
+    QUnit.test('should return a method which executes the chained sequence on its argument', function(assert) {
+      assert.expect(3);
+
+      if (!isNpm) {
+        var array = [1],
+            wrapped = _.chain().push(2).push(3).sum(),
+            callable = wrapped.callable();
+
+        assert.strictEqual(typeof callable , 'function');
+
+        assert.deepEqual(callable(array), 6);
+        assert.deepEqual(array, [1, 2, 3]);
+      }
+      else {
+        skipTest(assert, 4);
+      }
+    });
+
+    QUnit.test('should not affect the original chain when called', function(assert) {
+      assert.expect(5);
+
+      if (!isNpm) {
+        var original = [1],
+            array = [5],
+            wrapped = _.chain(original).push(2).push(3).sum(),
+            callable = wrapped.callable();
+
+        assert.strictEqual(typeof callable , 'function');
+
+        assert.strictEqual(callable(array), 10);
+        assert.deepEqual(original, [1]);
+        assert.strictEqual(wrapped.value(), 6);
+        assert.deepEqual(original, [1, 2, 3]);
+      }
+      else {
+        skipTest(assert, 5);
+      }
+    });
+
+    QUnit.test('should work with nested wrappers', function(assert) {
+      assert.expect(3);
+
+      if (!isNpm) {
+        var data = [[1, 0], [2, 0], [3, 0], [4, 0]],
+            dummy = [1],
+            wrapped = _.chain(dummy).map(_.compact).flatten().push(5).sum(),
+            callable = wrapped.callable();
+
+        function double (x) { return x*2; }
+
+        assert.strictEqual(typeof callable , 'function');
+
+        assert.strictEqual(callable(data), 15);
+        assert.deepEqual(dummy, [1]);
+      }
+      else {
+        skipTest(assert, 3);
+      }
+    });
+  })();
+
   /*--------------------------------------------------------------------------*/
 
   QUnit.module('lodash(...) methods that return the wrapped modified array');


### PR DESCRIPTION
Add `_().callable()`, which returns a function that executes the actions
of the chain `callable()` was called on its argument.

This enables the passing of chains to functions which take an interatee.

`callable()` works by cloning the wrapper and replacing the first `__wrapped__`
property which is not itself a wrapper with the argument passed to
the function. It then calls `value()` on the resulting wrapper object
and returns the result.