### PR TITLE
Enhancement: `createRound`

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4156,7 +4156,7 @@
           var pair = (toString(number) + 'e').split('e'),
               value = toString(func(pair[0] + 'e' + (+pair[1] + precision)));
           pair = (value + 'e').split('e');
-          return +(pair[0] + 'e' + (+pair[1]- precision));
+          return +(pair[0] + 'e' + (+pair[1] - precision));
         }
         return func(number);
       };

--- a/lodash.js
+++ b/lodash.js
@@ -4148,15 +4148,15 @@
     function createRound(methodName) {
       var func = Math[methodName];
       return function(number, precision) {
+        number = toNumber(number);
         precision = precision ? toInteger(precision) : 0;
         if (precision) {
           // Shift with exponential notation to avoid floating-point issues.
           // See [MDN](https://mdn.io/round#Examples) for more details.
-          var pair = (+number + 'e').split('e'),
-              value = func(pair[0] + 'e' + (+pair[1] + precision));
-
+          var pair = (toString(number) + 'e').split('e'),
+              value = toString(func(pair[0] + 'e' + (+pair[1] + precision)));
           pair = (value + 'e').split('e');
-          return +(pair[0] + 'e' + (pair[1] - precision));
+          return +(pair[0] + 'e' + (+pair[1]- precision));
         }
         return func(number);
       };

--- a/test/test.js
+++ b/test/test.js
@@ -16073,6 +16073,17 @@
         isCeil = methodName == 'ceil',
         isFloor = methodName == 'floor';
 
+    QUnit.test('`_.' + methodName + '` should return `0` with sign preserved', function(assert) {
+      assert.expect(1);
+
+      var actual = [1 / func(0), 1 / func(-0), 1 / func('0'), 1 / func('-0'),
+          1 / func(0, 1), 1 / func(-0, 1), 1 / func('0', 1), 1 / func('-0', 1)],
+        expected = [Infinity, -Infinity, Infinity, -Infinity,
+          Infinity, -Infinity, Infinity, -Infinity];
+
+      assert.deepEqual(actual, expected);
+    });
+
     QUnit.test('`_.' + methodName + '` should return a rounded number without a precision', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Enhance `createRound` by using `toNumber`, allows binary and octal strings.
Enhance by preserving sign of `0`s, using `toString`.
Add tests for sign preservation.

Ref https://github.com/lodash/lodash/issues/1602