### PR TITLE
Enhance `debounce` to handle binary and octal strings and ms times to integers.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8145,8 +8145,7 @@
       if (typeof func != 'function') {
         throw new TypeError(FUNC_ERROR_TEXT);
       }
-      wait = toInteger(wait);
-      wait = wait < 0 ? 0 : wait;
+      wait = clamp(toInteger(wait), 0, MAX_INTEGER);
       if (isObject(options)) {
         leading = !!options.leading;
         maxWait = 'maxWait' in options && nativeMax(toInteger(options.maxWait), wait);

--- a/lodash.js
+++ b/lodash.js
@@ -8145,10 +8145,11 @@
       if (typeof func != 'function') {
         throw new TypeError(FUNC_ERROR_TEXT);
       }
-      wait = wait < 0 ? 0 : (+wait || 0);
+      wait = toInteger(wait);
+      wait = wait < 0 ? 0 : wait;
       if (isObject(options)) {
         leading = !!options.leading;
-        maxWait = 'maxWait' in options && nativeMax(+options.maxWait || 0, wait);
+        maxWait = 'maxWait' in options && nativeMax(toInteger(options.maxWait), wait);
         trailing = 'trailing' in options ? !!options.trailing : trailing;
       }
 


### PR DESCRIPTION
Ref https://github.com/lodash/lodash/issues/1602