### PR TITLE
`throttle` uses `debounce` so no coersion of `wait` required.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8730,7 +8730,7 @@
         leading = 'leading' in options ? !!options.leading : leading;
         trailing = 'trailing' in options ? !!options.trailing : trailing;
       }
-      return debounce(func, wait, { 'leading': leading, 'maxWait': +wait, 'trailing': trailing });
+      return debounce(func, wait, { 'leading': leading, 'maxWait': wait, 'trailing': trailing });
     }
 
     /**


### PR DESCRIPTION
Refs https://github.com/lodash/lodash/pull/1602 https://github.com/lodash/lodash/pull/1610

As throttle uses debounce, do we need to do conversion here or should we just rely on debounce?