### PR TITLE
Enhance `delay` with `toInteger` and `clamp` to use binary and octal strings.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8285,7 +8285,7 @@
      * // => logs 'later' after one second
      */
     var delay = rest(function(func, wait, args) {
-      return baseDelay(func, wait, args);
+      return baseDelay(func, clamp(toInteger(wait), 0, MAX_INTEGER), args);
     });
 
     /**


### PR DESCRIPTION
Ref https://github.com/lodash/lodash/issues/1602