### PR TITLE
Support deepPaths as keynames for zipObject

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6671,9 +6671,9 @@
       while (++index < length) {
         var key = props[index];
         if (values) {
-          result[key] = values[index];
+          baseSet(result, key, values[index]);
         } else if (key) {
-          result[key[0]] = key[1];
+          baseSet(result, key[0], key[1]);
         }
       }
       return result;

--- a/test/test.js
+++ b/test/test.js
@@ -21236,6 +21236,24 @@
       assert.deepEqual(actual, expected);
     });
 
+    QUnit.test('should accept deep-path key: subscript with string', function(assert) {
+      assert.expect(1);
+
+      assert.deepEqual(_.zipObject([['a[b]', 1]]), { 'a': { 'b': 1 }});
+    });
+
+    QUnit.test('should accept deep-path key: subscript with index', function(assert) {
+      assert.expect(1);
+
+      assert.deepEqual(_.zipObject([['a[1]', 1]]), { 'a': [ undefined, 1 ]});
+    });
+
+    QUnit.test('should accept deep-path key: dot-notation', function(assert) {
+      assert.expect(1);
+
+      assert.deepEqual(_.zipObject(['a.b'], [1]), { 'a': { 'b': 1 }});
+    });
+
     QUnit.test('should support consuming the return value of `_.pairs`', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Closes #1151

This is implemented by simply using baseSet within the body of zipObject
when building up the object