### PR TITLE
add parseBool function

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -11857,6 +11857,62 @@
     }
 
     /**
+     * Converts `any` to a boolean. If a boolean is not able to be determined, it
+     * returns the string `"NaB"`. This is unfortunate being that there is no js equivalent
+     * to `NaN` for booleans.
+     *
+     * @static
+     * @memberOf _
+     * @category Any
+     * @param {any} any The variable to convert.
+     * @param {array} truthy Array or string to add to truthy values.
+     * @param {array} falsey Array or string to add to falsey values.
+     * @returns {boolean} Returns the fitting boolean or string "NaB".
+     * @example
+     *
+     * _.parseBool('yes');
+     * // => true
+     *
+     * _.parseBool('off');
+     * // => false
+     *
+     * _.parseBool('foo');
+     * // => 'NaB'
+     *
+     * _.parseBool('foo', ['foo']);
+     * // => 'true'
+     *
+     * _.parseBool('bar', 'foo', 'bar');
+     * // => 'false'
+     */
+    function parseBool(any, truthy, falsey) {
+      var truthyArr = ['on', 't', 'true', 'up', 'y', 'yes'].concat(truthy);
+      var falseyArr = ['off', 'f', 'false', 'down', 'n', 'no'].concat(falsey);
+      switch(typeof any) {
+        case 'boolean':
+          return any;
+        case 'undefined':
+          return false;
+        case 'function':
+          return parseBool(any());
+        case 'array':
+          return !!any.length;
+        case 'object':
+          return any !== null && !!Object.keys(any).length;
+        case 'number':
+          return any > 0;
+        case 'string':
+          if(truthyArr.indexOf(any) !== -1) {
+            return true;
+          }
+          if(falseyArr.indexOf(any) !== -1) {
+            return false;
+          }
+      }
+      return 'NaB';
+    }
+
+    /**
      * Converts `string` to an integer of the specified radix. If `radix` is
      * `undefined` or `0`, a `radix` of `10` is used unless `value` is a hexadecimal,
      * in which case a `radix` of `16` is used.
@@ -13676,6 +13732,7 @@
     lodash.eachRight = forEachRight;
     lodash.extend = assignIn;
     lodash.extendWith = assignInWith;
+    lodash.parseBoolean = parseBool;
 
     // Add functions to `lodash.prototype`.
     mixin(lodash, lodash);
@@ -13770,6 +13827,7 @@
     lodash.pad = pad;
     lodash.padLeft = padLeft;
     lodash.padRight = padRight;
+    lodash.parseBool = parseBool;
     lodash.parseInt = parseInt;
     lodash.random = random;
     lodash.reduce = reduce;

--- a/test/test.js
+++ b/test/test.js
@@ -14035,6 +14035,99 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.parseBool');
+
+  (function() {
+    QUnit.test('Should accept a `boolean` argument', function(assert) {
+      assert.expect(2);
+
+      var test1 = true;
+      var test2 = 'foo' === 'bar';
+
+      assert.ok(_.parseBool(test1));
+      assert.ok(!_.parseBool(test2));
+    });
+    QUnit.test('Should accept a `undefined` argument', function(assert) {
+      assert.expect(2);
+
+      var test1 = undefined;
+
+      assert.ok(!_.parseBool(test1));
+      assert.equal(_.parseBool('unknown'), 'NaB');
+    });
+    QUnit.test('Should accept a `function` argument', function(assert) {
+      assert.expect(2);
+
+      var test1 = function() {
+        return 5 > 3;
+      };
+      var test2 = function() {
+        return 'foo' === 'bar';
+      };
+
+      assert.ok(_.parseBool(test1));
+      assert.ok(!_.parseBool(test2));
+    });
+    QUnit.test('Should accept a `array` argument', function(assert) {
+      assert.expect(2);
+
+      var test1 = ['foo'];
+      var test2 = [];
+
+      assert.ok(_.parseBool(test1));
+      assert.ok(!_.parseBool(test2));
+    });
+    QUnit.test('Should accept a `object` argument', function(assert) {
+      assert.expect(3);
+
+      var test1 = {foo: 'bar'};
+      var test2 = {};
+      var test3 = null;
+
+      assert.ok(_.parseBool(test1));
+      assert.ok(!_.parseBool(test2));
+      assert.ok(!_.parseBool(test3));
+    });
+    QUnit.test('Should accept a `number` argument', function(assert) {
+      assert.expect(4);
+
+      var test1 = 25;
+      var test2 = -50;
+      var test3 = 0;
+      var test4 = NaN;
+
+      assert.ok(_.parseBool(test1));
+      assert.ok(!_.parseBool(test2));
+      assert.ok(!_.parseBool(test3));
+      assert.ok(!_.parseBool(test4));
+    });
+    QUnit.test('Should accept a `string` argument', function(assert) {
+      assert.expect(8);
+
+      assert.ok(_.parseBool('yes'));
+      assert.ok(!_.parseBool('no'));
+
+      assert.ok(_.parseBool('true'));
+      assert.ok(!_.parseBool('false'));
+
+      assert.ok(_.parseBool('up'));
+      assert.ok(!_.parseBool('down'));
+
+      assert.ok(_.parseBool('on'));
+      assert.ok(!_.parseBool('off'));
+    });
+    QUnit.test('Should accept a `string` 2nd and 3rd argument', function(assert) {
+      assert.expect(3);
+
+      assert.ok(_.parseBool('foo', 'foo'));
+      assert.ok(!_.parseBool('bar', 'foo', 'bar'));
+
+      assert.ok(_.parseBool('baz', ['foo', 'baz']));
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.parseInt');
 
   (function() {
@@ -22439,7 +22532,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(278);
+      assert.expect(280);
 
       var emptyArrays = lodashStable.map(falsey, lodashStable.constant([]));
 


### PR DESCRIPTION
_.parseBool (or _.parseBoolean) is a utility designed to receive almost any variable and convert it into a proper boolean.

The most common use-case will be for converting strings such as "yes"/"no" or "true"/"false" into actual booleans.

In the fringe case that a boolean cannot be resolved, the string "NaB" is returned as JS doesn't have an absent boolean equivalent.