### PR TITLE
Update email address in CoC. [ci skip]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,12 +35,11 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. Maintainers are
-obligated to maintain confidentiality with regard to the reporter of an
-incident.
-
+reported by contacting a project maintainer at
+[coc@lodash.com](mailto:coc@lodash.com). All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. Maintainers are obligated to maintain
+confidentiality with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.3.0, available at


### PR DESCRIPTION
Fixes #1673.

Updates email address in Code of Conduct to `coc@lodash.com`.