### PR TITLE
add test case for `sortBy` with property syntax and context

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -17995,7 +17995,7 @@
     QUnit.test('should work with "_.property" style `iteratee` and context', function(assert) {
       assert.expect(1);
 
-      var actual = lodashStable.map(_.sortBy(objects.concat(undefined), 'b', null), 'b');
+      var actual = lodashStable.map(_.sortBy(objects.concat(undefined), 'b', {}), 'b');
       assert.deepEqual(actual, [1, 2, 3, 4, undefined]);
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -17992,6 +17992,13 @@
       assert.deepEqual(actual, [1, 2, 3, 4, undefined]);
     });
 
+    QUnit.test('should work with "_.property" style `iteratee` and context', function(assert) {
+      assert.expect(1);
+
+      var actual = lodashStable.map(_.sortBy(objects.concat(undefined), 'b', null), 'b');
+      assert.deepEqual(actual, [1, 2, 3, 4, undefined]);
+    });
+
     QUnit.test('should work with an object for `collection`', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
I was recently bit by the regression mentioned in #1530 where using `_.sortBy` with a property shorthand and a supplied context stopped working. The bug has since been fixed, but this PR adds a test case to help discover future regressions.