### PR TITLE
fix doc: clone → cloneWith

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9088,7 +9088,7 @@
      *   }
      * }
      *
-     * var el = _.clone(document.body, customizer);
+     * var el = _.cloneWith(document.body, customizer);
      *
      * console.log(el === document.body);
      * // => false


### PR DESCRIPTION
Looks like typo occured when splitting `clone` & `cloneWith`.