### PR TITLE
Update contributing.md about how to launch tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Include updated unit tests in the `test` directory as part of your pull request.
 Don’t worry about regenerating the documentation, lodash.js, or lodash.min.js.
 
 Before running the unit tests you’ll need to install, `npm i`, [development dependencies](https://docs.npmjs.com/files/package.json#devdependencies).
-Run unit tests from the command-line via `node test/test`, or open `test/index.html` in a web browser.
+Run unit tests from the command-line via `npm test`, or open `test/index.html` and `test/fp.html` in a web browser.
 The [Backbone](http://backbonejs.org/) & [Underscore](http://underscorejs.org/) test suites are included as well.
 
 ## Contributor License Agreement


### PR DESCRIPTION
In e255818, the way to launch tests was updated to include the fp tests, but the contributing.md file was not updated with the new way to launch tests.