### PR TITLE
Update README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -7148,7 +7148,7 @@ The chainable wrapper methods are:<br>
 `dropWhile`, `fill`, `filter`, `flatten`, `flattenDeep`, `flip`, `flow`,
 `flowRight`, `forEach`, `forEachRight`, `forIn`, `forInRight`, `forOwn`,
 `forOwnRight`, `fromPairs`, `functions`, `functionsIn`, `groupBy`, `initial`,
-`intersection`, `intersectionBy`, `intersectionWith`, invert`, `invokeMap`,
+`intersection`, `intersectionBy`, `intersectionWith`, `invert`, `invokeMap`,
 `iteratee`, `keyBy`, `keys`, `keysIn`, `map`, `mapKeys`, `mapValues`,
 `matches`, `matchesProperty`, `memoize`, `merge`, `mergeWith`, `method`,
 `methodOf`, `mixin`, `negate`, `nthArg`, `omit`, `omitBy`, `once`, `orderBy`,


### PR DESCRIPTION
Missing a '`' in the chainable wrapper methods section that breaks the formatting.