### PR TITLE
Disable fp concat rearg

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -182,6 +182,7 @@ module.exports = {
   'skipRearg': {
     'assign': true,
     'assignIn': true,
+    'concat': true,
     'defaults': true,
     'defaultsDeep': true,
     'difference': true,


### PR DESCRIPTION
`concat` shouldn't flip its args.