### PR TITLE
Add npm scripts to build docs

### DIFF
--- a/doc/build-doc
+++ b/doc/build-doc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+docdown \
+  ./lodash.js  \
+  ./doc/README.md  \
+  toc="categories"  \
+  url="https://github.com/lodash/lodash/blob/$npm_package_version/lodash.js"  \
+  title="<a href=\"https://lodash.com/\">lodash</a> <span>v$npm_package_version</span>"  \
+  hash="$1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "build:fp": "node lib/fp/build-dist.js",
     "build:fp-modules": "node lib/fp/build-modules.js",
     "build:main": "node lib/main/build-dist.js",
+    "doc:github": "./doc/build-doc github",
+    "doc:default": "./doc/build-doc default",
     "style": "npm run style:main & npm run style:fp & npm run style:perf & npm run style:test",
     "style:fp": "jscs fp/*.js lib/**/*.js",
     "style:main": "jscs lodash.js",


### PR DESCRIPTION
Adding npm scripts to build docs, based on [this gist](https://gist.github.com/jdalton/938ea49ab3919f1c046c)

Leveraging the fact that scripts ran using `npm run` have the package's version set in the environment variables (as `npm_package_version`). This way, the version won't have to be manually updated every time the version changes.

I felt obligated to create a `build-doc` bash file containing the whole command, as it made the package.json huge horizontally (and it's not possible to create multiline commands). I put the bash file in doc/ as it was to me the most sensible, but I don't know it is a problematic solution.