### PR TITLE
Remove V8 JIT bug fix for isObject

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9792,10 +9792,7 @@
      * // => false
      */
     function isObject(value) {
-      // Avoid a V8 JIT bug in Chrome 19-20.
-      // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
-      var type = typeof value;
-      return !!value && (type == 'object' || type == 'function');
+      return value === Object(value);
     }
 
     /**


### PR DESCRIPTION
This bug has been fixed around 2012-08-15 and has landed in Node 0.8.8.

The workaround is no longer required.

Sources:

- https://bugs.chromium.org/p/v8/issues/detail?id=2291
- https://github.com/nodejs/node-v0.x-archive/issues/3867