### PR TITLE
_.attempt() should preserve custom errors

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -12926,7 +12926,7 @@
       try {
         return apply(func, undefined, args);
       } catch (e) {
-        return isError(e) ? e : new Error(e);
+        return isObject(e) ? e : new Error(e);
       }
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1482,6 +1482,20 @@
       assert.ok(lodashStable.isEqual(actual, Error('x')));
     });
 
+    QUnit.test('should preserve custom errors', function(assert) {
+      assert.expect(1);
+
+      function CustomError(message) {
+        this.name = 'CustomError';
+        this.message = message;
+      }
+      CustomError.prototype = Object.create(Error.prototype);
+      CustomError.prototype.constructor = CustomError;
+
+      var actual = _.attempt(function() { throw new CustomError('x'); });
+      assert.ok(lodashStable.isEqual(actual, new CustomError('x')));
+    });
+
     QUnit.test('should work with an error object from another realm', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Previously, custom errors were wrapped in a `new Error(e)`.

CLA signed as VanTanev (submitted a CLA on 2016-01-30 00:30:18).

Thanks!