### PR TITLE
Alias omit to unset in FP

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -27,6 +27,7 @@ exports.aliasToReal = {
   'somePass': 'overSome',
   'unapply': 'rest',
   'unnest': 'flatten',
+  'unset': 'omit',
   'useWith': 'overArgs',
   'whereEq': 'filter',
   'zipObj': 'zipObject'


### PR DESCRIPTION
I realize that `omit` is already aliased to `dissoc`, but currently lodash/fp's `unset` is not immutable, which is surprising and arguably incorrect for an FP method.

You could make `unset` immutable, but then it would be useless to return a boolean, so it might as well just be overwritten by `omit` to provide the same functionality as `dissoc`. Then it would pair more sensibly with `set`, which currently *is* immutable.