### PR TITLE
Update indexOf documentation

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5891,8 +5891,7 @@
      * Gets the index at which the first occurrence of `value` is found in `array`
      * using [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
      * for equality comparisons. If `fromIndex` is negative, it's used as the offset
-     * from the end of `array`. If `array` is sorted providing `true` for `fromIndex`
-     * performs a faster binary search.
+     * from the end of `array`.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
I think the option to pass `true` for indexOf to use binary search was removed when sortedIndexOf was added.