### PR TITLE
change _.pickBy documentation to include value as an argument

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -6827,7 +6827,7 @@ _.pick(object, ['a', 'c']);
 <a href="#_pickbyobject-predicate_identity">#</a> [&#x24C8;](https://github.com/lodash/lodash/blob/4.1.0/lodash.js#L11423 "View in source") [&#x24C9;][1] [&#x24C3;](https://www.npmjs.com/package/lodash.pickby "See the npm package")
 
 Creates an object composed of the `object` properties `predicate` returns
-truthy for. The predicate is invoked with one argument: (value).
+truthy for. The predicate is invoked with two arguments: (value, key).
 
 #### Arguments
 1. `object` *(Object)*: The source object.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "codecov.io": "~0.1.6",
     "coveralls": "^2.11.6",
     "curl-amd": "~0.8.12",
-    "docdown": "~0.4.0",
+    "docdown": "~0.4.1",
     "dojo": "^1.10.4",
     "ecstatic": "^1.4.0",
     "fs-extra": "~0.26.5",


### PR DESCRIPTION
Value was added as an argument in [this commit](https://github.com/lodash/lodash/commit/3eaa7b3b18069bfd32b98096c337edbb2cdca5fe). My PR adds this in README.md