### PR TITLE
Improve accuracy of _.throttle

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8649,7 +8649,7 @@
         if (maxWait === false) {
           var leadingCall = leading && !timeoutId;
         } else {
-          if (!maxTimeoutId && !leading) {
+          if (!lastCalled && !maxTimeoutId && !leading) {
             lastCalled = stamp;
           }
           var remaining = maxWait - (stamp - lastCalled),

--- a/test/test.js
+++ b/test/test.js
@@ -20399,6 +20399,28 @@
         }, 1);
       });
     });
+    
+    QUnit.test('should trigger a second throttled call as early as possible when invoked repeatedly', function(assert) {
+      assert.expect();
+
+      var done = assert.async();
+
+      var callCount = 0,
+          throttled = _.throttle(function() { callCount++; }, 32, {leading:false});
+
+      throttled();
+      setTimeout(function() {
+          throttled();
+      }, 40);
+
+      setTimeout(function() {
+        assert.strictEqual(callCount,1);
+      }, 38);
+      setTimeout(function() {
+        assert.strictEqual(callCount,2);
+        done();
+      }, 70);
+    });
 
     QUnit.test('should apply default options', function(assert) {
       assert.expect(3);


### PR DESCRIPTION
Repeated throttled executions are not as accurate as they could be.
For example, when

```` var throttled = _.throttle(doSomething,400) ````
and calling repeatedly ````throttled();```` every 200ms.

I expect the executions happen once every 400ms, but sometimes there are delays of more than 100ms until the next execution.

This pull request fixes the situation at ````trailing:true, leading:false```` and ````trailing:true, leading:true`````

There is no way of achieving a 400ms rate of execution for ````trailing:false, leading:true```` in this example I put, because by definition, is impossible to foresee the future. We need to wait for the next ````throttled() ````

I discover this lack of accuracy with this example:

```
$('.clickme')
    .on('click', _.throttle(function (){  
     t1 = performance.now(); 
     console.log('Time from last throttle: ', (t1 - t2).toFixed(4), 'ms ');
     t2 = performance.now();
  }, 400, {trailing:true, leading:false}))
  .on('click', function(){
    t0 = performance.now(); 
    console.log('Time from last click:', (t0-t4).toFixed(4), 'ms ');
    t4 = performance.now();
  })
```

![image](https://cloud.githubusercontent.com/assets/881333/12870172/9be6ad4a-cd30-11e5-915f-a14c2b91b3a2.png)

  