### PR TITLE
Contributing.md - Link to enhancement issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Feature requests are always welcome. They should be submitted in the
 the expected behavior & use case, where they’ll remain closed until sufficient
 interest has been shown by the community. Before submitting a request,
 please search for similar ones in the
-[closed issues](https://github.com/lodash/lodash/issues?q=is%3Aissue+is%3Aclosed).
+[closed issues](https://github.com/lodash/lodash/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
 
 ## Pull Requests
 


### PR DESCRIPTION
Change the link from "closed issues" to "closed issues with enhancement label".