### PR TITLE
meta: fix npm-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "style:main": "jscs lodash.js",
     "style:perf": "jscs perf/*.js perf/**/*.js",
     "style:test": "jscs test/*.js test/**/*.js",
-    "test": "npm run test:main && npm run test:fp && npm run test:docs",
+    "test": "npm run test:main && npm run test:fp",
     "test:fp": "node test/test-fp",
     "test:main": "node test/test"
   }


### PR DESCRIPTION
currently the test script is calling to a test-docs script
that does not exists.

Removing the call to test-docs allows the unit test suite to work again