### PR TITLE
Links _.remove and _.pull in the docs.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6187,6 +6187,7 @@
      * for equality comparisons.
      *
      * **Note:** Unlike `_.without`, this method mutates `array`.
+     * **Note:** To remove elements from an array based on a predicate, see `_.remove`.
      *
      * @static
      * @memberOf _
@@ -6295,6 +6296,7 @@
      * three arguments: (value, index, array).
      *
      * **Note:** Unlike `_.filter`, this method mutates `array`.
+     * **Note:** To remove elements from an array based on their values, see `_.pull`.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
It seems that `_.remove` is confusing people on how it works (https://github.com/lodash/lodash/issues/1892), so I added a note to its documentation pointing to `_.pull` and a note in `_.pull` pointing to `_.remove`.