### PR TITLE
Explain in CONTRIBUTING that +1 is encouraged for feature requests.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,9 +12,11 @@ may have already been discussed or fixed in `master`. To contribute,
 Feature requests are always welcome. They should be submitted in the
 [issue tracker](https://github.com/lodash/lodash/issues), with a description of
 the expected behavior & use case, where they’ll remain closed until sufficient
-interest has been shown by the community. Before submitting a request,
-please search for similar ones in the
+interest has been shown by the community. Before submitting a request, please
+search for similar ones in the
 [closed issues](https://github.com/lodash/lodash/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
+If you find a closed issue for your feature request you are encouraged to :+1:
+it to show your support.
 
 ## Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "doc": "node lib/main/build-doc github",
     "doc:fp": "node lib/fp/build-doc",
     "doc:site": "node lib/main/build-doc site",
-    "prepublish": "npm run style",
     "pretest": "npm run build",
     "style": "npm run style:main & npm run style:fp & npm run style:perf & npm run style:test",
     "style:fp": "jscs fp/*.js lib/**/*.js",


### PR DESCRIPTION
Hmm, now I'm confused. I came here to ask you to include this because this is my understanding of your policy from [conversation on Twitter yesterday](https://twitter.com/mccjm/status/700386076880461825). Many projects yell at people for +1'ing issues, so if you don't tell people it's ok a lot of them probably won't do it and the gauge of community interest will be skewed.

But before I submitted I noticed that the whole paragraph on feature requests was just added. I didn't know that before, the timing is a total coincidence. But I noticed that the commit that was merged from the PR adding that paragraph [had this at the end](https://github.com/lodash/lodash/commit/c7727f51e703dd42f933c0f4ce54a2fe5eaea7d3):

>  and leave a comment there if you could find one.

But it's gone from the commit that's in `master` https://github.com/lodash/lodash/commit/b7ae5f088573da15354ead52dddd4383f96daaaa.

Is there a reason that part was removed?