### PR TITLE
Docs: Fix order of arguments in FP docs [ci skip]

### DIFF
--- a/lib/fp/build-doc.js
+++ b/lib/fp/build-doc.js
@@ -18,9 +18,11 @@ var templateData = {
 };
 
 function toArgOrder(array) {
-  return '`(' + _.map(array, function(value) {
-    return argNames[value];
-  }).join(', ') + ')`';
+  var orderedNames = [];
+  array.forEach(function(newPosition, index) {
+    orderedNames[newPosition] = argNames[index];
+  });
+  return '`(' + orderedNames.join(', ') + ')`';
 }
 
 function toFuncList(array) {


### PR DESCRIPTION
The order of the rearranged arguments is incorrect in the FP guide

Example for `set`:
- Given rearrangement order: `(c, a, b)`
- Original order: `(object, path, value)`
- FP order: `(path, value, object)`, which corresponds to a `(b, c, a)` reordering.

This PR fixes the order of the arguments.

Thanks to @piercers for noticing this!