### PR TITLE
Add failing test for mergeWith with multi-ref source object

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -14386,6 +14386,24 @@
 
       assert.deepEqual(actual, { 'a': { 'b': ['c'] } });
     });
+
+    QUnit.test('should merge correctly when merging a source object with two keys referencing the same object', function(assert) {
+      assert.expect(1);
+      var vegetables = ['peas', 'brocolli'];
+      var foodToMerge = {
+        vegetables: vegetables,
+        greens: vegetables
+      };
+      var food = {
+        vegetables: ['carrot']
+      };
+
+      var actual = _.mergeWith(food, foodToMerge, function(a, b) {
+        return lodashStable.isArray(a) ? a.concat(b) : undefined;
+      });
+
+      assert.deepEqual(actual, { vegetables: ['carrot', 'peas', 'brocolli'], greens: ['peas', 'brocolli'] });
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
This seems pretty straightfoward to me. I've got a source object
I want to merge which has two keys, only one of which exists in
the object I want to merge into. Both keys in the source object
point to the same object, an array.

What I expect to come out of the merge is an object where the
key that existed before has been modified to contain the values
of the array too, and the key that didn't exist just got added
with the values of the array *only*.

What actually happens is the two keys in the final object are
exactly the same, a strict equals comparison is true. This is
unexpected.

We can take this problem a little further and start with an initial
object with both keys from the source object defined and set to
different things:
```js
var food = {
  vegetables: ['carrot'],
  greens: ['cabbage']
};
```
The result of `mergeWith` will actually end up destroying data because
`actual.greens` will no longer contain the element `cabbage`. This initial
state also produces an ordering problem. If you swap the order of the
keys in the source object, the final result is different - you end up with
`actual.vegetables` equal to `['cabbage', 'brocolli', 'peas']` and have
lost the `carrot` element. Merges with the same keys and data in the
source object feels to me like something that should be deterministic.

The problem appears to stem from `baseMergeDeep`'s stack because
the customiser function is only executed once, for the first key.
It feels like a bad assumption to make is that if you've seen a
source key's value once, the merge result will be the same no
matter what initial key you're merging into.