### PR TITLE
Remove custom rearg for `update`

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -142,7 +142,6 @@ exports.methodRearg = {
   'setWith': [3, 1, 2, 0],
   'sortedIndexBy': [2, 1, 0],
   'sortedLastIndexBy': [2, 1, 0],
-  'update': [2, 1, 0],
   'zipWith': [1, 2, 0]
 };
 

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -697,7 +697,7 @@
       assert.deepEqual(actual, { 'a': { 'c': 3 } }, 'fp.unset');
 
       value = _.cloneDeep(deepObject);
-      actual = fp.update(function(x) { return x + 1; })('a.b')(value);
+      actual = fp.update('a.b')(function(x) { return x + 1; })(value);
 
       assert.deepEqual(value, deepObject, 'fp.update');
       assert.deepEqual(actual, { 'a': { 'b': 3, 'c': 3 } }, 'fp.update');
@@ -773,7 +773,7 @@
       assert.strictEqual(actual.d, value.d, 'fp.unset');
 
       value = _.cloneDeep(object);
-      actual = fp.update(function(x) { return { 'c2': 2 }; }, 'a.b', value);
+      actual = fp.update('a.b', function(x) { return { 'c2': 2 }; }, value);
       assert.strictEqual(actual.d, value.d, 'fp.update');
     });
   }());


### PR DESCRIPTION
Remove custom rearg for `update` to have the same arg order as `set`
As discussed in #1832:
> How I see it:
the value argument in `update` is like the func argument in `set` (you could replicate set with update by passing `_.constant(someValue)` as func), so it'd make sense having them at the same position. So that, for example, if you need to modify your code to use `update` rather than `set`, you do not have to change the order of the arguments.
I also think it is more readable to have as first argument what you want to change, rather than how to change it.