### PR TITLE
Add _.isEqualTo

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9918,6 +9918,24 @@
     }
 
     /**
+    * Creates a function that checks whether its provided argument is deeply
+    * equal to `value`.
+    *
+    * @static
+    * @memberOf _
+    * @category Function
+    * @param {*} value The value to compare.
+    * @returns {Function} Returns the new function.
+    * @example
+    *
+    * _.filter([1, 2, 1, 3, 1, 4], _.isEqualTo(1))
+    * // => [1, 1, 1]
+    */
+    function isEqualTo(value) {
+      return partial(isEqual, value);
+    }
+
+    /**
      * This method is like `_.isEqual` except that it accepts `customizer` which
      * is invoked to compare values. If `customizer` returns `undefined` comparisons
      * are handled by the method instead. The `customizer` is invoked with up to
@@ -14712,6 +14730,7 @@
     lodash.isElement = isElement;
     lodash.isEmpty = isEmpty;
     lodash.isEqual = isEqual;
+    lodash.isEqualTo = isEqualTo;
     lodash.isEqualWith = isEqualWith;
     lodash.isError = isError;
     lodash.isFinite = isFinite;

--- a/test/test.js
+++ b/test/test.js
@@ -9502,6 +9502,29 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.isEqualTo');
+
+  (function() {
+    QUnit.test('should return a function that returns `true` when a deeply-equal value is provided', function(assert) {
+      assert.expect(4);
+
+      assert.strictEqual(_.isEqualTo('a')('a'), true);
+      assert.strictEqual(_.isEqualTo(['a'])(['a']), true);
+      assert.strictEqual(_.isEqualTo({ '0': 'a' })({ '0': 'a' }), true);
+      assert.strictEqual(_.isEqualTo(NaN)(NaN), true);
+    });
+
+    QUnit.test('should return a function that returns `false` when an unequal value is provided', function(assert) {
+      assert.expect(3);
+
+      assert.strictEqual(_.isEqualTo('a')('b'), false);
+      assert.strictEqual(_.isEqualTo('5')(5), false);
+      assert.strictEqual(_.isEqualTo(null)(undefined), false);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.isError');
 
   (function() {
@@ -24473,7 +24496,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(300);
+      assert.expect(301);
 
       var emptyArrays = lodashStable.map(falsey, alwaysEmptyArray);
 


### PR DESCRIPTION
This is similar to _.isEqual, but rather than accepting two parameters and returning a boolean, it accepts one parameter and returns a curried function. Its typical use would be as an iteratee for function parameters.

For example, the following two samples are equivalent:

```javascript
var object = { a: 1, b: 1, c: 2, d: 3 };
// Select only the properties that have value 1
_.pickBy(object, function(value) {
  return value === 1;
})
// => { a: 1, b: 1 }
```
```javascript
var object = { a: 1, b: 1, c: 2, d: 3 };
_.pickBy(object, _.isEqualTo(1))
// => { a: 1, b: 1 }
```

I think this would be a convenient shorthand for common boilerplate code.