### PR TITLE
Add reconvert method to fp functions

### DIFF
--- a/fp/_baseConvert.js
+++ b/fp/_baseConvert.js
@@ -279,6 +279,9 @@ function baseConvert(util, name, func, options) {
       setPlaceholder = true;
       func.placeholder = result.placeholder = placeholder;
     }
+    result.convert = function(options) {
+      return baseConvert(util, name, func, options);
+    };
     return result;
   };
 

--- a/lib/fp/template/doc/wiki.jst
+++ b/lib/fp/template/doc/wiki.jst
@@ -26,8 +26,25 @@ var extend = require('lodash/fp/extend');
 ## Convert
 
 Although `lodash/fp` & its method modules come pre-converted, there are times when
-you may want to convert another lodash package or create a customized conversion.
-That’s when the `convert` module comes in handy.
+you may want to customize the conversion. That’s when the `convert` method comes in handy.
+
+
+```js
+// Disable capping of the iteratee arguments so it is possible to access
+// the `key` argument
+var mapValuesWithKey = require("lodash/fp/mapValues").convert({cap: false});
+
+mapValuesWithKey(function(value, key) {
+  if (key === "foo") {
+    return -1;
+  }
+  return value;
+}, {foo: 1, bar: 1});
+// => {foo: -1, bar: 1}
+```
+
+It's also possible to use the convert function directly to convert functions or
+objects manually.
 
 ```js
 var convert = require('lodash/fp/convert');
@@ -45,7 +62,7 @@ var fp = convert({
 var fp = convert(lodash.runInContext());
 ```
 
-It’s even customizable.
+It’s customizable too.
 ```js
 // Every option is `true` by default.
 var filter = convert('filter', _.filter, {


### PR DESCRIPTION
Today I was happily hacking using the cherry picked `lodash/fp/<func>` functions but then I came to a situation where I really needed the second iteratee argument `key` of the `mapValues` function.

I seem to have two options:

1. Use the non-fp version
2. Manually do the conversion

But I find both ugly and I'm pretty sure it will be very confusing to whomever will be reading my code next time. So I propose the a `.convert(options)`  method to be added to all fp functions which will allow reconverting the function like this:

```js
import mapValues from "lodash/fp/mapValues";
const mapValuesWithKey = mapValues.convert({cap: false});

// or even simpler with commonjs
const mapValuesWithKey = require("lodash/fp/mapValues").convert({cap: false});
```

What do you think?

I'm not sure this is the best way to implement it. It works, but consider this PR just as a proposal for a feature like this.