### PR TITLE
break before unnecessary string concatenation

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -13116,6 +13116,9 @@
           result += string;
         }
         n = nativeFloor(n / 2);
+        if(n === 0) {
+            break;
+        }
         string += string;
       } while (n);
 


### PR DESCRIPTION
Pull request for issue #2103. Break before string concatenation that will never be used.