### PR TITLE
Docs: Add missing param for `_.reverse` [ci skip]

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6584,6 +6584,7 @@
      * @memberOf _
      * @since 4.0.0
      * @category Array
+     * @param {Array} array The array to modify.
      * @returns {Array} Returns `array`.
      * @example
      *


### PR DESCRIPTION
The `array` param for `reverse` is missing in the docs https://lodash.com/docs#reverse.
I reused the one for `remove` which seemed similar.