### PR TITLE
Re-ordered arguments for fp.isEqualWith + some additional tests for lodash.isEqualWith

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -143,6 +143,7 @@ exports.methodRearg = {
   'assignInWith': [1, 2, 0],
   'assignWith': [1, 2, 0],
   'getOr': [2, 1, 0],
+  'isEqualWith': [2, 1, 0],
   'isMatchWith': [2, 1, 0],
   'mergeWith': [1, 2, 0],
   'padChars': [2, 1, 0],

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -1693,6 +1693,49 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('fp.isEqualWith');
+
+  (function() {
+    QUnit.test('should handle comparisons if `customizer` returns `undefined`', function(assert) {
+      assert.expect(6);
+
+      assert.strictEqual(fp.isEqualWith(noop)('a', 'a'), true);
+      assert.strictEqual(fp.isEqualWith(noop)(['a'], ['a']), true);
+      assert.strictEqual(fp.isEqualWith(noop)({ '0': 'a' }, { '0': 'a' }), true);
+
+      assert.strictEqual(fp.isEqualWith(noop)('a', 'b'), false);
+      assert.strictEqual(fp.isEqualWith(noop)(['a'], ['b']), false);
+      assert.strictEqual(fp.isEqualWith(noop)({ '0': 'a' }, { '0': 'b' }), false);
+    });
+
+    QUnit.test('should not handle comparisons if `customizer` returns `true`', function(assert) {
+      assert.expect(3);
+
+      var customizer = function(value) {
+        return fp.isString(value) || undefined;
+      };
+
+      assert.strictEqual(fp.isEqualWith(customizer)('a', 'b'), true);
+      assert.strictEqual(fp.isEqualWith(customizer)(['a'], ['b']), true);
+      assert.strictEqual(fp.isEqualWith(customizer)({ '0': 'a' }, { '0': 'b' }), true);
+    });
+
+    QUnit.test('should not handle comparisons if `customizer` returns `false`', function(assert) {
+      assert.expect(3);
+
+      var customizer = function(value) {
+        return fp.isString(value) ? false : undefined;
+      };
+
+      assert.strictEqual(fp.isEqualWith(customizer)('a', 'a'), false);
+      assert.strictEqual(fp.isEqualWith(customizer)(['a'], ['a']), false);
+      assert.strictEqual(fp.isEqualWith(customizer)({ '0': 'a' }, { '0': 'a' }), false);
+    });
+  }());
+
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.config.asyncRetries = 10;
   QUnit.config.hidepassed = true;
 

--- a/test/test.js
+++ b/test/test.js
@@ -9519,11 +9519,15 @@
     });
 
     QUnit.test('should handle comparisons if `customizer` returns `undefined`', function(assert) {
-      assert.expect(3);
+      assert.expect(6);
 
       assert.strictEqual(_.isEqualWith('a', 'a', noop), true);
       assert.strictEqual(_.isEqualWith(['a'], ['a'], noop), true);
       assert.strictEqual(_.isEqualWith({ '0': 'a' }, { '0': 'a' }, noop), true);
+
+      assert.strictEqual(_.isEqualWith('a', 'b', noop), false);
+      assert.strictEqual(_.isEqualWith(['a'], ['b'], noop), false);
+      assert.strictEqual(_.isEqualWith({ '0': 'a' }, { '0': 'b' }, noop), false);
     });
 
     QUnit.test('should not handle comparisons if `customizer` returns `true`', function(assert) {


### PR DESCRIPTION
Here's the fix. It seems to work OK.

I wasn't sure how many tests you'd expect for an FP version of an existing operation (there aren't any tests for `fp.isMatchWith`), so I converted some of the basic ones from `test.js`.

Also, I was surprised that the original `lodash.isEqualWith` is tested for expected positive results, but not for expected negative results, so I added some additional tests there, too.