### PR TITLE
add opt-in githook to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 lodash.compat.min.js
 coverage
 node_modules
+.opt-in
+.opt-out

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "dojo": "^1.11.0",
     "ecstatic": "^1.4.0",
     "fs-extra": "~0.26.7",
+    "ghooks": "1.0.3",
     "glob": "^7.0.3",
     "istanbul": "0.4.2",
     "jquery": "^2.2.2",
     "jscs": "^2.11.0",
     "lodash": "4.5.0",
+    "opt-cli": "1.1.1",
     "platform": "^1.3.1",
     "qunit-extras": "^1.5.0",
     "qunitjs": "~1.22.0",
@@ -46,6 +48,12 @@
     "style:test": "jscs test/*.js test/**/*.js",
     "test": "npm run test:main && npm run test:fp",
     "test:fp": "node test/test-fp",
-    "test:main": "node test/test"
+    "test:main": "node test/test",
+    "validate": "npm run style & npm run test"
+  },
+  "config": {
+    "ghooks": {
+      "pre-push": "opt --in pre-push --exec \"npm run validate\""
+    }
   }
 }


### PR DESCRIPTION
**What**: Add `ghooks` and `opt-cli` to allow regular contributors to automatically run a `validate` script before committing.

**Why**: To help automate the process of regularly contributing code. However, because it's `opt-in` new contributors wont have a barrier to contributing.

**How**:

- Add `validate` script to run: `npm run build & npm run style & npm run test`
- Add `opt-cli` and `ghooks` as dependencies. `ghooks` auto-installs githooks when installed (backs up any previously installed githooks). These preinstalled githooks will run any hooks configured in the `package.json`. `opt-cli` will check for the existence of an `.opt-in`/`.opt-out` file and check the contents to determine whether the given command should be run. In this case, for the `pre-commit` githook to run the new `validate` script, you must have a `.opt-in` file with `pre-commit` in the contents.
- Add `.opt-in` and `.opt-out` to the `gitignore` so people can have their own preferences for whether githooks should be run (in this case only `opt --in` is implemented, so we really only need a `.opt-in` file, but I figured we could just add both and not worry about it in the future).

Happy to answer any questions about this! I feel that the real value add here is for regular contributors to automatically run this new `validate` script before committing to avoid the: "whoops, looks like I need to fix that and amend my commit"

We could also use `pre-push` if you want it run less.

Thoughts :thought_balloon:?