### PR TITLE
ensure all background jobs finish before continuing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "webpack": "^1.12.14"
   },
   "scripts": {
-    "build": "npm run build:main & npm run build:fp",
+    "build": "npm run build:main & npm run build:fp & wait",
     "build:fp": "node lib/fp/build-dist.js",
     "build:fp-modules": "node lib/fp/build-modules.js",
     "build:main": "node lib/main/build-dist.js",
@@ -41,7 +41,7 @@
     "doc:fp": "node lib/fp/build-doc",
     "doc:site": "node lib/main/build-doc site",
     "pretest": "npm run build",
-    "style": "npm run style:main & npm run style:fp & npm run style:perf & npm run style:test",
+    "style": "npm run style:main & npm run style:fp & npm run style:perf & npm run style:test & wait",
     "style:fp": "jscs fp/*.js lib/**/*.js",
     "style:main": "jscs lodash.js",
     "style:perf": "jscs perf/*.js perf/**/*.js",
@@ -49,7 +49,7 @@
     "test": "npm run test:main && npm run test:fp",
     "test:fp": "node test/test-fp",
     "test:main": "node test/test",
-    "validate": "npm run style & npm run test"
+    "validate": "npm run style & npm run test & wait"
   },
   "config": {
     "ghooks": {


### PR DESCRIPTION
Multiple scripts can be run in parallel by running all but one in the background. EG, `sleep 1` runs sleep in the foreground, `sleep 2 &` runs sleep in the background, and `sleep 2 & sleep 1` runs `sleep 2` in the background and `sleep 1` in the foreground (hence, in parallel). Currently in lodash, this is being utilized for scripts that can be run in parallel, but there is a racetime condition with the script being run in the foreground.

For example `echo 'sleeps beginning' && sleep 7 & sleep 1 && echo 'sleeps finished'` demonstrates this racetime condition where the process running in the foreground finishes before the process running with it in parallel in the background.

This is not demonstrating itself currently with the scripts employing background processes because the foreground process (the last piece of the script) happens to take longer. The place where you would see it would be with `npm test` which waits for `npm run build`. If `npm run build:fp` finishes before `npm run build:main`, the testing will begin with build:main incomplete.

Using `wait` solves this problem. Eg, `echo 'sleeps beginning' && sleep 7 & sleep 1 & wait && echo 'sleeps finished'`

```bash
cmartin:lodash martin$ time (echo 'sleeps beginning' && sleep 7 & sleep 1 & wait && echo 'sleeps finished')
sleeps beginning
sleeps finished

real	0m7.015s
user	0m0.003s
sys	0m0.006s
```

vs 

```bash
cmartin:lodash martin$ time (echo 'sleeps beginning' && sleep 7 & sleep 1 && echo 'sleeps finished')
sleeps beginning
sleeps finished

real	0m1.011s
user	0m0.001s
sys	0m0.004s
cmartin:lodash martin$ ps aux | grep sleep
martin         15895   0.0  0.0  2423356    196 s002  R+    2:03PM   0:00.00 grep sleep
martin         15893   0.0  0.0  2432752    512 s002  S     2:03PM   0:00.00 sleep 7
```