### PR TITLE
Simplify _.result

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -12539,9 +12539,9 @@
           index = length;
           value = defaultValue;
         }
-        object = value = isFunction(value) ? value.call(object) : value;
+        object = isFunction(value) ? value.call(object) : value;
       }
-      return value;
+      return object;
     }
 
     /**


### PR DESCRIPTION
Avoid an unneeded assignment.

It's possible that you are doing this on purpose because returning `value` feels more readable. But in the off-chance that this was just an oversight, I figured I'd propose the change.