### PR TITLE
Set the type of `apply`'s `args` parameter to `Array`

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -409,7 +409,7 @@
    * @private
    * @param {Function} func The function to invoke.
    * @param {*} thisArg The `this` binding of `func`.
-   * @param {...*} args The arguments to invoke `func` with.
+   * @param {Array} args The arguments to invoke `func` with.
    * @returns {*} Returns the result of `func`.
    */
   function apply(func, thisArg, args) {


### PR DESCRIPTION
Fixes #2187 