### PR TITLE
run scripts synchronous in foreground

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "webpack": "^1.12.14"
   },
   "scripts": {
-    "build": "npm run build:main & npm run build:fp & wait",
+    "build": "npm run build:main && npm run build:fp",
     "build:fp": "node lib/fp/build-dist.js",
     "build:fp-modules": "node lib/fp/build-modules.js",
     "build:main": "node lib/main/build-dist.js",
@@ -39,7 +39,7 @@
     "doc:fp": "node lib/fp/build-doc",
     "doc:site": "node lib/main/build-doc site",
     "pretest": "npm run build",
-    "style": "npm run style:main & npm run style:fp & npm run style:perf & npm run style:test & wait",
+    "style": "npm run style:main && npm run style:fp && npm run style:perf && npm run style:test",
     "style:fp": "jscs fp/*.js lib/**/*.js",
     "style:main": "jscs lodash.js",
     "style:perf": "jscs perf/*.js perf/**/*.js",
@@ -47,6 +47,6 @@
     "test": "npm run test:main && npm run test:fp",
     "test:fp": "node test/test-fp",
     "test:main": "node test/test",
-    "validate": "npm run style & npm run test & wait"
+    "validate": "npm run style && npm run test"
   }
 }


### PR DESCRIPTION
PR #2177 made the use of background scripts safer by introducing `wait` to ensure all background tasks finish before continuing, but there is still an issue with background scripts: `wait` doesn't return an exit code if one of the background scripts fails. EG,

```bash
cmartin:static martin$ echo 'start' && sleep 3 & exit 1 & sleep 2 & wait && echo 'end'     
[1] 34914
[2] 34915
[3] 34916
start
[1]   Done                    echo 'start' && sleep 3
[2]-  Exit 1                  exit 1
[3]+  Done                    sleep 2
end
```

This PR changes npm scripts back to using the synchronous `&&` which only continues if the previous command is successful. As it relates to the npm scripts, this will ensure that tests only will be run on a successful build, and that the validate git hook behaves correctly. Further, I'm not sure how you manage publishing, but if you do something like `npm run validate && node some_publish_script` this would prevent you from possibly publishing unsuccessfully built code and/or code not passing tests.

Feel free to close if you're comfortable with how it is now, or if you would rather introduce a [tool](https://github.com/mysticatea/npm-run-all) to still keep this parallel. Just wanted to bring it up :)