### PR TITLE
Test documentation with markdown-doctest

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -34,7 +34,7 @@ module.exports = {
 
     cwd: __dirname,
     mainText: '',
-    data: {user: 'Quinoa'},
+    data: {user: 'mock'},
 
     document: {
       body: {

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,4 +1,4 @@
-function noop () {}
+var _ = require(__dirname);
 
 function jQuery () {
   return {
@@ -14,23 +14,23 @@ jQuery.each = function (items, f) {
 
 module.exports = {
   globals: {
-    '_': require(__dirname),
+    '_': _,
 
-    asyncSave: noop,
-    addContactToList: noop,
-    calculateLayout: noop,
-    createApplication: noop,
-    updatePosition: noop,
-    sendMail: noop,
-    renewToken: noop,
-    batchLog: noop,
+    asyncSave: _.noop,
+    addContactToList: _.noop,
+    calculateLayout: _.noop,
+    createApplication: _.noop,
+    updatePosition: _.noop,
+    sendMail: _.noop,
+    renewToken: _.noop,
+    batchLog: _.noop,
 
     setImmediate: setImmediate,
     Buffer: Buffer,
     EventSource: function () {},
 
-    fs: {writeFileSync: noop},
-    path: {join: noop},
+    fs: {writeFileSync: _.noop},
+    path: {join: _.noop},
 
     cwd: __dirname,
     mainText: '',

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,0 +1,53 @@
+function noop () {}
+
+function jQuery () {
+  return {
+    on: function (ev, cb) {
+      cb()
+    }
+  }
+}
+
+jQuery.each = function (items, f) {
+  items.forEach(f)
+}
+
+module.exports = {
+  globals: {
+    '_': require(__dirname),
+
+    asyncSave: noop,
+    addContactToList: noop,
+    calculateLayout: noop,
+    createApplication: noop,
+    updatePosition: noop,
+    sendMail: noop,
+    renewToken: noop,
+    batchLog: noop,
+
+    setImmediate: setImmediate,
+    Buffer: Buffer,
+    EventSource: function () {},
+
+    fs: {writeFileSync: noop},
+    path: {join: noop},
+
+    cwd: __dirname,
+    mainText: '',
+    data: {user: 'Quinoa'},
+
+    document: {
+      body: {
+        childNodes: [],
+        nodeName: 'body'
+      }
+    },
+
+    jQuery: jQuery,
+
+    element: {},
+    window: {}
+  },
+
+  babel: false
+}

--- a/lodash.js
+++ b/lodash.js
@@ -13908,12 +13908,6 @@
      * compiled({ 'user': 'pebbles' });
      * // => 'hello pebbles!'
      *
-     * // Use custom template delimiters.
-     * _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
-     * var compiled = _.template('hello {{ user }}!');
-     * compiled({ 'user': 'mustache' });
-     * // => 'hello mustache!'
-     *
      * // Use backslashes to treat delimiters as plain text.
      * var compiled = _.template('<%= "\\<%- value %\\>" %>');
      * compiled({ 'value': 'ignored' });
@@ -13938,6 +13932,12 @@
      * //   __p += 'hi ' + ((__t = ( data.user )) == null ? '' : __t) + '!';
      * //   return __p;
      * // }
+     *
+     * // Use custom template delimiters.
+     * _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
+     * var compiled = _.template('hello {{ user }}!');
+     * compiled({ 'user': 'mustache' });
+     * // => 'hello mustache!'
      *
      * // Use the `source` property to inline compiled templates for meaningful
      * // line numbers in error messages and stack traces.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:fp-modules": "node lib/fp/build-modules.js",
     "build:main": "node lib/main/build-dist.js",
     "build:main-modules": "node lib/main/build-modules.js",
-    "doc": "node lib/main/build-doc github",
+    "doc": "node lib/main/build-doc github && npm run test:docs",
     "doc:fp": "node lib/fp/build-doc",
     "doc:site": "node lib/main/build-doc site",
     "pretest": "npm run build",
@@ -22,6 +22,7 @@
     "test": "npm run test:main && npm run test:fp",
     "test:fp": "node test/test-fp",
     "test:main": "node test/test",
+    "test:docs": "markdown-doctest",
     "validate": "npm run style && npm run test"
   },
   "devDependencies": {
@@ -40,6 +41,7 @@
     "jquery": "^2.2.3",
     "jscs": "^3.0.1",
     "lodash": "4.10.0",
+    "markdown-doctest": "^0.3.4",
     "platform": "^1.3.1",
     "qunit-extras": "^1.5.0",
     "qunitjs": "~1.23.1",


### PR DESCRIPTION
Hello!

I'm the author of [markdown-doctest](https://github.com/Widdershin/markdown-doctest). markdown-doctest runs all of the code examples present in your markdown files to ensure that they are runnable.

I have to congratulate you, as lodash is the first project I've ever integrated markdown-doctest with that didn't have any typos! It's also the first project where no examples needed to be skipped. 🎉 

I think it might still be useful as a means of detecting when the documentation needs to be updated because of breaking changes (and catching any future typos).

markdown-doctest currently tests the documentation of RxJS v5, most.js and xstream, among other libraries.

I'm aware that your examples are written in jsdoc and compiled to markdown, but it seems to work fine regardless.

In other projects I have set markdown-doctest to run after npm test (so that it would run as part of the CI build), but as it seems you regenerate your documentation manually it seems more appropriate in this case to run it after documentation generation as part of `npm run doc`. Perhaps we can also add it to the travis config.

Let me know what you think! I should note that if this pull request isn't for you, that's totally okay 😄. Your documentation is pretty flawless to begin with.

<img width="722" alt="screen shot 2016-04-29 at 10 29 07 am" src="https://cloud.githubusercontent.com/assets/398365/14911370/3caa0aa6-0df5-11e6-9750-6557299213ec.png">

