### PR TITLE
Remove duplicate method from FP mapping

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -64,7 +64,7 @@ exports.aryMethod = {
     'bindKey', 'chunk', 'cloneDeepWith', 'cloneWith', 'concat', 'countBy', 'curryN',
     'curryRightN', 'debounce', 'defaults', 'defaultsDeep', 'delay', 'difference',
     'divide', 'drop', 'dropRight', 'dropRightWhile', 'dropWhile', 'endsWith',
-    'eq', 'every', 'filter', 'find', 'find', 'findIndex', 'findKey', 'findLast',
+    'eq', 'every', 'filter', 'find', 'findIndex', 'findKey', 'findLast',
     'findLastIndex', 'findLastKey', 'flatMap', 'flatMapDeep', 'flattenDepth',
     'forEach', 'forEachRight', 'forIn', 'forInRight', 'forOwn', 'forOwnRight',
     'get', 'groupBy', 'gt', 'gte', 'has', 'hasIn', 'includes', 'indexOf',


### PR DESCRIPTION
`find` was present multiple times in the `aryMethod` section of the FP mapping.