### PR TITLE
Add `findIndexFrom` and `findLastIndexFrom` in FP.

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -84,12 +84,12 @@ exports.aryMethod = {
   ],
   '3': [
     'assignInWith', 'assignWith', 'clamp', 'differenceBy', 'differenceWith',
-    'findIndexFrom', 'findLastIndexFrom', 'getOr', 'inRange', 'intersectionBy',
-    'intersectionWith', 'invokeArgs', 'invokeArgsMap', 'isEqualWith', 'isMatchWith',
-    'flatMapDepth', 'mergeWith', 'orderBy', 'padChars', 'padCharsEnd', 'padCharsStart',
-    'pullAllBy', 'pullAllWith', 'reduce', 'reduceRight', 'replace', 'set', 'slice',
-    'sortedIndexBy', 'sortedLastIndexBy', 'transform', 'unionBy', 'unionWith',
-    'update', 'xorBy', 'xorWith', 'zipWith'
+    'findIndexFrom', 'findLastIndexFrom', 'getOr', 'indexOfFrom', 'inRange',
+    'intersectionBy', 'intersectionWith', 'invokeArgs', 'invokeArgsMap', 'isEqualWith',
+    'isMatchWith', 'flatMapDepth', 'lastIndexOfFrom', 'mergeWith', 'orderBy', 'padChars',
+    'padCharsEnd', 'padCharsStart', 'pullAllBy', 'pullAllWith', 'reduce', 'reduceRight',
+    'replace', 'set', 'slice', 'sortedIndexBy', 'sortedLastIndexBy', 'transform',
+    'unionBy', 'unionWith', 'update', 'xorBy', 'xorWith', 'zipWith'
   ],
   '4': [
     'fill', 'setWith', 'updateWith'
@@ -238,8 +238,10 @@ exports.remap = {
   'findIndexFrom': 'findIndex',
   'findLastIndexFrom': 'findLastIndex',
   'getOr': 'get',
+  'indexOfFrom': 'indexOf',
   'invokeArgs': 'invoke',
   'invokeArgsMap': 'invokeMap',
+  'lastIndexOfFrom': 'lastIndexOf',
   'padChars': 'pad',
   'padCharsEnd': 'padEnd',
   'padCharsStart': 'padStart',

--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -84,10 +84,10 @@ exports.aryMethod = {
   ],
   '3': [
     'assignInWith', 'assignWith', 'clamp', 'differenceBy', 'differenceWith',
-    'getOr', 'inRange', 'intersectionBy', 'intersectionWith', 'invokeArgs',
-    'invokeArgsMap', 'isEqualWith', 'isMatchWith', 'flatMapDepth', 'mergeWith',
-    'orderBy', 'padChars', 'padCharsEnd', 'padCharsStart', 'pullAllBy',
-    'pullAllWith', 'reduce', 'reduceRight', 'replace', 'set', 'slice',
+    'findIndexFrom', 'findLastIndexFrom', 'getOr', 'inRange', 'intersectionBy',
+    'intersectionWith', 'invokeArgs', 'invokeArgsMap', 'isEqualWith', 'isMatchWith',
+    'flatMapDepth', 'mergeWith', 'orderBy', 'padChars', 'padCharsEnd', 'padCharsStart',
+    'pullAllBy', 'pullAllWith', 'reduce', 'reduceRight', 'replace', 'set', 'slice',
     'sortedIndexBy', 'sortedLastIndexBy', 'transform', 'unionBy', 'unionWith',
     'update', 'xorBy', 'xorWith', 'zipWith'
   ],
@@ -235,6 +235,8 @@ exports.realToAlias = (function() {
 exports.remap = {
   'curryN': 'curry',
   'curryRightN': 'curryRight',
+  'findIndexFrom': 'findIndex',
+  'findLastIndexFrom': 'findLastIndex',
   'getOr': 'get',
   'invokeArgs': 'invoke',
   'invokeArgsMap': 'invokeMap',

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -1262,6 +1262,33 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('fp.indexOfFrom methods');
+
+  var indexOfTestCases = {
+    indexOfFrom: [
+      {fromIndex: 0, expected: 1},
+      {fromIndex: 2, expected: 3}
+    ],
+    lastIndexOfFrom: [
+      {fromIndex: -1, expected: 3},
+      {fromIndex: 2, expected: 1}
+    ]
+  };
+
+  _.each(indexOfTestCases, function(testCases, methodName) {
+    QUnit.test('`fp.' + methodName + '` should have an argument order of `value`, `fromIndex` then `array`', function(assert) {
+      assert.expect(testCases.length);
+
+      var array = [100, 0, 100, 0];
+
+      _.each(testCases, function(testCase) {
+        assert.deepEqual(fp[methodName](0)(testCase.fromIndex)(array), testCase.expected);
+      });
+    });
+  });
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('fp.inRange');
 
   (function() {

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -1097,6 +1097,47 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('fp.findIndexFrom methods');
+
+  var findIndexTestCases = {
+    findIndexFrom: [
+      {fromIndex: 0, expected: 1},
+      {fromIndex: 2, expected: 3}
+    ],
+    findLastIndexFrom: [
+      {fromIndex: -1, expected: 3},
+      {fromIndex: 2, expected: 1}
+    ]
+  };
+
+  _.each(findIndexTestCases, function(testCases, methodName) {
+    QUnit.test('`fp.' + methodName + '` should have an argument order of `predicate`, `fromIndex` then `array`', function(assert) {
+      assert.expect(testCases.length);
+
+      var array = [100, 0, 100, 0];
+
+      _.each(testCases, function(testCase) {
+        assert.deepEqual(fp[methodName](fp.eq(0))(testCase.fromIndex)(array), testCase.expected);
+      });
+    });
+
+    QUnit.test('`fp.' + methodName + '` should have its iteratee capped at 1 argument', function(assert) {
+      assert.expect(2);
+
+      var array = [100, 100];
+
+      var iteratee = function(value, index) {
+        assert.equal(value, 100);
+        assert.equal(index, undefined, 'iteratee is not capped');
+        return true;
+      };
+
+      fp[methodName](iteratee)(1)(array);
+    });
+  });
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('fp.flatMapDepth');
 
   (function() {


### PR DESCRIPTION
Add `findIndexFrom` and `findLastIndexFrom` in FP. Closes #2329

I've added tests to make sure the iteratee was capped, wasn't sure that it would take the capping of its alias method, so better safe than sorry. And I've tried to make the tests look like the rest (`_.each`-y), I hope it doesn't make them too hard to understand.