### PR TITLE
Added method _.categorize

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6134,6 +6134,33 @@
       }
       return result;
     }
+    
+    /**
+     * Creates an object with its element categorized according to the datatype.
+     *
+     * @static
+     * @category Array
+     * @param {Array} array The array to categorize.
+     * @returns {Object} Returns an Object with categorized data.
+     * @example
+     *
+     * _.categorize([1, "a", null, undefined, true, [1,2,3], { name: "Frank"}]);
+     * // => { number: [ 1 ], string: [ 'a' ], object: [ null, [ 1, 2, 3 ], { name: 'Frank' } ], undefined: [ undefined ],boolean: [ true ] }
+     */
+    function categorize(array) {
+      var index = -1,
+          length = array ? array.length : 0,
+          result = {};
+
+      while (++index < length) {
+        var value = array[index];
+        if (result[typeof array[index]] === undefined) {
+          result[typeof array[index]] = [];
+        }
+        result[typeof array[index]].push(array[index]);
+      }
+      return result;
+    }
 
     /**
      * Creates a new array concatenating `array` with any additional arrays

--- a/test/test.js
+++ b/test/test.js
@@ -3156,6 +3156,23 @@
 
   /*--------------------------------------------------------------------------*/
 
+    QUnit.module('lodash.categorize');
+
+    (function() {
+      QUnit.test('should categorize elements according to datatype', function(assert) {
+        assert.expect(2);
+
+        var array = [1, "a", null, undefined, true, [1,2,3], { name: "Frank"}],
+            actual = _.categorize(array);
+
+        assert.deepEqual(actual, { number: [ 1 ], string: [ 'a' ], object: [ null, [ 1, 2, 3 ], { name: 'Frank' } ], undefined: [ undefined ], boolean: [ true ] });
+        assert.notStrictEqual(actual, array);
+      });
+
+    }());
+
+    /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.concat');
 
   (function() {


### PR DESCRIPTION
This method categorizes an array with heterogeneous elements according to their datatypes.

`_.categorize([1, "a", null, undefined, true, [1,2,3], { name: "Frank"}])`

gives `{ number: [ 1 ], string: [ 'a' ], object: [ null, [ 1, 2, 3 ], { name: 'Frank' } ], undefined: [ undefined ],boolean: [ true ] }`
