### PR TITLE
Added _.defaultTo

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -62,7 +62,7 @@ exports.aryMethod = {
   '2': [
     'add', 'after', 'ary', 'assign', 'assignIn', 'at', 'before', 'bind', 'bindAll',
     'bindKey', 'chunk', 'cloneDeepWith', 'cloneWith', 'concat', 'countBy', 'curryN',
-    'curryRightN', 'debounce', 'defaults', 'defaultsDeep', 'delay', 'difference',
+    'curryRightN', 'debounce', 'defaults', 'defaultsDeep', 'defaultTo', 'delay', 'difference',
     'divide', 'drop', 'dropRight', 'dropRightWhile', 'dropWhile', 'endsWith',
     'eq', 'every', 'filter', 'find', 'findIndex', 'findKey', 'findLast',
     'findLastIndex', 'findLastKey', 'flatMap', 'flatMapDeep', 'flattenDepth',

--- a/lodash.js
+++ b/lodash.js
@@ -14699,6 +14699,28 @@
     }
 
     /**
+     * Returns a default value if the input is `undefined`.
+     *
+     * @static
+     * @memberOf _
+     * @since 4.13.2
+     * @category Util
+     * @param {*} input The value to be checked if it is `undefined`.
+     * @param {*} defaultValue The default value that gets returned if the input is `undefined`.
+     * @returns {*} Returns the input or if it's `undefined`, the default value.
+     * @example
+     *
+     * console.log(_.defaultTo(undefined, 10));
+     * // => 10
+     *
+     * console.log(_.defaultTo([1,2,3,], 10));
+     * // => [1,2,3,]
+     */
+    function defaultTo(input, defaultValue) {
+      return input === undefined ? defaultValue : input;
+    }
+
+    /**
      * Creates a function that returns the result of invoking the given functions
      * with the `this` binding of the created function, where each successive
      * invocation is supplied the return value of the previous.
@@ -15972,6 +15994,7 @@
     lodash.cloneDeepWith = cloneDeepWith;
     lodash.cloneWith = cloneWith;
     lodash.deburr = deburr;
+    lodash.defaultTo = defaultTo;
     lodash.divide = divide;
     lodash.endsWith = endsWith;
     lodash.eq = eq;

--- a/lodash.js
+++ b/lodash.js
@@ -14713,11 +14713,17 @@
      * console.log(_.defaultTo(undefined, 10));
      * // => 10
      *
-     * console.log(_.defaultTo([1,2,3,], 10));
-     * // => [1,2,3,]
+     * // Inside flow (FP only)
+     * var findOrDefault = _.flow([
+     *   _.find(function(number) { number > 5; }),
+     *   _.defaultTo(0)
+     * ]);
+     *
+     * findOrDefault([1,2,3]);
+     * // => 0
      */
-    function defaultTo(input, defaultValue) {
-      return input === undefined ? defaultValue : input;
+    function defaultTo(value, defaultValue) {
+      return value === undefined ? defaultValue : value;
     }
 
     /**

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -837,16 +837,33 @@
 
   (function() {
     QUnit.test('should return a default value if input is undefined', function(assert) {
+      assert.expect(4);
+
+      // default (inverse params)
+      var actual = fp.defaultTo(0, fp.find(function(a) { return a > 1; }, [1,2,3]));
+      assert.deepEqual(actual, 2);
+
+      var actual = fp.defaultTo(0, fp.find(function(a) { return a > 5; }, [1,2,3]));
+      assert.deepEqual(actual, 0);
+
+      // curried
+      var actual = fp.defaultTo(0)(fp.find(function(a) { return a > 1; })([1,2,3]));
+      assert.deepEqual(actual, 2);
+
+      var actual = fp.defaultTo(0)(fp.find(function(a) { return a > 5; })([1,2,3]));
+      assert.deepEqual(actual, 0);
+    });
+
+    QUnit.test('should work in a flow', function(assert) {
       assert.expect(2);
 
-      var actual = fp.defaultTo(0)(undefined);
-      assert.deepEqual(actual, 0);
-
-      var actual = fp.flow(
-        fp.find(function(a) { return a > 5; }),
+      var actual = fp.flow([
+        fp.find(function(a) { return a > 3 }),
         fp.defaultTo(0)
-      )([1,2,3,4,5]);
-      assert.deepEqual(actual, 0);
+      ]);
+
+      assert.deepEqual(actual([1,2,3]), 0);
+      assert.deepEqual(actual([3,4,5]), 4);
     });
   }());
 

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -833,6 +833,25 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('fp.defaultTo');
+
+  (function() {
+    QUnit.test('should return a default value if input is undefined', function(assert) {
+      assert.expect(2);
+
+      var actual = fp.defaultTo(0)(undefined);
+      assert.deepEqual(actual, 0);
+
+      var actual = fp.flow(
+        fp.find(function(a) { return a > 5; }),
+        fp.defaultTo(0)
+      )([1,2,3,4,5]);
+      assert.deepEqual(actual, 0);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('fp.difference');
 
   (function() {

--- a/test/test.js
+++ b/test/test.js
@@ -4601,6 +4601,26 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.defaultTo');
+
+  (function() {
+    QUnit.test('should return a default value if the input is undefined', function(assert) {
+      assert.expect(2);
+
+      assert.strictEqual(_.defaultTo(undefined, 0), 0);
+      assert.strictEqual(_.defaultTo(undefined, ''), '');
+    });
+
+    QUnit.test('should return the input if it is not undefined', function(assert) {
+      assert.expect(2);
+
+      assert.strictEqual(_.defaultTo(1, 0), 1);
+      assert.strictEqual(_.defaultTo('string', ''), 'string');
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.defer');
 
   (function() {
@@ -26246,6 +26266,7 @@
       'ceil',
       'clone',
       'deburr',
+      'defaultTo',
       'divide',
       'endsWith',
       'escape',
@@ -26576,7 +26597,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(314);
+      assert.expect(315);
 
       var arrays = lodashStable.map(falsey, stubArray);
 

--- a/test/test.js
+++ b/test/test.js
@@ -4605,17 +4605,14 @@
 
   (function() {
     QUnit.test('should return a default value if the input is undefined', function(assert) {
-      assert.expect(2);
-
-      assert.strictEqual(_.defaultTo(undefined, 0), 0);
-      assert.strictEqual(_.defaultTo(undefined, ''), '');
-    });
-
-    QUnit.test('should return the input if it is not undefined', function(assert) {
-      assert.expect(2);
+      assert.expect(3);
 
       assert.strictEqual(_.defaultTo(1, 0), 1);
-      assert.strictEqual(_.defaultTo('string', ''), 'string');
+      assert.strictEqual(_.defaultTo(undefined, 0), 0);
+
+      var actual = _.defaultTo(_.find([1,2,3], function(n) { return n > 5; }), 0);
+
+      assert.strictEqual(actual, 0);
     });
   }());
 


### PR DESCRIPTION
Added method `_.defaultTo` discussed in #2375 and some tests in both `test.js` and `test-fp.js`.

In vanilla lodash it works like this
```javascript
_.defaultTo(undefined, 0)
// => 0

_.defaultTo(10, 0)
// => 10
```
Does **NOT** support chaining `_([1,2,3]).find(n => n > 5).defaultTo(0)` since `find` returns `undefined` (and tbh I don't know how to invoke `defaultTo` in this case)

In FP, it has the parameters inverted, there's also a curried version and can be used inside `fp.flow`
```javascript
fp.defaultTo(0, undefined)
// => 0

fp.defaultTo(0)(undefined)
// => 10

fp.flow([
  fp.find(n => n > 5),
  fp.defaultTo(0)
])([1, 2, 3])
// => 0
```