### PR TITLE
debounce: has delayed invocation

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9687,12 +9687,14 @@
         timerId = setTimeout(timerExpired, remainingWait(time));
       }
 
+      function hasDelayedInvocation() {
+        return trailing && !!lastArgs;
+      }
+
       function trailingEdge(time) {
         timerId = undefined;
 
-        // Only invoke if we have `lastArgs` which means `func` has been
-        // debounced at least once.
-        if (trailing && lastArgs) {
+        if (hasDelayedInvocation()) {
           return invokeFunc(time);
         }
         lastArgs = lastThis = undefined;
@@ -9733,6 +9735,7 @@
       }
       debounced.cancel = cancel;
       debounced.flush = flush;
+      debounced.hasDelayedInvocation = hasDelayedInvocation;
       return debounced;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -4391,6 +4391,28 @@
         done();
       }, 64);
     });
+
+    QUnit.test('should have a hasDelayedInvocation function', function(assert) {
+      assert.expect(4);
+
+      var done = assert.async();
+
+      var callCount = 0;
+
+      var debounced = _.debounce(function() {
+        ++callCount;
+      }, 32);
+
+      assert.strictEqual(debounced.hasDelayedInvocation(), false);
+      debounced();
+      assert.strictEqual(debounced.hasDelayedInvocation(), true);
+
+      setTimeout(function() {
+        assert.strictEqual(callCount, 1);
+        assert.strictEqual(debounced.hasDelayedInvocation(), false);
+        done()
+      }, 128);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Usage:

I have an app where the user can edit and I am autosaving in the background (similar to google docs). I am using debounce to save 5 seconds after the last edit or every 15 seconds. I need to issue a warning to the use when they try to close the browser if they have unsaved changes. 

---

Open to changing the name. I had also thought about canCancel / canFlush / cancelable / flushable. Maybe something that includes the word trailing?