### PR TITLE
Useless export default rename

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -326,4 +326,4 @@ export { default as zip } from './zip.js';
 export { default as zipObject } from './zipObject.js';
 export { default as zipObjectDeep } from './zipObjectDeep.js';
 export { default as zipWith } from './zipWith.js';
-export { default as default } from './lodash.default.js';
+export default './lodash.default.js';


### PR DESCRIPTION
Eslint says: `Export default unnecessarily renamed.`