### PR TITLE
Fixed display of transforms param in overArgs docs.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -10114,7 +10114,7 @@
      * @memberOf _
      * @category Function
      * @param {Function} func The function to wrap.
-     * @param {...(Function|Function[])} [transforms[_.identity]]
+     * @param {...(Function|Function[])} [transforms=[_.identity]]
      *  The argument transforms.
      * @returns {Function} Returns the new function.
      * @example


### PR DESCRIPTION
There is currently a small bug in the documentation for `_.overArgs` that prevents the information about the `transforms` parameters from being displayed.

<img width="666" alt="screen shot 2016-06-15 at 8 56 34 pm" src="https://cloud.githubusercontent.com/assets/7499938/16100817/a2118b9c-333b-11e6-8084-8cac94b57656.png">

This PR should fix that.