### PR TITLE
Add sortedFindBy and sortedLastFindBy functions

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -7475,6 +7475,43 @@
     }
 
     /**
+     * This method is like '_.sortedIndexOf' except that it accepts `iteratee`
+     * which is invoked for `value` and each element of `array` to compute their
+     # sort ranking. The iteratee is invoked with one argument: (value).
+     *
+     * @static
+     * @memberOf _
+     * @since 4.0.0
+     * @category Array
+     * @param {Array} array The sorted array to inspect.
+     * @param {*} value The value to search for.
+     * @param {Function} [iteratee=_.identity]
+     *  The iteratee invoked per element.
+     * @returns {number} Returns the index of the matched value, else `-1`.
+     * @example
+     *
+     * var objects = [{ 'x': 4 }, { 'x': 5 }];
+     *
+     * _.sortedFindBy(objects, { 'x': 4 }, function(o) { return o.x; });
+     * // => 0
+     *
+     * // The `_.property` iteratee shorthand.
+     * _.sortedFindBy(objects, { 'x': 4 }, 'x');
+     * // => 0
+     */
+    function sortedFindBy(array, value, iteratee) {
+      value = iteratee(value);
+      var length = array ? array.length : 0;
+      if (length) {
+        var index = baseSortedIndex(array, value);
+        if (index < length && eq(array[index], value)) {
+          return index;
+        }
+      }
+      return -1;
+    }
+
+    /**
      * This method is like `_.sortedIndex` except that it returns the highest
      * index at which `value` should be inserted into `array` in order to
      * maintain its sort order.
@@ -7543,6 +7580,43 @@
      * // => 3
      */
     function sortedLastIndexOf(array, value) {
+      var length = array ? array.length : 0;
+      if (length) {
+        var index = baseSortedIndex(array, value, true) - 1;
+        if (eq(array[index], value)) {
+          return index;
+        }
+      }
+      return -1;
+    }
+
+    /**
+     * This method is like '_.sortedLastIndexOf' except that it accepts `iteratee`
+     * which is invoked for `value` and each element of `array` to compute their
+     # sort ranking. The iteratee is invoked with one argument: (value).
+     *
+     * @static
+     * @memberOf _
+     * @since 4.0.0
+     * @category Array
+     * @param {Array} array The sorted array to inspect.
+     * @param {*} value The value to search for.
+     * @param {Function} [iteratee=_.identity]
+     *  The iteratee invoked per element.
+     * @returns {number} Returns the index of the matched value, else `-1`.
+     * @example
+     *
+     * var objects = [{ 'x': 4 }, { 'x': 4 }, { 'x': 5 }];
+     *
+     * _.sortedLastFindBy(objects, { 'x': 4 }, function(o) { return o.x; });
+     * // => 1
+     *
+     * // The `_.property` iteratee shorthand.
+     * _.sortedLastFindBy(objects, { 'x': 4 }, 'x');
+     * // => 0
+     */
+    function sortedLastFindBy(array, value, iteratee) {
+      value = iteratee(value);
       var length = array ? array.length : 0;
       if (length) {
         var index = baseSortedIndex(array, value, true) - 1;

--- a/test/test.js
+++ b/test/test.js
@@ -12840,6 +12840,21 @@
       }
     });
 
+    QUnit.test('`_.sortedFindBy` should use `_.iteratee` internally', function(assert) {
+      assert.expect(1);
+
+      if (!isModularize) {
+        var objects = [{ 'a': 40 }, { 'a': 50 }];
+
+        _.iteratee = getPropA;
+        assert.strictEqual(_.sortedFindBy(objects, { 'a': 40 }), 0);
+        _.iteratee = iteratee;
+      }
+      else {
+        skipAssert(assert);
+      }
+    });
+
     QUnit.test('`_.sortedLastIndexBy` should use `_.iteratee` internally', function(assert) {
       assert.expect(1);
 
@@ -12848,6 +12863,21 @@
 
         _.iteratee = getPropA;
         assert.strictEqual(_.sortedLastIndexBy(objects, { 'a': 40 }), 1);
+        _.iteratee = iteratee;
+      }
+      else {
+        skipAssert(assert);
+      }
+    });
+
+    QUnit.test('`_.sortedLastFindBy` should use `_.iteratee` internally', function(assert) {
+      assert.expect(1);
+
+      if (!isModularize) {
+        var objects = [{ 'a': 40 }, { 'a': 50 }];
+
+        _.iteratee = getPropA;
+        assert.strictEqual(_.sortedLastFindBy(objects, { 'a': 40 }), 1);
         _.iteratee = iteratee;
       }
       else {
@@ -20933,6 +20963,69 @@
 
       var sorted = [4, 4, 5, 5, 6, 6];
       assert.deepEqual(func(sorted, 5), isSortedIndexOf ? 2 : 3);
+    });
+  });
+
+  /*--------------------------------------------------------------------------*/
+
+  QUnit.module('sortedFindBy methods');
+
+  lodashStable.each(['sortedFindBy', 'sortedLastFindBy'], function(methodName) {
+    var func = _[methodName],
+        isSortedFindBy = methodName == 'sortedFindBy';
+
+    QUnit.test('`_.' + methodName + '` should provide correct `iteratee` arguments', function(assert) {
+      assert.expect(1);
+
+      var args;
+
+      func([40, 50], 40, function(assert) {
+        args || (args = slice.call(arguments));
+      });
+
+      assert.deepEqual(args, [40]);
+    });
+
+    QUnit.test('`_.' + methodName + '` should work with `_.property` shorthands', function(assert) {
+      assert.expect(1);
+
+      var objects = [{ 'x': 40 }, { 'x': 50 }],
+          actual = func(objects, { 'x': 40 }, 'x');
+
+      assert.strictEqual(actual, 1);
+    });
+
+    QUnit.test('`_.' + methodName + '` should support arrays larger than `MAX_ARRAY_LENGTH / 2`', function(assert) {
+      assert.expect(12);
+
+      lodashStable.each([Math.ceil(MAX_ARRAY_LENGTH / 2), MAX_ARRAY_LENGTH], function(length) {
+        var array = [],
+            values = [MAX_ARRAY_LENGTH, NaN, undefined];
+
+        array.length = length;
+
+        lodashStable.each(values, function(value) {
+          var steps = 0;
+
+          var actual = func(array, value, function(value) {
+            steps++;
+            return value;
+          });
+
+          var expected = (isSortedFindBy ? !lodashStable.isNaN(value) : lodashStable.isFinite(value))
+            ? 0
+            : Math.min(length, MAX_ARRAY_INDEX);
+
+          // Avoid false fails in older Firefox.
+          if (array.length == length) {
+            assert.ok(steps == 32 || steps == 33);
+            assert.strictEqual(actual, expected);
+          }
+          else {
+            skipAssert(assert, 2);
+          }
+        });
+      });
     });
   });
 


### PR DESCRIPTION
There's a pair of functions to search for a minimum index to insert an element while keeping array sorted - `sortedIndex` and `sortedIndexBy`. When it comes to checking whether element is in the array and returning its index when it is, there's no function that accepts an iteratee, just a lonely `sortedIndexOf`. It would be only logical to have `sortedIndexOfBy` or perhaps better named `sortedFindBy`. I also implemented `sortedLastFindBy`, to complement `sortedLastIndex` and `sortedLastIndexBy`.
