### PR TITLE
Formalize which value is picked by _.unionBy and _.unionWith 

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -7789,7 +7789,9 @@
     /**
      * This method is like `_.union` except that it accepts `iteratee` which is
      * invoked for each element of each `arrays` to generate the criterion by
-     * which uniqueness is computed. The iteratee is invoked with one argument:
+     * which uniqueness is computed. Result values are chosen from
+     * the first array in which the value occurs.
+     * The iteratee is invoked with one argument:
      * (value).
      *
      * @static
@@ -7819,7 +7821,8 @@
 
     /**
      * This method is like `_.union` except that it accepts `comparator` which
-     * is invoked to compare elements of `arrays`. The comparator is invoked
+     * is invoked to compare elements of `arrays`. Result values are chosen from
+     * the first array in which the value occurs. The comparator is invoked
      * with two arguments: (arrVal, othVal).
      *
      * @static

--- a/test/test.js
+++ b/test/test.js
@@ -24541,6 +24541,14 @@
 
       assert.deepEqual(args, [2.1]);
     });
+
+    QUnit.test('should output values from the first possible array', function(assert) {
+      assert.expect(1);
+
+      var actual = _.unionBy([{ 'x': 1, 'y': 1 }], [{ 'x': 1, 'y': 2 }], 'x');
+
+      assert.deepEqual(actual, [{ 'x': 1, 'y': 1 }]);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/
@@ -24556,6 +24564,18 @@
           actual = _.unionWith(objects, others, lodashStable.isEqual);
 
       assert.deepEqual(actual, [objects[0], objects[1], others[0]]);
+    });
+
+    QUnit.test('should output values from the first possible array', function(assert) {
+      assert.expect(1);
+
+      var objects = [{ 'x': 1, 'y': 1 }]
+      var others = [{ 'x': 1, 'y': 2 }]
+      var actual = _.unionWith(objects, others, function (a, b) {
+        return a.x === b.x;
+      });
+
+      assert.deepEqual(actual, [{x: 1, y: 1}]);
     });
   }());
 


### PR DESCRIPTION
Formalize which value is picked by `_.unionBy` and `_.unionWith` to pick the result from the first array in which it occurs.

This is the way that the library has always worked - this simply adds that information to the tests and docs. This information is explicitly documented for `_.intersection*`.