### PR TITLE
Fix reference to second param of _.invokeMap in doc description.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8921,7 +8921,7 @@
     /**
      * Invokes the method at `path` of each element in `collection`, returning
      * an array of the results of each invoked method. Any additional arguments
-     * are provided to each invoked method. If `methodName` is a function, it's
+     * are provided to each invoked method. If `path` is a function, it's
      * invoked for and `this` bound to, each element in `collection`.
      *
      * @static


### PR DESCRIPTION
Commit 0aef5155220ef4c6d7aad84cdfe441dd51b4265a changed the name of the second parameter of what is now `_.invokeMap` from `methodName` to `path`.

It is currently referred to as `path` on lines 8922 and 8932 of the docs, but on line 8924 it is still referred to as `methodName`.

This PR replaces the remaining use of `methodName` with `path`. 