### PR TITLE
Added _.chunkBy

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6321,6 +6321,59 @@
     }
 
     /**
+     * Creates an array of elements split into groups based on the result of
+     * `iteratee`. Consecutive elements that return the same value will be
+     * placed in the same group. The iteratee is invoked with one argument:
+     * (value).
+     *
+     * @static
+     * @memberOf _
+     * @since 4.15.0
+     * @category Array
+     * @param {Array} array The array to process.
+     * @param {Function} [iteratee=_.identity] The iteratee invoked per element.
+     * @returns {Array} Returns the new array of chunks.
+     * @example
+     *
+     * var users = [
+     *   { 'user': 'barney',  'age': 36, 'active': true },
+     *   { 'user': 'fred',    'age': 40, 'active': false },
+     *   { 'user': 'pebbles', 'age': 1,  'active': false }
+     * ];
+     *
+     * _.chunkBy(users, function(o) { return o.age > 30; });
+     * // => objects for [['barney', 'fred'], ['pebbles']]
+     *
+     * // The `_.property` iteratee shorthand.
+     * _.chunkBy(users, 'active');
+     * // => objects for [['barney'], ['fred', 'pebbles']]
+     */
+    function chunkBy(array, iteratee, guard) {
+      var length = array ? array.length : 0;
+      if (!length) {
+        return [];
+      }
+      var index = 1,
+          newIteratee = getIteratee(iteratee),
+          firstElement = array[0],
+          currentValue = newIteratee(firstElement),
+          result = [[firstElement]];
+
+      while (index < length) {
+        var nextElement = array[index],
+            nextValue = newIteratee(nextElement);
+        if (baseIsEqual(currentValue, nextValue)) {
+          last(result).push(nextElement);
+        } else {
+          currentValue = nextValue;
+          result.push([nextElement]);
+        }
+        index++;
+      }
+      return result;
+    }
+
+    /**
      * Creates an array with all falsey values removed. The values `false`, `null`,
      * `0`, `""`, `undefined`, and `NaN` are falsey.
      *
@@ -16008,6 +16061,7 @@
     lodash.castArray = castArray;
     lodash.chain = chain;
     lodash.chunk = chunk;
+    lodash.chunkBy = chunkBy;
     lodash.compact = compact;
     lodash.concat = concat;
     lodash.cond = cond;

--- a/test/test.js
+++ b/test/test.js
@@ -2567,6 +2567,35 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.chunkBy');
+
+  (function() {
+    QUnit.test('should return chunked arrays', function(assert) {
+      assert.expect(1);
+
+      var actual = _.chunkBy([8, 2, 4, 1, 3, 5], function(value) {
+        return value % 2;
+      });
+      assert.deepEqual(actual, [[8, 2, 4], [1, 3, 5]]);
+    });
+
+    QUnit.test('should use `_.identity` when `iteratee` is `undefined`', function(assert) {
+      assert.expect(1);
+
+      var actual = _.chunkBy(['a', 'a', 'b', 'c', 'c']);
+      assert.deepEqual(actual, [['a', 'a'], ['b'], ['c', 'c']]);
+    });
+
+    QUnit.test('should work with `_.property` shorthands', function(assert) {
+      assert.expect(1);
+
+      var actual = _.chunkBy(['one', 'two', 'three'], 'length');
+      assert.deepEqual(actual, [['one', 'two'], ['three']]);
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.clamp');
 
   (function() {
@@ -26629,6 +26658,7 @@
     var returnArrays = [
       'at',
       'chunk',
+      'chunkBy',
       'compact',
       'difference',
       'drop',
@@ -26667,7 +26697,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(316);
+      assert.expect(318);
 
       var arrays = lodashStable.map(falsey, stubArray);
 
@@ -26705,7 +26735,7 @@
     });
 
     QUnit.test('should return an array', function(assert) {
-      assert.expect(70);
+      assert.expect(72);
 
       var array = [1, 2, 3];
 


### PR DESCRIPTION
As requested in #1379, #1700, #1962.

I was also thinking about generalizing `_.chunk` to take an iteratee as an argument. Honestly I think either way would work fine.