### PR TITLE
Clarify _.sumBy iterating behaviour when using arrays and objects

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14980,10 +14980,16 @@
 
     /**
      * Creates a function that invokes `func` with the arguments of the created
-     * function. If `func` is a property name, the created function returns the
-     * property value for a given element. If `func` is an array or object, the
-     * created function returns `true` for elements that contain the equivalent
-     * source properties, otherwise it returns `false`.
+     * function.
+     * 
+     * If `func` is a property name, the created function returns the property
+     * value for a given element.
+     * 
+     * If `func` is an object, the created function returns `true` for elements
+     * that contain the equivalent source properties, otherwise it returns `false`.
+     * 
+     * If `func` is an array, the first two elements are passed as arguments to
+     * `_.matchesProperty`, and the resulting callback is returned.
      *
      * @static
      * @since 4.0.0
@@ -15980,6 +15986,9 @@
      * This method is like `_.sum` except that it accepts `iteratee` which is
      * invoked for each element in `array` to generate the value to be summed.
      * The iteratee is invoked with one argument: (value).
+     * 
+     * If an object or array is provided as the iteratee, the number of matches
+     * is returned. See `_.iteratee` for the default matching behaviour.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
The current `_.sumBy` behaviour with arrays and objects is not at all clear. I'm currently trying to fix up Lodash's type definitions for DefinitelyTyped, and I'm struggling to even work out what types are really valid, let alone how to use it.

After a little digging I think I've worked out how it works, so I've added details to iteratee explaining its behaviour generally, and a reference to that in `_.sumBy` explaining how that's used here.

I do think the array behaviour here (and probably everywhere that uses `_.iteratee`) is really kind of weird and surprising. For now, just documenting it seems best, but it might be worth considering future changes to that.