### PR TITLE
closest() method implemented to find closest number in array

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6335,6 +6335,32 @@
       return result;
     }
 
+    /*
+     * Finds closest number inside input collection.
+     * @param num {number} - required digit
+     * @param arr {array} - input set of digits
+     * @returns {number} - closest item
+     */
+    function closest(num, arr) {
+
+      if (!num || !arr || isNaN(num) || arr.constructor !== Array) {
+        return null;
+      }
+
+      var element = arr[0];
+      var difference = Math.abs(num - element);
+      var len = arr.length;
+      for (var i = 0; i < len; i++) {
+        var newDifference = Math.abs (num - arr[i]);
+        if (newDifference < difference) {
+          difference = newDifference;
+          element = arr[i];
+        }
+      }
+      return element;
+
+    }
+
     /**
      * Creates an array with all falsey values removed. The values `false`, `null`,
      * `0`, `""`, `undefined`, and `NaN` are falsey.
@@ -16015,6 +16041,7 @@
     lodash.castArray = castArray;
     lodash.chain = chain;
     lodash.chunk = chunk;
+    lodash.closest = closest;
     lodash.compact = compact;
     lodash.concat = concat;
     lodash.cond = cond;

--- a/test/test.js
+++ b/test/test.js
@@ -2567,6 +2567,31 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.closest');
+
+  (function() {
+
+    var collection = [43,54,65,3,4,4,232,11], target = 9, failedParam = undefined;
+
+    QUnit.test('should return closest number from array', function(assert) {
+      assert.expect(2);
+
+      var result = _.closest(target, collection);
+      assert.ok(result, "Returned result is not null.");
+      assert.equal(result, 11, "Result is a number.");
+    });
+    QUnit.test('should return null when first argument is not a number or seconde one is not an array of numbers', function(assert) {
+      assert.expect(2);
+
+      var numberFailed = _.closest(failedParam, collection);
+      var arrayFailed = _.closest(target, failedParam);
+      assert.equal(numberFailed, failedParam, "Failed due to the first argument is not a number.");
+      assert.equal(arrayFailed, failedParam, "Failed due to the second argument argument is not an array of numbers.");
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.clamp');
 
   (function() {
@@ -26393,7 +26418,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(316);
+      assert.expect(317);
 
       var arrays = lodashStable.map(falsey, stubArray);
 


### PR DESCRIPTION
```js
// Mock.
var collection = [0.12344, 0.12341, 0.12340], number = 0.12342;
```

```js
// Using "closest()" method, where 1st argument is a number, the 2nd one - an array of numbers
var result1 = _.closest(number, collection);   // will return a number '0.12341'
```

```js
// Arguments validation.
// If the first argument is not a number or the 2nd one is not an array, will be returned 'null'.
var result2 = _.closest("text", collection);   //null
var result3 = _.closest(number, 10);   //null
```