### PR TITLE
Fix missing semicolon

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5863,7 +5863,7 @@
      */
     function isFlattenable(value) {
       return isArray(value) || isArguments(value) ||
-        !!(spreadableSymbol && value && value[spreadableSymbol])
+        !!(spreadableSymbol && value && value[spreadableSymbol]);
     }
 
     /**


### PR DESCRIPTION
I started on a documentation change but `npm run validate` after my initial pull revealed this linting error:

```
> jscs lodash.js

requireSemicolons: Missing semicolon after statement at lodash.js :
  5864 |    function isFlattenable(value) {
  5865 |      return isArray(value) || isArguments(value) ||
  5866 |        !!(spreadableSymbol && value && value[spreadableSymbol])
-----------------------------------------------------------------------^
  5867 |    }
  5868 |
```