### PR TITLE
Clarify empty source comparisons with _.matches, _.isMatch and _.matchesProperty.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -11344,8 +11344,9 @@
      * Performs a partial deep comparison between `object` and `source` to
      * determine if `object` contains equivalent property values.
      *
-     * **Note:** This method supports comparing the same values as `_.isEqual`
-     * and is equivalent to `_.matches` when `source` is partially applied.
+     * **Note:** If source is empty, this method returns true. Otherwise, it supports
+     * comparing the same values as `_.isEqual` and is equivalent to `_.matches`
+     * when `source` is partially applied.
      *
      * @static
      * @memberOf _
@@ -15060,8 +15061,9 @@
      * object and `source`, returning `true` if the given object has equivalent
      * property values, else `false`.
      *
-     * **Note:** The created function supports comparing the same values as
-     * `_.isEqual` is equivalent to `_.isMatch` with `source` partially applied.
+     * **Note:** If source is empty, the created function returns true. Otherwise
+     * it supports comparing the same values as `_.isEqual` and is equivalent to
+     * `_.isMatch` with `source` partially applied.
      *
      * @static
      * @memberOf _
@@ -15088,7 +15090,8 @@
      * value at `path` of a given object to `srcValue`, returning `true` if the
      * object value is equivalent, else `false`.
      *
-     * **Note:** This method supports comparing the same values as `_.isEqual`.
+     * **Note:** If `srcValue` is an empty object, this method returns true. Otherwise,
+     * it supports comparing the same values as `_.isEqual`.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
In the below code, that all the `falseMatches` are `false` is intuitive. However, it is much less intuitive that all the `trueMatches` are `true`.

```
var _ = require('lodash');
var assert = require('assert');

var objectToMatch = {a: {b: 2}};

var falseMatches = [
	_.isMatch(objectToMatch, {a: {d: null}}),
	_.matchesProperty('a', null)(objectToMatch),
	_.matchesProperty('a', [])(objectToMatch),
	_.matches({b: null})(objectToMatch)
];

assert.deepEqual(falseMatches, [false, false, false, false]);

var trueMatches = [
	_.isMatch(objectToMatch, {a: {}}),
	_.matchesProperty('a', {})(objectToMatch),
	_.matches(undefined)(objectToMatch),
	_.matches({})(objectToMatch)
];

assert.deepEqual(trueMatches, [true, true, true, true]);
```

A good explanation for the `trueMatches` was made here: https://github.com/lodash/lodash/issues/999#issuecomment-76028607.

This PR attempts to make this behavior obvious when reading the documentation.