### PR TITLE
Update _.chunk to better leverage immutability and ES6 constructs

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6813,26 +6813,14 @@
      * _.chunk(['a', 'b', 'c', 'd'], 3);
      * // => [['a', 'b', 'c'], ['d']]
      */
-    function chunk(array, size, guard) {
-      if ((guard ? isIterateeCall(array, size, guard) : size === undefined)) {
-        size = 1;
-      } else {
-        size = nativeMax(toInteger(size), 0);
-      }
-      var length = array == null ? 0 : array.length;
-      if (!length || size < 1) {
-        return [];
-      }
-      var index = 0,
-          resIndex = 0,
-          result = Array(nativeCeil(length / size));
-
-      while (index < length) {
-        result[resIndex++] = baseSlice(array, index, (index += size));
-      }
-      return result;
-    }
-
+     function chunk(array, size) {
+       return array.reduce((accum, next, i) => {
+         const intI = Math.floor(i / size)
+         return Object.assign([], accum, {
+           [intI] : [...accum[intI], next]
+         })
+       }, Array(Math.ceil(array.length / size)).fill([]))
+     }
     /**
      * Creates an array with all falsey values removed. The values `false`, `null`,
      * `0`, `""`, `undefined`, and `NaN` are falsey.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "main": "lodash.js",
-  "engines": { "node": ">=4.0.0" },
+  "engines": { "node": ">=6.0.0" },
   "scripts": {
     "build": "npm run build:main && npm run build:fp",
     "build:fp": "node lib/fp/build-dist.js",


### PR DESCRIPTION
This version of chunk does not require the `guard` parameter and better utilizes ES6 constructs to chunk arrays. I think this style is easier to reason with (and looks prettier 👍). 
However this does require ES6, so that is why I bumped the node engine up to >=v6.0.0. 

If you want to make a new branch for rewriting many of the functions in ES6/7, I can begin updating other functions as well. 