### PR TITLE
Fix freeProcess.binding(util) usage

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -432,7 +432,7 @@
   /** Used to access faster Node.js helpers. */
   var nodeUtil = (function() {
     try {
-      return freeProcess && freeProcess.binding('util');
+      return freeProcess && freeProcess.binding && freeProcess.binding('util');
     } catch (e) {}
   }());
 


### PR DESCRIPTION
Currently I'm using WebWorker on Electron, and it have `process` object on global (it just mock `process.env`, no `process.binding`), it will pause at useless places if we open `Pause On Caught Excpetions` on devtools:

![2016-11-07 3 03 06](https://cloud.githubusercontent.com/assets/3001525/20040695/c31a35ec-a496-11e6-96e5-448b6f868144.png)

