### PR TITLE
typescript typings for lodash-es

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ $ lodash modularize exports=es -o ./
 ```
 
 See the [package source](https://github.com/lodash/lodash/tree/4.17.2-es) for more details.
+
+## TypeScript
+
+For typescript users, install the default typings for lodash + this
+
+```shell
+$ npm install @types/lodash --save-dev
+```
+
+### Example
+
+```ts
+import kebabCase from "lodash-es/kebabCase";
+
+const food = kebabCase("chickenWings");
+```

--- a/add/index.d.ts
+++ b/add/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const add: typeof _.add;
+export default add;

--- a/add/index.d.ts-new
+++ b/add/index.d.ts-new
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const add: typeof _.add;
+export default add;

--- a/add/index.d.ts-new
+++ b/add/index.d.ts-new
@@ -1,3 +1,0 @@
-import * as _ from "lodash";
-declare const add: typeof _.add;
-export default add;

--- a/after/index.d.ts
+++ b/after/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const after: typeof _.after;
+export default after;

--- a/ary/index.d.ts
+++ b/ary/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const ary: typeof _.ary;
+export default ary;

--- a/assign/index.d.ts
+++ b/assign/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const assign: typeof _.assign;
+export default assign;

--- a/assignIn/index.d.ts
+++ b/assignIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const assignIn: typeof _.assignIn;
+export default assignIn;

--- a/assignInWith/index.d.ts
+++ b/assignInWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const assignInWith: typeof _.assignInWith;
+export default assignInWith;

--- a/assignWith/index.d.ts
+++ b/assignWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const assignWith: typeof _.assignWith;
+export default assignWith;

--- a/at/index.d.ts
+++ b/at/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const at: typeof _.at;
+export default at;

--- a/attempt/index.d.ts
+++ b/attempt/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const attempt: typeof _.attempt;
+export default attempt;

--- a/before/index.d.ts
+++ b/before/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const before: typeof _.before;
+export default before;

--- a/bind/index.d.ts
+++ b/bind/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const bind: typeof _.bind;
+export default bind;

--- a/bindAll/index.d.ts
+++ b/bindAll/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const bindAll: typeof _.bindAll;
+export default bindAll;

--- a/bindKey/index.d.ts
+++ b/bindKey/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const bindKey: typeof _.bindKey;
+export default bindKey;

--- a/camelCase/index.d.ts
+++ b/camelCase/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const camelCase: typeof _.camelCase;
+export default camelCase;

--- a/capitalize/index.d.ts
+++ b/capitalize/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const capitalize: typeof _.capitalize;
+export default capitalize;

--- a/castArray/index.d.ts
+++ b/castArray/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const castArray: typeof _.castArray;
+export default castArray;

--- a/ceil/index.d.ts
+++ b/ceil/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const ceil: typeof _.ceil;
+export default ceil;

--- a/chain/index.d.ts
+++ b/chain/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const chain: typeof _.chain;
+export default chain;

--- a/chunk/index.d.ts
+++ b/chunk/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const chunk: typeof _.chunk;
+export default chunk;

--- a/clamp/index.d.ts
+++ b/clamp/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const clamp: typeof _.clamp;
+export default clamp;

--- a/clone/index.d.ts
+++ b/clone/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const clone: typeof _.clone;
+export default clone;

--- a/cloneDeep/index.d.ts
+++ b/cloneDeep/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const cloneDeep: typeof _.cloneDeep;
+export default cloneDeep;

--- a/cloneDeepWith/index.d.ts
+++ b/cloneDeepWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const cloneDeepWith: typeof _.cloneDeepWith;
+export default cloneDeepWith;

--- a/cloneWith/index.d.ts
+++ b/cloneWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const cloneWith: typeof _.cloneWith;
+export default cloneWith;

--- a/compact/index.d.ts
+++ b/compact/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const compact: typeof _.compact;
+export default compact;

--- a/concat/index.d.ts
+++ b/concat/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const concat: typeof _.concat;
+export default concat;

--- a/constant/index.d.ts
+++ b/constant/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const constant: typeof _.constant;
+export default constant;

--- a/countBy/index.d.ts
+++ b/countBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const countBy: typeof _.countBy;
+export default countBy;

--- a/create/index.d.ts
+++ b/create/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const create: typeof _.create;
+export default create;

--- a/curry/index.d.ts
+++ b/curry/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const curry: typeof _.curry;
+export default curry;

--- a/curryRight/index.d.ts
+++ b/curryRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const curryRight: typeof _.curryRight;
+export default curryRight;

--- a/debounce/index.d.ts
+++ b/debounce/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const debounce: typeof _.debounce;
+export default debounce;

--- a/deburr/index.d.ts
+++ b/deburr/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const deburr: typeof _.deburr;
+export default deburr;

--- a/defaults/index.d.ts
+++ b/defaults/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const defaults: typeof _.defaults;
+export default defaults;

--- a/defaultsDeep/index.d.ts
+++ b/defaultsDeep/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const defaultsDeep: typeof _.defaultsDeep;
+export default defaultsDeep;

--- a/defer/index.d.ts
+++ b/defer/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const defer: typeof _.defer;
+export default defer;

--- a/delay/index.d.ts
+++ b/delay/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const delay: typeof _.delay;
+export default delay;

--- a/difference/index.d.ts
+++ b/difference/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const difference: typeof _.difference;
+export default difference;

--- a/differenceBy/index.d.ts
+++ b/differenceBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const differenceBy: typeof _.differenceBy;
+export default differenceBy;

--- a/differenceWith/index.d.ts
+++ b/differenceWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const differenceWith: typeof _.differenceWith;
+export default differenceWith;

--- a/drop/index.d.ts
+++ b/drop/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const drop: typeof _.drop;
+export default drop;

--- a/dropRight/index.d.ts
+++ b/dropRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const dropRight: typeof _.dropRight;
+export default dropRight;

--- a/dropRightWhile/index.d.ts
+++ b/dropRightWhile/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const dropRightWhile: typeof _.dropRightWhile;
+export default dropRightWhile;

--- a/dropWhile/index.d.ts
+++ b/dropWhile/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const dropWhile: typeof _.dropWhile;
+export default dropWhile;

--- a/each/index.d.ts
+++ b/each/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const each: typeof _.each;
+export default each;

--- a/eachRight/index.d.ts
+++ b/eachRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const eachRight: typeof _.eachRight;
+export default eachRight;

--- a/endsWith/index.d.ts
+++ b/endsWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const endsWith: typeof _.endsWith;
+export default endsWith;

--- a/eq/index.d.ts
+++ b/eq/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const eq: typeof _.eq;
+export default eq;

--- a/escape/index.d.ts
+++ b/escape/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const escape: typeof _.escape;
+export default escape;

--- a/escapeRegExp/index.d.ts
+++ b/escapeRegExp/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const escapeRegExp: typeof _.escapeRegExp;
+export default escapeRegExp;

--- a/every/index.d.ts
+++ b/every/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const every: typeof _.every;
+export default every;

--- a/extend/index.d.ts
+++ b/extend/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const extend: typeof _.extend;
+export default extend;

--- a/extendWith/index.d.ts
+++ b/extendWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const extendWith: typeof _.extendWith;
+export default extendWith;

--- a/fb/index.d.ts
+++ b/fb/index.d.ts
@@ -1,0 +1,2 @@
+import * as _ from "lodash";
+export default _;

--- a/fill/index.d.ts
+++ b/fill/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const fill: typeof _.fill;
+export default fill;

--- a/filter/index.d.ts
+++ b/filter/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const filter: typeof _.filter;
+export default filter;

--- a/find/index.d.ts
+++ b/find/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const find: typeof _.find;
+export default find;

--- a/findIndex/index.d.ts
+++ b/findIndex/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const findIndex: typeof _.findIndex;
+export default findIndex;

--- a/findKey/index.d.ts
+++ b/findKey/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const findKey: typeof _.findKey;
+export default findKey;

--- a/findLast/index.d.ts
+++ b/findLast/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const findLast: typeof _.findLast;
+export default findLast;

--- a/findLastIndex/index.d.ts
+++ b/findLastIndex/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const findLastIndex: typeof _.findLastIndex;
+export default findLastIndex;

--- a/findLastKey/index.d.ts
+++ b/findLastKey/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const findLastKey: typeof _.findLastKey;
+export default findLastKey;

--- a/first/index.d.ts
+++ b/first/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const first: typeof _.first;
+export default first;

--- a/flatMap/index.d.ts
+++ b/flatMap/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flatMap: typeof _.flatMap;
+export default flatMap;

--- a/flatten/index.d.ts
+++ b/flatten/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flatten: typeof _.flatten;
+export default flatten;

--- a/flattenDeep/index.d.ts
+++ b/flattenDeep/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flattenDeep: typeof _.flattenDeep;
+export default flattenDeep;

--- a/flattenDepth/index.d.ts
+++ b/flattenDepth/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flattenDepth: typeof _.flattenDepth;
+export default flattenDepth;

--- a/flip/index.d.ts
+++ b/flip/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flip: typeof _.flip;
+export default flip;

--- a/floor/index.d.ts
+++ b/floor/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const floor: typeof _.floor;
+export default floor;

--- a/flow/index.d.ts
+++ b/flow/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flow: typeof _.flow;
+export default flow;

--- a/flowRight/index.d.ts
+++ b/flowRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const flowRight: typeof _.flowRight;
+export default flowRight;

--- a/forEach/index.d.ts
+++ b/forEach/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const forEach: typeof _.forEach;
+export default forEach;

--- a/forEachRight/index.d.ts
+++ b/forEachRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const forEachRight: typeof _.forEachRight;
+export default forEachRight;

--- a/forIn/index.d.ts
+++ b/forIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const forIn: typeof _.forIn;
+export default forIn;

--- a/forInRight/index.d.ts
+++ b/forInRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const forInRight: typeof _.forInRight;
+export default forInRight;

--- a/forOwn/index.d.ts
+++ b/forOwn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const forOwn: typeof _.forOwn;
+export default forOwn;

--- a/forOwnRight/index.d.ts
+++ b/forOwnRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const forOwnRight: typeof _.forOwnRight;
+export default forOwnRight;

--- a/fromPairs/index.d.ts
+++ b/fromPairs/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const fromPairs: typeof _.fromPairs;
+export default fromPairs;

--- a/functions/index.d.ts
+++ b/functions/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const functions: typeof _.functions;
+export default functions;

--- a/functionsIn/index.d.ts
+++ b/functionsIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const functionsIn: typeof _.functionsIn;
+export default functionsIn;

--- a/get/index.d.ts
+++ b/get/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const get: typeof _.get;
+export default get;

--- a/groupBy/index.d.ts
+++ b/groupBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const groupBy: typeof _.groupBy;
+export default groupBy;

--- a/gt/index.d.ts
+++ b/gt/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const gt: typeof _.gt;
+export default gt;

--- a/gte/index.d.ts
+++ b/gte/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const gte: typeof _.gte;
+export default gte;

--- a/has/index.d.ts
+++ b/has/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const has: typeof _.has;
+export default has;

--- a/hasIn/index.d.ts
+++ b/hasIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const hasIn: typeof _.hasIn;
+export default hasIn;

--- a/head/index.d.ts
+++ b/head/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const head: typeof _.head;
+export default head;

--- a/identity/index.d.ts
+++ b/identity/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const identity: typeof _.identity;
+export default identity;

--- a/inRange/index.d.ts
+++ b/inRange/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const inRange: typeof _.inRange;
+export default inRange;

--- a/includes/index.d.ts
+++ b/includes/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const includes: typeof _.includes;
+export default includes;

--- a/indexOf/index.d.ts
+++ b/indexOf/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const indexOf: typeof _.indexOf;
+export default indexOf;

--- a/initial/index.d.ts
+++ b/initial/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const initial: typeof _.initial;
+export default initial;

--- a/intersection/index.d.ts
+++ b/intersection/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const intersection: typeof _.intersection;
+export default intersection;

--- a/intersectionBy/index.d.ts
+++ b/intersectionBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const intersectionBy: typeof _.intersectionBy;
+export default intersectionBy;

--- a/intersectionWith/index.d.ts
+++ b/intersectionWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const intersectionWith: typeof _.intersectionWith;
+export default intersectionWith;

--- a/invert/index.d.ts
+++ b/invert/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const invert: typeof _.invert;
+export default invert;

--- a/invertBy/index.d.ts
+++ b/invertBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const invertBy: typeof _.invertBy;
+export default invertBy;

--- a/invoke/index.d.ts
+++ b/invoke/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const invoke: typeof _.invoke;
+export default invoke;

--- a/invokeMap/index.d.ts
+++ b/invokeMap/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const invokeMap: typeof _.invokeMap;
+export default invokeMap;

--- a/isArguments/index.d.ts
+++ b/isArguments/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isArguments: typeof _.isArguments;
+export default isArguments;

--- a/isArray/index.d.ts
+++ b/isArray/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isArray: typeof _.isArray;
+export default isArray;

--- a/isArrayBuffer/index.d.ts
+++ b/isArrayBuffer/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isArrayBuffer: typeof _.isArrayBuffer;
+export default isArrayBuffer;

--- a/isArrayLike/index.d.ts
+++ b/isArrayLike/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isArrayLike: typeof _.isArrayLike;
+export default isArrayLike;

--- a/isArrayLikeObject/index.d.ts
+++ b/isArrayLikeObject/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isArrayLikeObject: typeof _.isArrayLikeObject;
+export default isArrayLikeObject;

--- a/isBoolean/index.d.ts
+++ b/isBoolean/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isBoolean: typeof _.isBoolean;
+export default isBoolean;

--- a/isBuffer/index.d.ts
+++ b/isBuffer/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isBuffer: typeof _.isBuffer;
+export default isBuffer;

--- a/isDate/index.d.ts
+++ b/isDate/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isDate: typeof _.isDate;
+export default isDate;

--- a/isElement/index.d.ts
+++ b/isElement/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isElement: typeof _.isElement;
+export default isElement;

--- a/isEmpty/index.d.ts
+++ b/isEmpty/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isEmpty: typeof _.isEmpty;
+export default isEmpty;

--- a/isEqual/index.d.ts
+++ b/isEqual/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isEqual: typeof _.isEqual;
+export default isEqual;

--- a/isEqualWith/index.d.ts
+++ b/isEqualWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isEqualWith: typeof _.isEqualWith;
+export default isEqualWith;

--- a/isError/index.d.ts
+++ b/isError/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isError: typeof _.isError;
+export default isError;

--- a/isFinite/index.d.ts
+++ b/isFinite/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isFinite: typeof _.isFinite;
+export default isFinite;

--- a/isFunction/index.d.ts
+++ b/isFunction/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isFunction: typeof _.isFunction;
+export default isFunction;

--- a/isInteger/index.d.ts
+++ b/isInteger/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isInteger: typeof _.isInteger;
+export default isInteger;

--- a/isLength/index.d.ts
+++ b/isLength/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isLength: typeof _.isLength;
+export default isLength;

--- a/isMap/index.d.ts
+++ b/isMap/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isMap: typeof _.isMap;
+export default isMap;

--- a/isMatch/index.d.ts
+++ b/isMatch/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isMatch: typeof _.isMatch;
+export default isMatch;

--- a/isMatchWith/index.d.ts
+++ b/isMatchWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isMatchWith: typeof _.isMatchWith;
+export default isMatchWith;

--- a/isNaN/index.d.ts
+++ b/isNaN/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isNaN: typeof _.isNaN;
+export default isNaN;

--- a/isNative/index.d.ts
+++ b/isNative/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isNative: typeof _.isNative;
+export default isNative;

--- a/isNil/index.d.ts
+++ b/isNil/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isNil: typeof _.isNil;
+export default isNil;

--- a/isNull/index.d.ts
+++ b/isNull/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isNull: typeof _.isNull;
+export default isNull;

--- a/isNumber/index.d.ts
+++ b/isNumber/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isNumber: typeof _.isNumber;
+export default isNumber;

--- a/isObject/index.d.ts
+++ b/isObject/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isObject: typeof _.isObject;
+export default isObject;

--- a/isObjectLike/index.d.ts
+++ b/isObjectLike/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isObjectLike: typeof _.isObjectLike;
+export default isObjectLike;

--- a/isPlainObject/index.d.ts
+++ b/isPlainObject/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isPlainObject: typeof _.isPlainObject;
+export default isPlainObject;

--- a/isRegExp/index.d.ts
+++ b/isRegExp/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isRegExp: typeof _.isRegExp;
+export default isRegExp;

--- a/isSafeInteger/index.d.ts
+++ b/isSafeInteger/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isSafeInteger: typeof _.isSafeInteger;
+export default isSafeInteger;

--- a/isSet/index.d.ts
+++ b/isSet/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isSet: typeof _.isSet;
+export default isSet;

--- a/isString/index.d.ts
+++ b/isString/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isString: typeof _.isString;
+export default isString;

--- a/isSymbol/index.d.ts
+++ b/isSymbol/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isSymbol: typeof _.isSymbol;
+export default isSymbol;

--- a/isTypedArray/index.d.ts
+++ b/isTypedArray/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isTypedArray: typeof _.isTypedArray;
+export default isTypedArray;

--- a/isUndefined/index.d.ts
+++ b/isUndefined/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isUndefined: typeof _.isUndefined;
+export default isUndefined;

--- a/isWeakMap/index.d.ts
+++ b/isWeakMap/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isWeakMap: typeof _.isWeakMap;
+export default isWeakMap;

--- a/isWeakSet/index.d.ts
+++ b/isWeakSet/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const isWeakSet: typeof _.isWeakSet;
+export default isWeakSet;

--- a/iteratee/index.d.ts
+++ b/iteratee/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const iteratee: typeof _.iteratee;
+export default iteratee;

--- a/join/index.d.ts
+++ b/join/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const join: typeof _.join;
+export default join;

--- a/kebabCase/index.d.ts
+++ b/kebabCase/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const kebabCase: typeof _.kebabCase;
+export default kebabCase;

--- a/keyBy/index.d.ts
+++ b/keyBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const keyBy: typeof _.keyBy;
+export default keyBy;

--- a/keys/index.d.ts
+++ b/keys/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const keys: typeof _.keys;
+export default keys;

--- a/keysIn/index.d.ts
+++ b/keysIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const keysIn: typeof _.keysIn;
+export default keysIn;

--- a/last/index.d.ts
+++ b/last/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const last: typeof _.last;
+export default last;

--- a/lastIndexOf/index.d.ts
+++ b/lastIndexOf/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const lastIndexOf: typeof _.lastIndexOf;
+export default lastIndexOf;

--- a/lowerCase/index.d.ts
+++ b/lowerCase/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const lowerCase: typeof _.lowerCase;
+export default lowerCase;

--- a/lowerFirst/index.d.ts
+++ b/lowerFirst/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const lowerFirst: typeof _.lowerFirst;
+export default lowerFirst;

--- a/lt/index.d.ts
+++ b/lt/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const lt: typeof _.lt;
+export default lt;

--- a/lte/index.d.ts
+++ b/lte/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const lte: typeof _.lte;
+export default lte;

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const map: typeof _.map;
+export default map;

--- a/mapKeys/index.d.ts
+++ b/mapKeys/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const mapKeys: typeof _.mapKeys;
+export default mapKeys;

--- a/mapValues/index.d.ts
+++ b/mapValues/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const mapValues: typeof _.mapValues;
+export default mapValues;

--- a/matches/index.d.ts
+++ b/matches/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const matches: typeof _.matches;
+export default matches;

--- a/matchesProperty/index.d.ts
+++ b/matchesProperty/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const matchesProperty: typeof _.matchesProperty;
+export default matchesProperty;

--- a/max/index.d.ts
+++ b/max/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const max: typeof _.max;
+export default max;

--- a/maxBy/index.d.ts
+++ b/maxBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const maxBy: typeof _.maxBy;
+export default maxBy;

--- a/mean/index.d.ts
+++ b/mean/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const mean: typeof _.mean;
+export default mean;

--- a/meanBy/index.d.ts
+++ b/meanBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const meanBy: typeof _.meanBy;
+export default meanBy;

--- a/memoize/index.d.ts
+++ b/memoize/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const memoize: typeof _.memoize;
+export default memoize;

--- a/merge/index.d.ts
+++ b/merge/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const merge: typeof _.merge;
+export default merge;

--- a/mergeWith/index.d.ts
+++ b/mergeWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const mergeWith: typeof _.mergeWith;
+export default mergeWith;

--- a/method/index.d.ts
+++ b/method/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const method: typeof _.method;
+export default method;

--- a/methodOf/index.d.ts
+++ b/methodOf/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const methodOf: typeof _.methodOf;
+export default methodOf;

--- a/min/index.d.ts
+++ b/min/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const min: typeof _.min;
+export default min;

--- a/minBy/index.d.ts
+++ b/minBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const minBy: typeof _.minBy;
+export default minBy;

--- a/mixin/index.d.ts
+++ b/mixin/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const mixin: typeof _.mixin;
+export default mixin;

--- a/negate/index.d.ts
+++ b/negate/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const negate: typeof _.negate;
+export default negate;

--- a/noConflict/index.d.ts
+++ b/noConflict/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const noConflict: typeof _.noConflict;
+export default noConflict;

--- a/noop/index.d.ts
+++ b/noop/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const noop: typeof _.noop;
+export default noop;

--- a/now/index.d.ts
+++ b/now/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const now: typeof _.now;
+export default now;

--- a/nthArg/index.d.ts
+++ b/nthArg/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const nthArg: typeof _.nthArg;
+export default nthArg;

--- a/omit/index.d.ts
+++ b/omit/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const omit: typeof _.omit;
+export default omit;

--- a/omitBy/index.d.ts
+++ b/omitBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const omitBy: typeof _.omitBy;
+export default omitBy;

--- a/once/index.d.ts
+++ b/once/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const once: typeof _.once;
+export default once;

--- a/orderBy/index.d.ts
+++ b/orderBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const orderBy: typeof _.orderBy;
+export default orderBy;

--- a/over/index.d.ts
+++ b/over/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const over: typeof _.over;
+export default over;

--- a/overArgs/index.d.ts
+++ b/overArgs/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const overArgs: typeof _.overArgs;
+export default overArgs;

--- a/overEvery/index.d.ts
+++ b/overEvery/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const overEvery: typeof _.overEvery;
+export default overEvery;

--- a/overSome/index.d.ts
+++ b/overSome/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const overSome: typeof _.overSome;
+export default overSome;

--- a/pad/index.d.ts
+++ b/pad/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pad: typeof _.pad;
+export default pad;

--- a/padEnd/index.d.ts
+++ b/padEnd/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const padEnd: typeof _.padEnd;
+export default padEnd;

--- a/padStart/index.d.ts
+++ b/padStart/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const padStart: typeof _.padStart;
+export default padStart;

--- a/parseInt/index.d.ts
+++ b/parseInt/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const parseInt: typeof _.parseInt;
+export default parseInt;

--- a/partial/index.d.ts
+++ b/partial/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const partial: typeof _.partial;
+export default partial;

--- a/partialRight/index.d.ts
+++ b/partialRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const partialRight: typeof _.partialRight;
+export default partialRight;

--- a/partition/index.d.ts
+++ b/partition/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const partition: typeof _.partition;
+export default partition;

--- a/pick/index.d.ts
+++ b/pick/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pick: typeof _.pick;
+export default pick;

--- a/pickBy/index.d.ts
+++ b/pickBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pickBy: typeof _.pickBy;
+export default pickBy;

--- a/property/index.d.ts
+++ b/property/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const property: typeof _.property;
+export default property;

--- a/propertyOf/index.d.ts
+++ b/propertyOf/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const propertyOf: typeof _.propertyOf;
+export default propertyOf;

--- a/pull/index.d.ts
+++ b/pull/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pull: typeof _.pull;
+export default pull;

--- a/pullAll/index.d.ts
+++ b/pullAll/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pullAll: typeof _.pullAll;
+export default pullAll;

--- a/pullAllBy/index.d.ts
+++ b/pullAllBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pullAllBy: typeof _.pullAllBy;
+export default pullAllBy;

--- a/pullAt/index.d.ts
+++ b/pullAt/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const pullAt: typeof _.pullAt;
+export default pullAt;

--- a/random/index.d.ts
+++ b/random/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const random: typeof _.random;
+export default random;

--- a/range/index.d.ts
+++ b/range/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const range: typeof _.range;
+export default range;

--- a/rangeRight/index.d.ts
+++ b/rangeRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const rangeRight: typeof _.rangeRight;
+export default rangeRight;

--- a/rearg/index.d.ts
+++ b/rearg/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const rearg: typeof _.rearg;
+export default rearg;

--- a/reduce/index.d.ts
+++ b/reduce/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const reduce: typeof _.reduce;
+export default reduce;

--- a/reduceRight/index.d.ts
+++ b/reduceRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const reduceRight: typeof _.reduceRight;
+export default reduceRight;

--- a/reject/index.d.ts
+++ b/reject/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const reject: typeof _.reject;
+export default reject;

--- a/remove/index.d.ts
+++ b/remove/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const remove: typeof _.remove;
+export default remove;

--- a/repeat/index.d.ts
+++ b/repeat/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const repeat: typeof _.repeat;
+export default repeat;

--- a/replace/index.d.ts
+++ b/replace/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const replace: typeof _.replace;
+export default replace;

--- a/rest/index.d.ts
+++ b/rest/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const rest: typeof _.rest;
+export default rest;

--- a/result/index.d.ts
+++ b/result/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const result: typeof _.result;
+export default result;

--- a/reverse/index.d.ts
+++ b/reverse/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const reverse: typeof _.reverse;
+export default reverse;

--- a/round/index.d.ts
+++ b/round/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const round: typeof _.round;
+export default round;

--- a/runInContext/index.d.ts
+++ b/runInContext/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const runInContext: typeof _.runInContext;
+export default runInContext;

--- a/sample/index.d.ts
+++ b/sample/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sample: typeof _.sample;
+export default sample;

--- a/sampleSize/index.d.ts
+++ b/sampleSize/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sampleSize: typeof _.sampleSize;
+export default sampleSize;

--- a/set/index.d.ts
+++ b/set/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const set: typeof _.set;
+export default set;

--- a/setWith/index.d.ts
+++ b/setWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const setWith: typeof _.setWith;
+export default setWith;

--- a/shuffle/index.d.ts
+++ b/shuffle/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const shuffle: typeof _.shuffle;
+export default shuffle;

--- a/size/index.d.ts
+++ b/size/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const size: typeof _.size;
+export default size;

--- a/slice/index.d.ts
+++ b/slice/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const slice: typeof _.slice;
+export default slice;

--- a/snakeCase/index.d.ts
+++ b/snakeCase/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const snakeCase: typeof _.snakeCase;
+export default snakeCase;

--- a/some/index.d.ts
+++ b/some/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const some: typeof _.some;
+export default some;

--- a/sortBy/index.d.ts
+++ b/sortBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortBy: typeof _.sortBy;
+export default sortBy;

--- a/sortedIndex/index.d.ts
+++ b/sortedIndex/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedIndex: typeof _.sortedIndex;
+export default sortedIndex;

--- a/sortedIndexBy/index.d.ts
+++ b/sortedIndexBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedIndexBy: typeof _.sortedIndexBy;
+export default sortedIndexBy;

--- a/sortedIndexOf/index.d.ts
+++ b/sortedIndexOf/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedIndexOf: typeof _.sortedIndexOf;
+export default sortedIndexOf;

--- a/sortedLastIndex/index.d.ts
+++ b/sortedLastIndex/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedLastIndex: typeof _.sortedLastIndex;
+export default sortedLastIndex;

--- a/sortedLastIndexBy/index.d.ts
+++ b/sortedLastIndexBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedLastIndexBy: typeof _.sortedLastIndexBy;
+export default sortedLastIndexBy;

--- a/sortedLastIndexOf/index.d.ts
+++ b/sortedLastIndexOf/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedLastIndexOf: typeof _.sortedLastIndexOf;
+export default sortedLastIndexOf;

--- a/sortedUniq/index.d.ts
+++ b/sortedUniq/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedUniq: typeof _.sortedUniq;
+export default sortedUniq;

--- a/sortedUniqBy/index.d.ts
+++ b/sortedUniqBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sortedUniqBy: typeof _.sortedUniqBy;
+export default sortedUniqBy;

--- a/split/index.d.ts
+++ b/split/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const split: typeof _.split;
+export default split;

--- a/spread/index.d.ts
+++ b/spread/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const spread: typeof _.spread;
+export default spread;

--- a/startCase/index.d.ts
+++ b/startCase/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const startCase: typeof _.startCase;
+export default startCase;

--- a/startsWith/index.d.ts
+++ b/startsWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const startsWith: typeof _.startsWith;
+export default startsWith;

--- a/subtract/index.d.ts
+++ b/subtract/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const subtract: typeof _.subtract;
+export default subtract;

--- a/sum/index.d.ts
+++ b/sum/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sum: typeof _.sum;
+export default sum;

--- a/sumBy/index.d.ts
+++ b/sumBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const sumBy: typeof _.sumBy;
+export default sumBy;

--- a/tail/index.d.ts
+++ b/tail/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const tail: typeof _.tail;
+export default tail;

--- a/take/index.d.ts
+++ b/take/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const take: typeof _.take;
+export default take;

--- a/takeRight/index.d.ts
+++ b/takeRight/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const takeRight: typeof _.takeRight;
+export default takeRight;

--- a/takeRightWhile/index.d.ts
+++ b/takeRightWhile/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const takeRightWhile: typeof _.takeRightWhile;
+export default takeRightWhile;

--- a/takeWhile/index.d.ts
+++ b/takeWhile/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const takeWhile: typeof _.takeWhile;
+export default takeWhile;

--- a/tap/index.d.ts
+++ b/tap/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const tap: typeof _.tap;
+export default tap;

--- a/template/index.d.ts
+++ b/template/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const template: typeof _.template;
+export default template;

--- a/throttle/index.d.ts
+++ b/throttle/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const throttle: typeof _.throttle;
+export default throttle;

--- a/thru/index.d.ts
+++ b/thru/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const thru: typeof _.thru;
+export default thru;

--- a/times/index.d.ts
+++ b/times/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const times: typeof _.times;
+export default times;

--- a/toArray/index.d.ts
+++ b/toArray/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toArray: typeof _.toArray;
+export default toArray;

--- a/toInteger/index.d.ts
+++ b/toInteger/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toInteger: typeof _.toInteger;
+export default toInteger;

--- a/toLength/index.d.ts
+++ b/toLength/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toLength: typeof _.toLength;
+export default toLength;

--- a/toLower/index.d.ts
+++ b/toLower/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toLower: typeof _.toLower;
+export default toLower;

--- a/toNumber/index.d.ts
+++ b/toNumber/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toNumber: typeof _.toNumber;
+export default toNumber;

--- a/toPairs/index.d.ts
+++ b/toPairs/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toPairs: typeof _.toPairs;
+export default toPairs;

--- a/toPairsIn/index.d.ts
+++ b/toPairsIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toPairsIn: typeof _.toPairsIn;
+export default toPairsIn;

--- a/toPath/index.d.ts
+++ b/toPath/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toPath: typeof _.toPath;
+export default toPath;

--- a/toPlainObject/index.d.ts
+++ b/toPlainObject/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toPlainObject: typeof _.toPlainObject;
+export default toPlainObject;

--- a/toSafeInteger/index.d.ts
+++ b/toSafeInteger/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toSafeInteger: typeof _.toSafeInteger;
+export default toSafeInteger;

--- a/toString/index.d.ts
+++ b/toString/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toString: typeof _.toString;
+export default toString;

--- a/toUpper/index.d.ts
+++ b/toUpper/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const toUpper: typeof _.toUpper;
+export default toUpper;

--- a/transform/index.d.ts
+++ b/transform/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const transform: typeof _.transform;
+export default transform;

--- a/trim/index.d.ts
+++ b/trim/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const trim: typeof _.trim;
+export default trim;

--- a/trimEnd/index.d.ts
+++ b/trimEnd/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const trimEnd: typeof _.trimEnd;
+export default trimEnd;

--- a/trimStart/index.d.ts
+++ b/trimStart/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const trimStart: typeof _.trimStart;
+export default trimStart;

--- a/truncate/index.d.ts
+++ b/truncate/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const truncate: typeof _.truncate;
+export default truncate;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,2 @@
+// Type definitions for Lo-Dash-es 4.14
+// Definitions by: Stephen Lautier <https://github.com/stephenlautier>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,2 +1,0 @@
-// Type definitions for Lo-Dash-es 4.14
-// Definitions by: Stephen Lautier <https://github.com/stephenlautier>

--- a/unary/index.d.ts
+++ b/unary/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unary: typeof _.unary;
+export default unary;

--- a/unescape/index.d.ts
+++ b/unescape/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unescape: typeof _.unescape;
+export default unescape;

--- a/union/index.d.ts
+++ b/union/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const union: typeof _.union;
+export default union;

--- a/unionBy/index.d.ts
+++ b/unionBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unionBy: typeof _.unionBy;
+export default unionBy;

--- a/unionWith/index.d.ts
+++ b/unionWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unionWith: typeof _.unionWith;
+export default unionWith;

--- a/uniq/index.d.ts
+++ b/uniq/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const uniq: typeof _.uniq;
+export default uniq;

--- a/uniqBy/index.d.ts
+++ b/uniqBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const uniqBy: typeof _.uniqBy;
+export default uniqBy;

--- a/uniqWith/index.d.ts
+++ b/uniqWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const uniqWith: typeof _.uniqWith;
+export default uniqWith;

--- a/uniqueId/index.d.ts
+++ b/uniqueId/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const uniqueId: typeof _.uniqueId;
+export default uniqueId;

--- a/unset/index.d.ts
+++ b/unset/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unset: typeof _.unset;
+export default unset;

--- a/unzip/index.d.ts
+++ b/unzip/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unzip: typeof _.unzip;
+export default unzip;

--- a/unzipWith/index.d.ts
+++ b/unzipWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const unzipWith: typeof _.unzipWith;
+export default unzipWith;

--- a/update/index.d.ts
+++ b/update/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const update: typeof _.update;
+export default update;

--- a/upperCase/index.d.ts
+++ b/upperCase/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const upperCase: typeof _.upperCase;
+export default upperCase;

--- a/upperFirst/index.d.ts
+++ b/upperFirst/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const upperFirst: typeof _.upperFirst;
+export default upperFirst;

--- a/values/index.d.ts
+++ b/values/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const values: typeof _.values;
+export default values;

--- a/valuesIn/index.d.ts
+++ b/valuesIn/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const valuesIn: typeof _.valuesIn;
+export default valuesIn;

--- a/without/index.d.ts
+++ b/without/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const without: typeof _.without;
+export default without;

--- a/words/index.d.ts
+++ b/words/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const words: typeof _.words;
+export default words;

--- a/wrap/index.d.ts
+++ b/wrap/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const wrap: typeof _.wrap;
+export default wrap;

--- a/xor/index.d.ts
+++ b/xor/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const xor: typeof _.xor;
+export default xor;

--- a/xorBy/index.d.ts
+++ b/xorBy/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const xorBy: typeof _.xorBy;
+export default xorBy;

--- a/xorWith/index.d.ts
+++ b/xorWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const xorWith: typeof _.xorWith;
+export default xorWith;

--- a/xx
+++ b/xx
@@ -1,0 +1,2 @@
+Get-Content
+C:\Users\chiko-pc\Development\git.depot\lodash\add\index.d.ts

--- a/xx
+++ b/xx
@@ -1,2 +1,0 @@
-Get-Content
-C:\Users\chiko-pc\Development\git.depot\lodash\add\index.d.ts

--- a/xx.xx
+++ b/xx.xx
@@ -1,0 +1,2 @@
+Get-Content
+C:\Users\chiko-pc\Development\git.depot\lodash\add\index.d.ts

--- a/xx.xx
+++ b/xx.xx
@@ -1,2 +1,0 @@
-Get-Content
-C:\Users\chiko-pc\Development\git.depot\lodash\add\index.d.ts

--- a/zip/index.d.ts
+++ b/zip/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const zip: typeof _.zip;
+export default zip;

--- a/zipObject/index.d.ts
+++ b/zipObject/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const zipObject: typeof _.zipObject;
+export default zipObject;

--- a/zipWith/index.d.ts
+++ b/zipWith/index.d.ts
@@ -1,0 +1,3 @@
+import * as _ from "lodash";
+declare const zipWith: typeof _.zipWith;
+export default zipWith;


### PR DESCRIPTION
Currently in order to use TypeScript with `lodash-es` its a problem since they are not available.

This would allow the TS users to simply download this package + typings from original source `@types/lodash` and they get typings out of the box for lodash-es.