### PR TITLE
Mention ES6 delimiters in templateSettings docs

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1728,8 +1728,8 @@
 
     /**
      * By default, the template delimiters used by lodash are like those in
-     * embedded Ruby (ERB). Change the following template settings to use
-     * alternative delimiters.
+     * embedded Ruby (ERB), as well as ES6 template strings. Change the 
+     * following template settings to use alternative delimiters.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
After a fair amount of confusion and hunting, I finally realized (via #399) that the template function defaults to ERB _and_ ES6 template string delimiters by default. The `templateSettings` docs explicitly mention the ERB style delimiters, but the ES6 style is mentioned only in a code sample comment on the template function itself.