### PR TITLE
perf(isObject): Avoid caching loose comparison to null

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -11755,8 +11755,7 @@
      * // => false
      */
     function isObject(value) {
-      var type = typeof value;
-      return value != null && (type == 'object' || type == 'function');
+      return value !== null && (typeof value == 'object' || typeof value == 'function');
     }
 
     /**


### PR DESCRIPTION
Hi, from this [benchmark](https://gist.run/?id=680c1d0d904fad05549ab93fa033897d)

Using strict null check and avoiding caching can help increase performance about 25 - 30%