### PR TITLE
Update CONTRIBUTING.md with info about the state of the master branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+# Notice
+
+Work continues on version 5.0.0 of Lodash and the `master` branch is ['in flux right now'](https://github.com/lodash/lodash/commit/2900cfd288f72671c335021fa3220818445f9123#commitcomment-20478564). Unfortunately that also means the `package.json` scripts, which we suggest using for your contributions in our guide below, currently aren't working (e.g. `npm run build`, `npm test`). The last commit with working scripts is the [v4.17.4 release](https://github.com/lodash/lodash/tree/912d6b04a1f6b732508a6da72a95ec4f96bda154). Thank you for understanding! 
+
 # Contributing to Lodash
 
 Contributions are always welcome. Before contributing please read the


### PR DESCRIPTION
Hey there! First, thanks for Lodash, freakin' awesome!

I just spent a good deal of time crawling around the repository trying to figure out why the tests are not running on master, where `lodash.js` is and what I'm doing wrong. 

Then I found the modularization commit and its comments and it all became clear. My first step 
(before walking around the repo) was to read CONTRIBUTING.md, but there was nothing in there that would explain the current situation. 

So I propose a change to CONTRIBUTING with a small notice about the current state of master, and the last commit with working `package.json` scripts. This can be removed when `master` is ready to take contributions again.


