### PR TITLE
Use parentheses around arrow function argument having a body with cur…

### DIFF
--- a/cond.js
+++ b/cond.js
@@ -31,7 +31,7 @@ import arrayMap from './.internal/arrayMap.js'
 function cond(pairs) {
   const length = pairs == null ? 0 : pairs.length
 
-  pairs = !length ? [] : arrayMap(pairs, pair => {
+  pairs = !length ? [] : arrayMap(pairs, (pair) => {
     if (typeof pair[1] != 'function') {
       throw new TypeError('Expected a function')
     }

--- a/invokeMap.js
+++ b/invokeMap.js
@@ -29,7 +29,7 @@ function invokeMap(collection, path, args) {
   const isFunc = typeof path == 'function'
   const result = isArrayLike(collection) ? Array(collection.length) : []
 
-  baseEach(collection, value => {
+  baseEach(collection, (value) => {
     result[++index] = isFunc ? apply(path, value, args) : invoke(value, path, args)
   })
   return result

--- a/unzip.js
+++ b/unzip.js
@@ -30,7 +30,7 @@ function unzip(array) {
     return []
   }
   let length = 0
-  array = arrayFilter(array, group => {
+  array = arrayFilter(array, (group) => {
     if (isArrayLikeObject(group)) {
       length = nativeMax(group.length, length)
       return true


### PR DESCRIPTION
It's a style matter, but reasonable to use parentheses when you use function body.
So use `var => fn(var)` or `(var) => {  fn(var) }`, what do you think?