### PR TITLE
Minimal eslint config.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,35 @@
+module.exports = {
+  'extends': ['plugin:import/errors'],
+  'plugins': ['import'],
+  'env': {
+    'es6': true
+  },
+  'parserOptions': {
+    'ecmaVersion': 6,
+    'sourceType': 'module',
+    'ecmaFeatures': {
+      'impliedStrict': true,
+      'objectLiteralDuplicateProperties': false
+    }
+  },
+  'rules': {
+    'comma-dangle': ['error', 'never'],
+
+    'indent': ['error', 2, {
+      'SwitchCase': 1
+    }],
+
+    'max-len': ['error', {
+      'code': 180,
+      'ignoreComments': true,
+      'ignoreRegExpLiterals': true
+    }],
+
+    'no-const-assign': 'error',
+
+    'quotes': ['error', 'single', {
+      'avoidEscape': true,
+      'allowTemplateLiterals': true
+    }]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "docdown": "~0.7.2",
     "dojo": "^1.12.1",
     "ecstatic": "^2.1.0",
+    "eslint": "^3.15.0",
+    "eslint-plugin-import": "^2.2.0",
     "fs-extra": "~1.0.0",
     "glob": "^7.1.1",
     "istanbul": "0.4.5",


### PR DESCRIPTION
Minimal eslint config for failed imports tracking and others. I didn't want to put any coding style configuration stuff since we're in loose mode at master. Porting jscs config one to one is pointless I guess, any thoughts @jdalton?