### PR TITLE
Resolving a Promise without any argument breaks in some browsers

### DIFF
--- a/.internal/getTag.js
+++ b/.internal/getTag.js
@@ -26,6 +26,7 @@ const weakMapCtorString = toSource(WeakMap)
 let getTag = baseGetTag
 
 // Fallback for data views, maps, sets, and weak maps in IE 11 and promises in Node.js < 6.
+// Promise solving without any arguments will throw an error in webmaf, lg (smarttv) browsers
 if ((DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
     (getTag(new Map) != mapTag) ||
     (getTag(Promise.resolve(undefined)) != promiseTag) ||

--- a/.internal/getTag.js
+++ b/.internal/getTag.js
@@ -28,7 +28,7 @@ let getTag = baseGetTag
 // Fallback for data views, maps, sets, and weak maps in IE 11 and promises in Node.js < 6.
 if ((DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
     (getTag(new Map) != mapTag) ||
-    (getTag(Promise.resolve()) != promiseTag) ||
+    (getTag(Promise.resolve(undefined)) != promiseTag) ||
     (getTag(new Set) != setTag) ||
     (getTag(new WeakMap) != weakMapTag)) {
   getTag = value => {


### PR DESCRIPTION
### Background

Promise.resolve without any argument throws an error with

```
TypeError: Expected at least one argument
```

This happens in lg (smarttv) and webmaf browsers

### Proposed Solution

Resolve with ``undefined``so the check passes and still keep the previous behavior.