### PR TITLE
Fixed small typo in debounce docs

### DIFF
--- a/debounce.js
+++ b/debounce.js
@@ -21,7 +21,7 @@ const nativeMin = Math.min
  * is invoked more than once during the `wait` timeout.
  *
  * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
- * until to the next tick, similar to `setTimeout` with a timeout of `0`.
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
  *
  * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
  * for details over the differences between `debounce` and `throttle`.


### PR DESCRIPTION
Just a small thing I noticed, I think it reads better this way.