### PR TITLE
Fix trailing edge issue in throttle

### DIFF
--- a/debounce.js
+++ b/debounce.js
@@ -117,7 +117,7 @@ function debounce(func, wait, options) {
       return cooldownRemaining;
     }
 
-    return maxing ? nativeMin(remaining, maxWaitRemaining, cooldownRemaining) : remaining
+    return maxing ? nativeMin(remaining, maxWaitRemaining) : remaining
   }
 
   function shouldInvoke(time) {

--- a/debounce.js
+++ b/debounce.js
@@ -31,6 +31,9 @@ const nativeMin = Math.min
  * @param {Function} func The function to debounce.
  * @param {number} [wait=0] The number of milliseconds to delay.
  * @param {Object} [options={}] The options object.
+ * @param {number} [options.cooldown]
+ *  The minimum amount of time between the trailing edge
+  * and the next leading edge. Takes precedence over maxWait.
  * @param {boolean} [options.leading=false]
  *  Specify invoking on the leading edge of the timeout.
  * @param {number} [options.maxWait]
@@ -65,6 +68,7 @@ function debounce(func, wait, options) {
     timerId,
     lastCallTime
 
+  let cooldown = 0
   let lastInvokeTime = 0
   let leading = false
   let maxing = false
@@ -75,6 +79,7 @@ function debounce(func, wait, options) {
   }
   wait = toNumber(wait) || 0
   if (isObject(options)) {
+    cooldown = 'cooldown' in options ? toNumber(options.cooldown || 0) : cooldown
     leading = !!options.leading
     maxing = 'maxWait' in options
     maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait
@@ -103,20 +108,31 @@ function debounce(func, wait, options) {
   function remainingWait(time) {
     const timeSinceLastCall = time - lastCallTime
     const timeSinceLastInvoke = time - lastInvokeTime
-    const result = wait - timeSinceLastCall
 
-    return maxing ? nativeMin(result, maxWait - timeSinceLastInvoke) : result
+    const remaining = wait - timeSinceLastCall
+    const maxWaitRemaining = maxWait - timeSinceLastInvoke
+    const cooldownRemaining = cooldown - timeSinceLastInvoke
+
+    if (cooldownRemaining > 0) {
+      return cooldownRemaining;
+    }
+
+    return maxing ? nativeMin(remaining, maxWaitRemaining, cooldownRemaining) : remaining
   }
 
   function shouldInvoke(time) {
     const timeSinceLastCall = time - lastCallTime
     const timeSinceLastInvoke = time - lastInvokeTime
 
-    // Either this is the first call, activity has stopped and we're at the
-    // trailing edge, the system time has gone backwards and we're treating
-    // it as the trailing edge, or we've hit the `maxWait` limit.
-    return (lastCallTime === undefined || (timeSinceLastCall >= wait) ||
-      (timeSinceLastCall < 0) || (maxing && timeSinceLastInvoke >= maxWait))
+    const isFirstCall = lastCallTime === undefined
+    const timeWentBackwards = timeSinceLastCall < 0
+
+    const cooldownInProgress = cooldown && timeSinceLastInvoke < cooldown
+    const maxWaitExpired = maxing && timeSinceLastInvoke >= maxWait
+    const activityHasStopped = timeSinceLastCall >= wait
+    const isEdge = !cooldownInProgress && (maxWaitExpired || activityHasStopped)
+
+    return (isFirstCall || timeWentBackwards || isEdge)
   }
 
   function timerExpired() {
@@ -171,7 +187,7 @@ function debounce(func, wait, options) {
       }
     }
     if (timerId === undefined) {
-      timerId = setTimeout(timerExpired, wait)
+      timerId = setTimeout(timerExpired, remainingWait(time))
     }
     return result
   }

--- a/throttle.js
+++ b/throttle.js
@@ -55,6 +55,7 @@ function throttle(func, wait, options) {
     trailing = 'trailing' in options ? !!options.trailing : trailing
   }
   return debounce(func, wait, {
+    'cooldown': wait,
     'leading': leading,
     'maxWait': wait,
     'trailing': trailing


### PR DESCRIPTION
PR to address issue https://github.com/lodash/lodash/issues/3051

Note: Given the state of flux of the repo, I was unable to run any scripts or tests, except for some local tests. There are also not any tests here, since they don't seem to be in this repo? Please advise.

Eventually I determined that the issue boils down to a fundamental incompatibility between the expectations for `debounce` and the expectations for `throttle`. Following the trailing edge, `debounce` does not (and should not) care about the the amount of time elapsed before the next leading edge. `throttle` does. There seem to be three possible approaches to resolving this:

1. Decouple the `throttle` and `debounce` implementations again. No thanks.
1. Reclaim `maxWait` in the name of House Throttle. In the original debounce-based throttle implementation, setting `maxWait` reset the `lastCall` time to the time that the trailing edge created by `maxWait` was invoked (see [here](https://github.com/lodash/lodash/commit/1933a766310997518ab09f591cf364bd71d30607#diff-001d0647fb00f8336795faccdec19a31R4885). This is ostensibly not correct, which is probably why the behavior was changed at some point.
1. Add a new option that `throttle` can utilize. This is the approach I went with.

I added an option called `cooldown` which lets you specify the minimum amount of time that must elapse between a trailing edge and a leading edge. Calls to `debounced` that occur in that interval are deferred until the end of that cooldown period (effectively creating a new trailing edge).
