### PR TITLE
Remove constant function from examples

### DIFF
--- a/cond.js
+++ b/cond.js
@@ -13,9 +13,9 @@ import arrayMap from './.internal/arrayMap.js'
  * @example
  *
  * const func = cond([
- *   [matches({ 'a': 1 }),         constant('matches A')],
- *   [conforms({ 'b': isNumber }), constant('matches B')],
- *   [() => true,                  constant('no match')]
+ *   [matches({ 'a': 1 }),         () => 'matches A'],
+ *   [conforms({ 'b': isNumber }), () => 'matches B'],
+ *   [() => true,                  () => 'no match']
  * ])
  *
  * func({ 'a': 1, 'b': 2 })

--- a/functions.js
+++ b/functions.js
@@ -10,11 +10,11 @@
  * @example
  *
  * function Foo() {
- *   this.a = constant('a')
- *   this.b = constant('b')
+ *   this.a = () => 'a'
+ *   this.b = () => 'b'
  * }
  *
- * Foo.prototype.c = constant('c')
+ * Foo.prototype.c = () => 'c'
  *
  * functions(new Foo)
  * // => ['a', 'b']

--- a/method.js
+++ b/method.js
@@ -12,8 +12,8 @@ import invoke from './invoke.js'
  * @example
  *
  * const objects = [
- *   { 'a': { 'b': constant(2) } },
- *   { 'a': { 'b': constant(1) } }
+ *   { 'a': { 'b': () => 2 } },
+ *   { 'a': { 'b': () => 1 } }
  * ]
  *
  * map(objects, method('a.b'))

--- a/methodOf.js
+++ b/methodOf.js
@@ -12,14 +12,14 @@ import invoke from './invoke.js'
  * @returns {Function} Returns the new invoker function.
  * @example
  *
- * const array = times(3, constant)
+ * const array = times(3, i => () => i)
  * const object = { 'a': array, 'b': array, 'c': array }
  *
  * map(['a[2]', 'c[0]'], methodOf(object))
  * // => [2, 0]
  *
  * map([['a', '2'], ['c', '0']], methodOf(object))
- * // => [2, 0]
+ * // => [2, 0]f
  */
 function methodOf(object, args) {
   return (path) => invoke(object, path, args)

--- a/result.js
+++ b/result.js
@@ -14,7 +14,7 @@ import toKey from './.internal/toKey.js'
  * @returns {*} Returns the resolved value.
  * @example
  *
- * const object = { 'a': [{ 'b': { 'c1': 3, 'c2': constant(4) } }] }
+ * const object = { 'a': [{ 'b': { 'c1': 3, 'c2': () => 4 } }] }
  *
  * result(object, 'a[0].b.c1')
  * // => 3
@@ -25,7 +25,7 @@ import toKey from './.internal/toKey.js'
  * result(object, 'a[0].b.c3', 'default')
  * // => 'default'
  *
- * result(object, 'a[0].b.c3', constant('default'))
+ * result(object, 'a[0].b.c3', () => 'default')
  * // => 'default'
  */
 function result(object, path, defaultValue) {

--- a/times.js
+++ b/times.js
@@ -18,7 +18,7 @@ const MAX_ARRAY_LENGTH = 4294967295
  * times(3, String)
  * // => ['0', '1', '2']
  *
- *  times(4, constant(0))
+ *  times(4, () => 0)
  * // => [0, 0, 0, 0]
  */
 function times(n, iteratee) {

--- a/updateWith.js
+++ b/updateWith.js
@@ -19,7 +19,7 @@ import baseUpdate from './.internal/baseUpdate.js'
  *
  * const object = {}
  *
- * updateWith(object, '[0][1]', constant('a'), Object)
+ * updateWith(object, '[0][1]', () => 'a', Object)
  * // => { '0': { '1': 'a' } }
  */
 function updateWith(object, path, updater, customizer) {


### PR DESCRIPTION
`methodOf` example is pretty ugly now (`i => () => i` part), but I've never seen this method in real life and can't create a nicer example