### PR TITLE
Fix #3087: Update _.pad* examples to show pad length < string.

### DIFF
--- a/pad.js
+++ b/pad.js
@@ -19,7 +19,7 @@ import stringSize from './.internal/stringSize.js'
  * pad('abc', 8, '_-')
  * // => '_-abc_-_'
  *
- * pad('abc', 3)
+ * pad('abc', 2)
  * // => 'abc'
  */
 function pad(string, length, chars) {

--- a/padEnd.js
+++ b/padEnd.js
@@ -19,7 +19,7 @@ import stringSize from './.internal/stringSize.js'
  * padEnd('abc', 6, '_-')
  * // => 'abc_-_'
  *
- * padEnd('abc', 3)
+ * padEnd('abc', 2)
  * // => 'abc'
  */
 function padEnd(string, length, chars) {

--- a/padStart.js
+++ b/padStart.js
@@ -19,7 +19,7 @@ import stringSize from './.internal/stringSize.js'
  * padStart('abc', 6, '_-')
  * // => '_-_abc'
  *
- * padStart('abc', 3)
+ * padStart('abc', 2)
  * // => 'abc'
  */
 function padStart(string, length, chars) {


### PR DESCRIPTION
One example now shows that specifying a padding length of less than the
length of the string returns the entire original string.