### PR TITLE
Update get.js documentation including better examples

### DIFF
--- a/get.js
+++ b/get.js
@@ -1,8 +1,9 @@
 import baseGet from './.internal/baseGet.js'
 
 /**
- * Gets the value at `path` of `object` or `undefined` if the path cannot be evaluated.  If 
- * the resolved value is `undefined`, the `defaultValue` is returned in its place.
+ * Gets the value at `path` of `object` or gets `undefined` if the 
+ * path cannot be evaluated.  If the resolved value is `undefined`, 
+ * the `defaultValue` is returned in its place.
  *
  * @since 3.7.0
  * @category Object

--- a/get.js
+++ b/get.js
@@ -1,14 +1,14 @@
 import baseGet from './.internal/baseGet.js'
 
 /**
- * Gets the value at `path` of `object`. If the resolved value is
- * `undefined` or invalid, the `defaultValue` is returned in its place.
+ * Gets the value at `path` of `object` or `undefined` if the path cannot be evaluated.  If 
+ * the resolved value is `undefined`, the `defaultValue` is returned in its place.
  *
  * @since 3.7.0
  * @category Object
  * @param {Object} object The object to query.
  * @param {Array|string} path The path of the property to get.
- * @param {*} [defaultValue] The value returned for `undefined` or invalid resolved values.
+ * @param {*} [defaultValue] The value returned for `undefined` resolved values.
  * @returns {*} Returns the resolved value.
  * @see has, hasIn, set, unset
  * @example

--- a/get.js
+++ b/get.js
@@ -2,13 +2,13 @@ import baseGet from './.internal/baseGet.js'
 
 /**
  * Gets the value at `path` of `object`. If the resolved value is
- * `undefined`, the `defaultValue` is returned in its place.
+ * `undefined` or invalid, the `defaultValue` is returned in its place.
  *
  * @since 3.7.0
  * @category Object
  * @param {Object} object The object to query.
  * @param {Array|string} path The path of the property to get.
- * @param {*} [defaultValue] The value returned for `undefined` resolved values.
+ * @param {*} [defaultValue] The value returned for `undefined` or invalid resolved values.
  * @returns {*} Returns the resolved value.
  * @see has, hasIn, set, unset
  * @example
@@ -21,7 +21,10 @@ import baseGet from './.internal/baseGet.js'
  * get(object, ['a', '0', 'b', 'c'])
  * // => 3
  *
- * get(object, 'a.b.c', 'default')
+ * get(object, 'a.a.a')
+ * // => undefined
+ * 
+ * get(object, 'a.a.a', 'default')
  * // => 'default'
  */
 function get(object, path, defaultValue) {


### PR DESCRIPTION
Documentation now clearly shows this function also allows accessing a path that may not be valid.  The examples now show a more clearly invalid path and that an invalid path returns `undefined` if no default value is provided.