### PR TITLE
Enable no-unexpected-multiline

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,8 @@ module.exports = {
 
     'no-undef': ['error'],
 
+    'no-unexpected-multiline': ['error'],
+
     'no-unused-vars': ['error', {
       'args': 'none',
       'vars': 'all'


### PR DESCRIPTION
This rule can help catch errors introduced by automatic semicolon insertion
edge cases. It seems like a sensible thing to have enabled in a code base that
does not use semicolons.

http://eslint.org/docs/rules/no-unexpected-multiline