### PR TITLE
A 'families' function on Collections

### DIFF
--- a/families.js
+++ b/families.js
@@ -1,0 +1,52 @@
+import pullAt from './pullAt.js'
+import flatMap from './flatMap.js'
+import findIndex from './findIndex.js'
+import some from './some.js'
+
+/**
+ * Creates an array of elements split into groups. For any elements x and y of the collection,
+ * if predicate(x,y) returns truthy, x and y will end up in the same group. It is assumed that
+ * predicate(x,y) returns the same as predicate(y,x).
+ * 
+ * @category Collection
+ * @param {Array|Object} collection The collection to divide into groups.
+ * @param {Function} predicate The function invoked to determine membership in the same group.
+ * @returns {Array} Returns the array of grouped elements.
+ * @see partition, groupBy, keyBy
+ * @example
+ * 
+ * var numbers = [1,2,3,4,5,6,7];
+ * 
+ * families(numbers, function(x,y){return x - y == 2 || y - x == 2;})
+ * // => [[1,3,5,7],[2,4,6]]
+ * 
+ * numbers = [1,2,3,100,101,102];
+ * 
+ * families(numbers, function(x,y){return x - y == 1 || y - x == 1;})
+ * // => [[1,2,3],[100,101,102]]
+ */
+
+function families(collection, predicate){
+	var unassigned = flatMap(collection);
+	var result = [];
+	var currentFamily, foundIndex, foundElement;
+	while(unassigned.length){
+		if(!currentFamily){
+			currentFamily = pullAt(unassigned,[0]);
+			result.push(currentFamily);
+		}else{
+			foundIndex = findIndex(unassigned, e => some(currentFamily, f => predicate(e,f)));
+			if(foundIndex > -1){
+				foundElement = pullAt(unassigned, [foundIndex])[0];
+				currentFamily.push(foundElement);
+			}else{
+				currentFamily = pullAt(unassigned,[0]);
+				result.push(currentFamily);
+			}
+		}
+	}
+	return result;
+}
+
+export default families
+

--- a/partition.js
+++ b/partition.js
@@ -1,4 +1,4 @@
-import reduce from './reduce.js'
+import families from './families.js'
 
 /**
  * Creates an array of elements split into two groups, the first of which
@@ -24,9 +24,7 @@ import reduce from './reduce.js'
  * // => objects for [['fred'], ['barney', 'pebbles']]
  */
 function partition(collection, predicate) {
-  return reduce(collection, (result, value, key) => (
-    result[predicate(value) ? 0 : 1].push(value), result
-  ), [[], []])
+  return families(collection, (x,y) => predicate(x) == predicate(y));
 }
 
 export default partition


### PR DESCRIPTION
This is related to https://github.com/lodash/lodash/issues/2195.

I have often needed to partition a collection of things based on whether two elements in the collection belong to the same group. Say, for instance, you have a collection of things that are linked to each other one-by-one, so A is connected to C, C is connected to E and B is connected to D. I would like a function that, given A, B, C, D and E, returns two groups: one containing A, C and E and one containing B and D.

In other words, it would be very cool if there were like a ‘families’ function accepting two parameters:
- a collection, and
- a predicate of two parameters which, if it returns true, means that those two elements belong to the same group.

This would be a generalization of 'partition', in other words: 'partition', when called with predicate 'p', would call 'families' with predicate (x,y) => p(x) == p(y).

I don't know if 'families' is a good name. I was inspired by Wittgenstein's notion of family resemblance: https://en.wikipedia.org/wiki/Family_resemblance