### PR TITLE
remove useless return in setToPairs

### DIFF
--- a/.internal/setToPairs.js
+++ b/.internal/setToPairs.js
@@ -9,9 +9,9 @@ function setToPairs(set) {
   let index = -1
   const result = new Array(set.size)
 
-  set.forEach((value) =>
+  set.forEach((value) => {
     result[++index] = [value, value]
-  )
+  })
   return result
 }
 


### PR DESCRIPTION
https://buble.surge.sh/#%20%20set.forEach((value)%20%3D%3E%20%0A%20%20%20%20result%5B%2B%2Bindex%5D%20%3D%20%5Bvalue%2C%20value%5D%0A%20%20)

vs

https://buble.surge.sh/#%20%20set.forEach((value)%20%3D%3E%20%7B%0A%20%20%20%20result%5B%2B%2Bindex%5D%20%3D%20%5Bvalue%2C%20value%5D%0A%20%20%7D)