### PR TITLE
remove unnecessary check

### DIFF
--- a/.internal/baseIntersection.js
+++ b/.internal/baseIntersection.js
@@ -45,7 +45,6 @@ function baseIntersection(arrays, iteratee, comparator) {
     let value = array[index]
     const computed = iteratee ? iteratee(value) : value
 
-    value = (comparator || value !== 0) ? value : 0
     if (!(seen
           ? cacheHas(seen, computed)
           : includes(result, computed, comparator)


### PR DESCRIPTION
I found an unnecessary check.
``` value = (comparator || value !== 0) ? value : 0```

If value is 0 then always return 0;
if value is not 0 then always return value;

I also write a simple code to prove my thought.
```
var origin = (comparator, value) => ((comparator || value !== 0) ? value : 0); 
var updated = (comparator, value) => value;

console.log(origin(false, 0) === updated(false, 0)); //true
console.log(origin(false, 1) === updated(false, 1)); //true
console.log(origin(true, 0) === updated(true, 0)); //true
console.log(origin(true, 1) === updated(true, 1)); //true
```

Hope this pull request can save some byte for lodash.