### PR TITLE
Compare strictly pickBy param with null

### DIFF
--- a/pickBy.js
+++ b/pickBy.js
@@ -19,7 +19,7 @@ import getAllKeysIn from './.internal/getAllKeysIn.js'
  * // => { 'a': 1, 'c': 3 }
  */
 function pickBy(object, predicate) {
-  if (object == null) {
+  if (object === null) {
     return {}
   }
   const props = map(getAllKeysIn(object), (prop) => [prop])


### PR DESCRIPTION
Best practices thing 
Maybe there was a good reason to use `==` here, that I would be glad to hear 👍 (honestly 😉)
