### PR TITLE
Clearing memoize cache if size >= 500

### DIFF
--- a/.internal/memoizeCapped.js
+++ b/.internal/memoizeCapped.js
@@ -14,7 +14,7 @@ const MAX_MEMOIZE_SIZE = 500
 function memoizeCapped(func) {
   const result = memoize(func, (key) => {
     const { cache } = result
-    if (cache.size === MAX_MEMOIZE_SIZE) {
+    if (cache.size >= MAX_MEMOIZE_SIZE) {
       cache.clear()
     }
     return key


### PR DESCRIPTION
* If we somehow skipped from 499 to 501 the cache would never clear