### PR TITLE
Correct license references to be CC0 instead of MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ lodash core -o ./dist/lodash.core.js
  * [Full build](https://raw.githubusercontent.com/lodash/lodash/4.17.4/dist/lodash.js) ([~24 kB gzipped](https://raw.githubusercontent.com/lodash/lodash/4.17.4/dist/lodash.min.js))
  * [CDN copies](https://www.jsdelivr.com/projects/lodash)
 
-Lodash is released under the [MIT license](https://raw.githubusercontent.com/lodash/lodash/4.17.4/LICENSE) & supports modern environments.<br>
+Lodash is released under the [Creative Commons Zero 1.0 Universal license](https://raw.githubusercontent.com/lodash/lodash/4.17.4/LICENSE) & supports modern environments.<br>
 Review the [build differences](https://github.com/lodash/lodash/wiki/build-differences) & pick one that’s right for you.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lodash",
   "version": "4.17.4",
-  "license": "MIT",
+  "license": "CC0-1.0",
   "private": true,
   "main": "lodash.js",
   "engines": {


### PR DESCRIPTION
lodash is licensed as CC0, but the package.json and README.md say MIT.  This changes the package.json SPDX license identifier and README.md to match the actual license.