### PR TITLE
Update compareMultiple.js

### DIFF
--- a/.internal/compareMultiple.js
+++ b/.internal/compareMultiple.js
@@ -27,7 +27,7 @@ function compareMultiple(object, other, orders) {
       if (index >= ordersLength) {
         return result
       }
-      const order = orders[index]
+      const order = orders[index].toLowerCase()
       return result * (order == 'desc' ? -1 : 1)
     }
   }


### PR DESCRIPTION
This PR extend sorting
Now available only lower case sorting `'asc' || 'desc'`
And after this PR will be ` 'asc' || 'desc' || 'ASC' || 'DESC'`
**Actual Result**
```
 const users = [
    { 'user': 'fred',   'age': 48 },
    { 'user': 'barney', 'age': 34 },
    { 'user': 'fred',   'age': 40 },
    { 'user': 'barney', 'age': 36 }
  ]
  // Sort by `user` in ascending order and by `age` in descending order.
 _.orderBy(users, ['user', 'age'], ['asc', 'desc'])
 // => objects for [['barney', 36], ['barney', 34], ['fred', 48], ['fred', 40]]

```
**Now will we can use**
```
  // Sort by `user` in ascending order and by `age` in descending order.
 _.orderBy(users, ['user', 'age'], ['ASC', 'DESC'])
 // => objects for [['barney', 36], ['barney', 34], ['fred', 48], ['fred', 40]]
```

