### PR TITLE
feat(defaultTo): allow multiple default values

### DIFF
--- a/defaultTo.js
+++ b/defaultTo.js
@@ -1,12 +1,12 @@
 /**
  * Checks `value` to determine whether a default value should be returned in
- * its place. The `defaultValue` is returned if `value` is `NaN`, `null`,
- * or `undefined`.
+ * its place. The first `defaultValues` argument that is not `NaN`, `null`,
+ * or `undefined` is returned.
  *
  * @since 4.14.0
  * @category Util
  * @param {*} value The value to check.
- * @param {*} defaultValue The default value.
+ * @param {*} [...defaultValues] The default value.
  * @returns {*} Returns the resolved value.
  * @example
  *
@@ -15,9 +15,18 @@
  *
  * defaultTo(undefined, 10)
  * // => 10
+ *
+ * defaultTo(undefined, NaN, 'hello', 'world')
+ * // => 'hello'
  */
-function defaultTo(value, defaultValue) {
-  return (value == null || value !== value) ? defaultValue : value
+ function defaultTo(value, ...defaultValues) {
+   for (const index in [value, ...defaultValues]) {
+     const defaultValue = defaultValues[index]
+     if (defaultValue != null && defaultValue === defaultValue) {
+       return defaultValue
+     }
+   }
+   return undefined
 }
 
 export default defaultTo


### PR DESCRIPTION
This allows `defaultTo` to accept multiple arguments `defaultTo(value, default1, default2, ..., defaultN)` returning the first value to pass the existing `defaultTo` check.

This should remain a non-breaking change and should be backward compatible with existing functionality.