### PR TITLE
Fix baseXor implementation

### DIFF
--- a/.internal/baseXor.js
+++ b/.internal/baseXor.js
@@ -18,19 +18,15 @@ function baseXor(arrays, iteratee, comparator) {
     return length ? baseUniq(arrays[0]) : []
   }
   let index = -1
-  const result = new Array(length)
+  let result = []
 
   while (++index < length) {
-    const array = arrays[index]
-    let othIndex = -1
-
-    while (++othIndex < length) {
-      if (othIndex != index) {
-        result[index] = baseDifference(result[index] || array, arrays[othIndex], iteratee, comparator)
-      }
-    }
+    result = baseFlatten([
+      baseDifference(result, arrays[index], iteratee, comparator),
+      baseDifference(arrays[index], result, iteratee, comparator)
+    ], 1)
   }
-  return baseUniq(baseFlatten(result, 1), iteratee, comparator)
+  return baseUniq(result, iteratee, comparator)
 }
 
 export default baseXor


### PR DESCRIPTION
baseXor and its dependents were changed on commit
729d1a57aa77a9c82c8292dcfa0054e4b90060b1, based on issue #2758.

But the previous implementation was correct, which respected the
properties of the algebra.

The symmetric difference of two sets is the union of both of their
relative complements, and it is commutative:

`A Δ B = (A ∖ B) ∪ (B ∖ A)`

`A Δ B = B Δ A`

In that respect, both implementations were equivalents, the problem
appeared when you tired to xor multiple sets, since the new
implementation didn't respect the associative property:

`A Δ (B Δ C) = (A Δ B) Δ C`

```javascript
const a = [1, 2, 4, 5]
const b = [2, 3, 5, 6]
const c = [4, 5, 6, 7]

_.xor( _.xor(a, b), c )
// [1, 3, 5, 7] (correct)

_.xor( a, _.xor(b, c) )
// [1, 3, 5, 7] (correct)

_.xor( a, b, c )
// [1, 3, 7] (wrong)
```

With this fix, the associativity is respected:

```javascript
_.xor( a, b, c )
// [1, 3, 5, 7] (correct)

```

See:

https://en.wikipedia.org/wiki/Symmetric_difference
https://en.wikipedia.org/wiki/Exclusive_or
https://math.stackexchange.com/questions/84184/relation-between-xor-and-symmetric-difference