### PR TITLE
Fix typo in `parseInt`

### DIFF
--- a/parseInt.js
+++ b/parseInt.js
@@ -8,7 +8,7 @@ const nativeParseInt = root.parseInt
 
 /**
  * Converts `string` to an integer of the specified radix. If `radix` is
- * `undefined` or `0`, a `radix` of `10` is used unless `value` is a
+ * `undefined` or `0`, a `radix` of `10` is used unless `string` is a
  * hexadecimal, in which case a `radix` of `16` is used.
  *
  * **Note:** This method aligns with the
@@ -17,7 +17,7 @@ const nativeParseInt = root.parseInt
  * @since 1.1.0
  * @category String
  * @param {string} string The string to convert.
- * @param {number} [radix=10] The radix to interpret `value` by.
+ * @param {number} [radix=10] The radix to interpret `string` by.
  * @returns {number} Returns the converted integer.
  * @example
  *


### PR DESCRIPTION
Parameter name is `string` not `value`.