### PR TITLE
fix(Node): ignore log files that end with random numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-*.log
+*.log*
 doc/*.html
 node_modules


### PR DESCRIPTION
This is a pretty minor update but I sometimes see npm and yarn log files that are generated with the format `npm-debug.log.<randomNumbers>`. I'm not actually sure what causes this but it seems to happen to me when I'm in a location where my wi-fi reception is spotty.

This would prevent a file such as `npm-debug.log.123456789` from being added to the commit.