### PR TITLE
Workaround memory leak issue caused by slice method

### DIFF
--- a/truncate.js
+++ b/truncate.js
@@ -74,7 +74,7 @@ function truncate(string, options) {
   }
   let result = strSymbols
     ? castSlice(strSymbols, 0, end).join('')
-    : (' ' + string.slice(0, end)).substr(1) // https://bugs.chromium.org/p/v8/issues/detail?id=2869
+    : ` ${string.slice(0, end)}`.substr(1) // https://bugs.chromium.org/p/v8/issues/detail?id=2869
 
   if (separator === undefined) {
     return result + omission

--- a/truncate.js
+++ b/truncate.js
@@ -74,7 +74,7 @@ function truncate(string, options) {
   }
   let result = strSymbols
     ? castSlice(strSymbols, 0, end).join('')
-    : string.slice(0, end)
+    : (' ' + string.slice(0, end)).substr(1) // https://bugs.chromium.org/p/v8/issues/detail?id=2869
 
   if (separator === undefined) {
     return result + omission

--- a/truncate.js
+++ b/truncate.js
@@ -72,9 +72,14 @@ function truncate(string, options) {
   if (end < 1) {
     return omission
   }
-  let result = strSymbols
-    ? castSlice(strSymbols, 0, end).join('')
-    : ` ${string.slice(0, end)}`.substr(1) // https://bugs.chromium.org/p/v8/issues/detail?id=2869
+  let result
+  if (strSymbols) {
+    result = castSlice(strSymbols, 0, end).join('')
+  } else {
+    result = string.slice(0, end)
+    // Try to force a flatten: https://github.com/davidmarkclements/flatstr
+    Number(result)
+  }
 
   if (separator === undefined) {
     return result + omission


### PR DESCRIPTION
Recently we got several complains from our users about process crash due to OutOfMemory error. We've figured out, that the leak happens when one truncates a long string and passes it to the logger. More details here https://github.com/appium/appium/issues/9543

And [this Chromium bug report](https://bugs.chromium.org/p/v8/issues/detail?id=2869) contains more detailed description of what is happening under the hood. 

So, since we use `_.truncate` method to perform strings truncation, it might be a good idea to incorporate the fix/workaround here as well, so other module users don't suffer from this problem anymore.