### PR TITLE
Faster/simpler isPlainObject check

### DIFF
--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -28,7 +28,7 @@ import isObjectLike from './isObjectLike.js'
  * // => true
  */
 function isPlainObject(value) {
-  if (!isObjectLike(value) || baseGetTag(value) != objectTag) {
+  if (!isObjectLike(value) || baseGetTag(value) != '[object Object]') {
     return false
   }
   if (Object.getPrototypeOf(value) === null) {

--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -1,15 +1,6 @@
 import baseGetTag from './.internal/baseGetTag.js'
 import isObjectLike from './isObjectLike.js'
 
-/** Used to resolve the decompiled source of functions. */
-const funcToString = Function.prototype.toString
-
-/** Used to check objects for own properties. */
-const hasOwnProperty = Object.prototype.hasOwnProperty
-
-/** Used to infer the `Object` constructor. */
-const objectCtorString = funcToString.call(Object)
-
 /**
  * Checks if `value` is a plain object, that is, an object created by the
  * `Object` constructor or one with a `[[Prototype]]` of `null`.
@@ -37,16 +28,17 @@ const objectCtorString = funcToString.call(Object)
  * // => true
  */
 function isPlainObject(value) {
-  if (!isObjectLike(value) || baseGetTag(value) != '[object Object]') {
+  if (!isObjectLike(value) || baseGetTag(value) != objectTag) {
     return false
   }
-  const proto = Object.getPrototypeOf(value)
-  if (proto === null) {
+  if (Object.getPrototypeOf(value) === null) {
     return true
   }
-  const Ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor
-  return typeof Ctor == 'function' && Ctor instanceof Ctor &&
-    funcToString.call(Ctor) == objectCtorString
+  var proto = value
+  while (Object.getPrototypeOf(proto) !== null) {
+    proto = Object.getPrototypeOf(proto)
+  }
+  return Object.getPrototypeOf(value) === proto
 }
 
 export default isPlainObject

--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -34,7 +34,7 @@ function isPlainObject(value) {
   if (Object.getPrototypeOf(value) === null) {
     return true
   }
-  var proto = value
+  let proto = value
   while (Object.getPrototypeOf(proto) !== null) {
     proto = Object.getPrototypeOf(proto)
   }


### PR DESCRIPTION
This runs up the prototype chain to check equivalency. When run in a cross-realm environment (differing contexts, iframes, etc), this ensures we're checking the value's prototype matches its context-specific instance of Object. 

This is faster than calling `toString()` on the constructor. There's still the `baseGetTag()` call, which does its own `toString()`, but this swaps out one for cross-realm stuff. It's also a bit simpler to understand, I think.