### PR TITLE
Remove `map` example from `parseInt` and `trim`

### DIFF
--- a/parseInt.js
+++ b/parseInt.js
@@ -23,9 +23,6 @@ const nativeParseInt = root.parseInt
  *
  * parseInt('08')
  * // => 8
- *
- * map(['6', '08', '10'], parseInt)
- * // => [6, 8, 10]
  */
 function parseInt(string, radix) {
   if (radix == null) {

--- a/trim.js
+++ b/trim.js
@@ -19,9 +19,6 @@ import stringToArray from './.internal/stringToArray.js'
  *
  * trim('-_-abc-_-', '_-')
  * // => 'abc'
- *
- * map(['  foo  ', '  bar  '], trim)
- * // => ['foo', 'bar']
  */
 function trim(string, chars) {
   if (string && chars === undefined) {


### PR DESCRIPTION
The examples where `parseInt` and `trim` are used with `map` are not valid anymore because the `guard` param was removed:
``` javascript
map(['6', '08', '10'], parseInt)
 // => [6, NaN, 2]
map(['  foo  ', '  bar  '], trim)
 // => ['  foo  ', '  bar  ']
```