### PR TITLE
make returning copy not over-lengthing the source

### DIFF
--- a/.internal/copyArray.js
+++ b/.internal/copyArray.js
@@ -7,6 +7,10 @@
  * @returns {Array} Returns `array`.
  */
 function copyArray(source, array) {
+  if (source.length <= array.length) {
+    return source.slice()
+  }
+
   let index = -1
   const length = source.length
 


### PR DESCRIPTION
I might be wrong but it's more intuitive to me to return a copy of the source when the destination array out-length the source.

//    copyArray([]source, <[]destination>) -> []copy
original: copyArray([1],[1,1]) // -> [1,1]
now     : copyArray([1],[1,1]) // -> [1]
