### PR TITLE
fix a test for the set methods

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -20056,7 +20056,7 @@
     QUnit.test('`_.' + methodName + '` should handle complex paths', function(assert) {
       assert.expect(2);
 
-      var object = { 'a': { '1.23': { '["b"]': { 'c': { "['d']": { '\ne\n': { 'f': { 'g': oldValue } } } } } } } };
+      var object = { 'a': { '-1.23': { '["b"]': { 'c': { "['d']": { '\ne\n': { 'f': { 'g': oldValue } } } } } } } };
 
       var paths = [
         'a[-1.23]["[\\"b\\"]"].c[\'[\\\'d\\\']\'][\ne\n][f].g',


### PR DESCRIPTION
I believe this was intended. A negative number is used here in all other "complex paths" tests, and it wouldn't make sense to create keys past this one if it doesn't match the paths used.