### PR TITLE
rAF as default for debounce/throtte (#3560)

### DIFF
--- a/debounce.js
+++ b/debounce.js
@@ -1,4 +1,5 @@
 import isObject from './isObject.js'
+import root from './.internal/root.js'
 
 /**
  * Creates a debounced function that delays invoking `func` until after `wait`
@@ -16,7 +17,9 @@ import isObject from './isObject.js'
  * is invoked more than once during the `wait` timeout.
  *
  * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
- * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ * until the next tick, similar to `setTimeout` with a timeout of `0`, unless
+ * `useRAF` is `true` in which invocation will be deferred until the next
+ * browser draw frame (typically about 16ms).
  *
  * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
  * for details over the differences between `debounce` and `throttle`.
@@ -32,6 +35,8 @@ import isObject from './isObject.js'
  *  The maximum time `func` is allowed to be delayed before it's invoked.
  * @param {boolean} [options.trailing=true]
  *  Specify invoking on the trailing edge of the timeout.
+ * @param {boolean} [options.useRAF=false]
+ *  Use requestAnimationFrame instead of setTimeout.
  * @returns {Function} Returns the new debounced function.
  * @example
  *
@@ -67,6 +72,8 @@ function debounce(func, wait, options) {
   let leading = false
   let maxing = false
   let trailing = true
+  let useRAF = false
+  const rafCapable = typeof root.requestAnimationFrame === 'function'
 
   if (typeof func != 'function') {
     throw new TypeError('Expected a function')
@@ -77,6 +84,7 @@ function debounce(func, wait, options) {
     maxing = 'maxWait' in options
     maxWait = maxing ? Math.max(+options.maxWait || 0, wait) : maxWait
     trailing = 'trailing' in options ? !!options.trailing : trailing
+    useRAF = ('useRAF' in options && rafCapable) ? !!options.useRAF : useRAF
   }
 
   function invokeFunc(time) {
@@ -89,11 +97,25 @@ function debounce(func, wait, options) {
     return result
   }
 
+  function startTimer(pendingFunc, wait) {
+    if (useRAF) {
+      return root.requestAnimationFrame(pendingFunc)
+    }
+    return setTimeout(pendingFunc, wait)
+  }
+
+  function cancelTimer(id) {
+    if (useRAF) {
+      return root.cancelAnimationFrame(id)
+    }
+    clearTimeout(id)
+  }
+
   function leadingEdge(time) {
     // Reset any `maxWait` timer.
     lastInvokeTime = time
     // Start the timer for the trailing edge.
-    timerId = setTimeout(timerExpired, wait)
+    timerId = startTimer(timerExpired, wait)
     // Invoke the leading edge.
     return leading ? invokeFunc(time) : result
   }
@@ -125,7 +147,7 @@ function debounce(func, wait, options) {
       return trailingEdge(time)
     }
     // Restart the timer.
-    timerId = setTimeout(timerExpired, remainingWait(time))
+    timerId = startTimer(timerExpired, remainingWait(time))
   }
 
   function trailingEdge(time) {
@@ -142,7 +164,7 @@ function debounce(func, wait, options) {
 
   function cancel() {
     if (timerId !== undefined) {
-      clearTimeout(timerId)
+      cancelTimer(timerId)
     }
     lastInvokeTime = 0
     lastArgs = lastCallTime = lastThis = timerId = undefined
@@ -170,12 +192,12 @@ function debounce(func, wait, options) {
       }
       if (maxing) {
         // Handle invocations in a tight loop.
-        timerId = setTimeout(timerExpired, wait)
+        timerId = startTimer(timerExpired, wait)
         return invokeFunc(lastCallTime)
       }
     }
     if (timerId === undefined) {
-      timerId = setTimeout(timerExpired, wait)
+      timerId = startTimer(timerExpired, wait)
     }
     return result
   }

--- a/throttle.js
+++ b/throttle.js
@@ -3,11 +3,11 @@ import isObject from './isObject.js'
 
 /**
  * Creates a throttled function that only invokes `func` at most once per
- * every `wait` milliseconds. The throttled function comes with a `cancel`
- * method to cancel delayed `func` invocations and a `flush` method to
- * immediately invoke them. Provide `options` to indicate whether `func`
- * should be invoked on the leading and/or trailing edge of the `wait`
- * timeout. The `func` is invoked with the last arguments provided to the
+ * every `wait` milliseconds (or once per browser frame). The throttled function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
  * throttled function. Subsequent calls to the throttled function return the
  * result of the last `func` invocation.
  *
@@ -16,9 +16,11 @@ import isObject from './isObject.js'
  * is invoked more than once during the `wait` timeout.
  *
  * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
- * until to the next tick, similar to `setTimeout` with a timeout of `0`, unless
- * `useRAF` is `true` in which invocation will be deferred until the next
- * browser draw frame (typically about 16ms).
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * If `wait` is omitted in an environment with `requestAnimationFrame`, `func`
+ * invocation will be deferred until the next frame is drawn (typically about
+ * 16ms).
  *
  * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
  * for details over the differences between `throttle` and `debounce`.
@@ -26,14 +28,14 @@ import isObject from './isObject.js'
  * @since 0.1.0
  * @category Function
  * @param {Function} func The function to throttle.
- * @param {number} [wait=0] The number of milliseconds to throttle invocations to.
+ * @param {number} [wait=0]
+ *  The number of milliseconds to throttle invocations to; if omitted,
+ *  `requestAnimationFrame` is used (if available).
  * @param {Object} [options={}] The options object.
  * @param {boolean} [options.leading=true]
  *  Specify invoking on the leading edge of the timeout.
  * @param {boolean} [options.trailing=true]
  *  Specify invoking on the trailing edge of the timeout.
- * @param {boolean} [options.useRAF=false]
- *  Use requestAnimationFrame instead of setTimeout.
  * @returns {Function} Returns the new throttled function.
  * @example
  *
@@ -50,7 +52,6 @@ import isObject from './isObject.js'
 function throttle(func, wait, options) {
   let leading = true
   let trailing = true
-  let useRAF = false
 
   if (typeof func != 'function') {
     throw new TypeError('Expected a function')
@@ -58,13 +59,11 @@ function throttle(func, wait, options) {
   if (isObject(options)) {
     leading = 'leading' in options ? !!options.leading : leading
     trailing = 'trailing' in options ? !!options.trailing : trailing
-    useRAF = 'useRAF' in options ? !!options.useRAF : useRAF
   }
   return debounce(func, wait, {
     'leading': leading,
     'maxWait': wait,
-    'trailing': trailing,
-    'useRAF': useRAF
+    'trailing': trailing
   })
 }
 

--- a/throttle.js
+++ b/throttle.js
@@ -16,7 +16,9 @@ import isObject from './isObject.js'
  * is invoked more than once during the `wait` timeout.
  *
  * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
- * until to the next tick, similar to `setTimeout` with a timeout of `0`.
+ * until to the next tick, similar to `setTimeout` with a timeout of `0`, unless
+ * `useRAF` is `true` in which invocation will be deferred until the next
+ * browser draw frame (typically about 16ms).
  *
  * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
  * for details over the differences between `throttle` and `debounce`.
@@ -30,6 +32,8 @@ import isObject from './isObject.js'
  *  Specify invoking on the leading edge of the timeout.
  * @param {boolean} [options.trailing=true]
  *  Specify invoking on the trailing edge of the timeout.
+ * @param {boolean} [options.useRAF=false]
+ *  Use requestAnimationFrame instead of setTimeout.
  * @returns {Function} Returns the new throttled function.
  * @example
  *
@@ -46,6 +50,7 @@ import isObject from './isObject.js'
 function throttle(func, wait, options) {
   let leading = true
   let trailing = true
+  let useRAF = false
 
   if (typeof func != 'function') {
     throw new TypeError('Expected a function')
@@ -53,11 +58,13 @@ function throttle(func, wait, options) {
   if (isObject(options)) {
     leading = 'leading' in options ? !!options.leading : leading
     trailing = 'trailing' in options ? !!options.trailing : trailing
+    useRAF = 'useRAF' in options ? !!options.useRAF : useRAF
   }
   return debounce(func, wait, {
     'leading': leading,
     'maxWait': wait,
-    'trailing': trailing
+    'trailing': trailing,
+    'useRAF': useRAF
   })
 }
 


### PR DESCRIPTION
Uses `requestAnimationFrame` by default (when available on the `root` object), unless `wait` is passed as `0` or a truthy value.

This is in reply to #3562, and in turn, #3560.

Feedback is welcome and appreciated. 😀