### PR TITLE
 fix support string, chinese sort

### DIFF
--- a/.internal/compareAscending.js
+++ b/.internal/compareAscending.js
@@ -22,7 +22,7 @@ function compareAscending(value, other) {
 
     let val = 0
     if (typeof value == 'string') {
-      val = value.localeCompare(other)
+      val = value.localeCompare(other,'zh')
     } else {
       val = value - other
     }

--- a/.internal/compareAscending.js
+++ b/.internal/compareAscending.js
@@ -20,14 +20,21 @@ function compareAscending(value, other) {
     const othIsReflexive = other === other
     const othIsSymbol = isSymbol(other)
 
-    if ((!othIsNull && !othIsSymbol && !valIsSymbol && value > other) ||
+    let val = 0
+    if (typeof value == 'string') {
+      val = value.localeCompare(other)
+    } else {
+      val = value - other
+    }
+
+    if ((!othIsNull && !othIsSymbol && !valIsSymbol && val>0) ||
         (valIsSymbol && othIsDefined && othIsReflexive && !othIsNull && !othIsSymbol) ||
         (valIsNull && othIsDefined && othIsReflexive) ||
         (!valIsDefined && othIsReflexive) ||
         !valIsReflexive) {
       return 1
     }
-    if ((!valIsNull && !valIsSymbol && !othIsSymbol && value < other) ||
+    if ((!valIsNull && !valIsSymbol && !othIsSymbol && val<0) ||
         (othIsSymbol && valIsDefined && valIsReflexive && !valIsNull && !valIsSymbol) ||
         (othIsNull && valIsDefined && valIsReflexive) ||
         (!othIsDefined && valIsReflexive) ||


### PR DESCRIPTION
**test code**
```js
 var users = [
        {'name': '孤',py:'gu'},
        {'name': '帆',py:'fan'},
        {'name': '远',py:'yuan'},
        {'name': '影',py:'ying'},
        {'name': '碧',py:'bi'},
        {'name': '空',py:'kong'},
        {'name': '尽',py:'jin'},
    ];
    var orderedPY = _.orderBy(users,['py'],['asc']);
    var orderedCn = _.orderBy(users,['name'],['asc']);    
    console.log(orderedPY);
    console.log(orderedCn);
```