### PR TITLE
Pass key option to partition

### DIFF
--- a/partition.js
+++ b/partition.js
@@ -22,6 +22,9 @@ import reduce from './reduce.js'
  *
  * partition(users, ({ active }) => active)
  * // => objects for [['fred'], ['barney', 'pebbles']]
+ *
+ * partition(users, (value, key) => key < 1)
+ * // => objects for [['barney'], ['fred', 'pebbles']]
  */
 function partition(collection, predicate) {
   return reduce(collection, (result, value, key) => (

--- a/partition.js
+++ b/partition.js
@@ -25,7 +25,7 @@ import reduce from './reduce.js'
  */
 function partition(collection, predicate) {
   return reduce(collection, (result, value, key) => (
-    result[predicate(value) ? 0 : 1].push(value), result
+    result[predicate(value, key) ? 0 : 1].push(value), result
   ), [[], []])
 }
 


### PR DESCRIPTION
In partition it is not possible to access the key of the object. This is a bit inconsistent with the rest of the methods (map, forEach...).

I've added the code and the example