### PR TITLE
internal: use util.types to migrate DEP0103 in Node.js

### DIFF
--- a/.internal/nodeTypes.js
+++ b/.internal/nodeTypes.js
@@ -13,10 +13,16 @@ const moduleExports = freeModule && freeModule.exports === freeExports
 const freeProcess = moduleExports && freeGlobal.process
 
 /** Used to access faster Node.js helpers. */
-const nodeUtil = ((() => {
+const nodeTypes = ((() => {
   try {
-    return freeProcess && freeProcess.binding && freeProcess.binding('util')
+    /* Detect public `util.types` helpers for Node.js v10+. */
+    /* Node.js deprecation code: DEP0103. */
+    const typesHelper = freeModule && freeModule.require && freeModule.require('util').types
+    return typesHelper
+      ? typesHelper
+      /* Legacy process.binding('util') for Node.js earlier than v10. */
+      : freeProcess && freeProcess.binding && freeProcess.binding('util')
   } catch (e) {}
 })())
 
-export default nodeUtil
+export default nodeTypes

--- a/isArrayBuffer.js
+++ b/isArrayBuffer.js
@@ -1,9 +1,9 @@
 import baseGetTag from './.internal/baseGetTag.js'
 import isObjectLike from './isObjectLike.js'
-import nodeUtil from './.internal/nodeUtil.js'
+import nodeTypes from './.internal/nodeTypes.js'
 
 /* Node.js helper references. */
-const nodeIsArrayBuffer = nodeUtil && nodeUtil.isArrayBuffer
+const nodeIsArrayBuffer = nodeTypes && nodeTypes.isArrayBuffer
 
 /**
  * Checks if `value` is classified as an `ArrayBuffer` object.

--- a/isDate.js
+++ b/isDate.js
@@ -1,9 +1,9 @@
 import baseGetTag from './.internal/baseGetTag.js'
 import isObjectLike from './isObjectLike.js'
-import nodeUtil from './.internal/nodeUtil.js'
+import nodeTypes from './.internal/nodeTypes.js'
 
 /* Node.js helper references. */
-const nodeIsDate = nodeUtil && nodeUtil.isDate
+const nodeIsDate = nodeTypes && nodeTypes.isDate
 
 /**
  * Checks if `value` is classified as a `Date` object.

--- a/isMap.js
+++ b/isMap.js
@@ -1,9 +1,9 @@
 import getTag from './.internal/getTag.js'
 import isObjectLike from './isObjectLike.js'
-import nodeUtil from './.internal/nodeUtil.js'
+import nodeTypes from './.internal/nodeTypes.js'
 
 /* Node.js helper references. */
-const nodeIsMap = nodeUtil && nodeUtil.isMap
+const nodeIsMap = nodeTypes && nodeTypes.isMap
 
 /**
  * Checks if `value` is classified as a `Map` object.

--- a/isRegExp.js
+++ b/isRegExp.js
@@ -1,9 +1,9 @@
 import baseGetTag from './.internal/baseGetTag.js'
 import isObjectLike from './isObjectLike.js'
-import nodeUtil from './.internal/nodeUtil.js'
+import nodeTypes from './.internal/nodeTypes.js'
 
 /* Node.js helper references. */
-const nodeIsRegExp = nodeUtil && nodeUtil.isRegExp
+const nodeIsRegExp = nodeTypes && nodeTypes.isRegExp
 
 /**
  * Checks if `value` is classified as a `RegExp` object.

--- a/isSet.js
+++ b/isSet.js
@@ -1,9 +1,9 @@
 import getTag from './.internal/getTag.js'
-import nodeUtil from './.internal/nodeUtil.js'
+import nodeTypes from './.internal/nodeTypes.js'
 import isObjectLike from './isObjectLike'
 
 /* Node.js helper references. */
-const nodeIsSet = nodeUtil && nodeUtil.isSet
+const nodeIsSet = nodeTypes && nodeTypes.isSet
 
 /**
  * Checks if `value` is classified as a `Set` object.

--- a/isTypedArray.js
+++ b/isTypedArray.js
@@ -1,12 +1,12 @@
 import getTag from './.internal/getTag.js'
-import nodeUtil from './.internal/nodeUtil.js'
+import nodeTypes from './.internal/nodeTypes.js'
 import isObjectLike from './isObjectLike'
 
 /** Used to match `toStringTag` values of typed arrays. */
 const reTypedTag = /^\[object (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)\]$/
 
 /* Node.js helper references. */
-const nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray
+const nodeIsTypedArray = nodeTypes && nodeTypes.isTypedArray
 
 /**
  * Checks if `value` is classified as a typed array.


### PR DESCRIPTION
- Use require('util').types instead of using process.binding('util')
  to get the type checking helpers
- Rename nodeUtil to nodeTypes since that is what it is for

Refs: https://github.com/nodejs/node/pull/18415

Here is what I used to test this script:

arr.js

```js
import isArrayBuffer from './isArrayBuffer.js'
import isDate from './isDate.js'
import isMap from './isMap.js'
import isRegExp from './isRegExp.js'
import isSet from './isSet.js'
import isTypedArray from './isTypedArray.js'

const arr = [
  isArrayBuffer(new Uint8Array().buffer),
  isDate(new Date()),
  isMap(new Map()),
  isRegExp(/test/),
  isSet(new Set()),
  isTypedArray(new Uint8Array())
]

export default arr
```

test.js

```js
'use strict';
const a = require('./bundle');
console.log(a);
```

```bash
wget https://nodejs.org/download/nightly/v10.0.0-nightly20180322e714da6f0a/node-v10.0.0-nightly20180322e714da6f0a-darwin-x64.tar.xz
tar xf node-v10.0.0-nightly20180322e714da6f0a-darwin-x64.tar.xz

git checkout master
rollup arr.js --output.format cjs --output.file bundle.js
node-v10.0.0-nightly20180322e714da6f0a-darwin-x64/bin/node --pending-deprecation --trace-warnings test.js
# [ true, true, true, true, true, true ]
# [DEP0103] DeprecationWarning: Accessing native typechecking bindings of Node directly is deprecated. Please use `util.types.isArrayBuffer` instead.

git checkout node-dep-0103
rollup arr.js --output.format cjs --output.file bundle.js
node-v10.0.0-nightly20180322e714da6f0a-darwin-x64/bin/node --pending-deprecation --trace-warnings test.js
# [ true, true, true, true, true, true ]
# no warnings
```
