### PR TITLE
Added short circuit for typed arrays

### DIFF
--- a/.internal/baseClone.js
+++ b/.internal/baseClone.js
@@ -218,6 +218,10 @@ function baseClone(value, bitmask, customizer, key, object, stack) {
     return result
   }
 
+  if (isTypedArray(value)) {
+    return result;
+  }
+
   const keysFunc = isFull
     ? (isFlat ? getAllKeysIn : getAllKeys)
     : (isFlat ? keysIn : keys)


### PR DESCRIPTION
We're using `cloneDeep` for large typed arrays (80k entries or more). We noticed that `cloneDeep` was taking a lot longer than expected for these data sets. After some sleuthing, it looks like the culprit is `baseClone` trying to iterate over the keys of the typed array and copy over its values

We've decided to put in a short circuit clause (not sure if I did it right -- there's probably a slicker way with the `tag` string) to prevent this from happening

We've seen a decrease from 300ms to 3-30ms for 80k entries on an iPad mini

```js
console.time('a');
lodash.cloneDeep(new Float32Array(80e3));
console.timeEnd('a');
```

In this PR:

- Added short circuit for typed arrays

**Notes:**

We'd be happy to write performance tests as well but couldn't seem to find a location to do so