### PR TITLE
Clarify doc for `range` usage with single arg

### DIFF
--- a/range.js
+++ b/range.js
@@ -4,7 +4,7 @@ import createRange from './.internal/createRange.js'
  * Creates an array of numbers (positive and/or negative) progressing from
  * `start` up to, but not including, `end`. A step of `-1` is used if a negative
  * `start` is specified without an `end` or `step`. If `end` is not specified,
- * it's set to `start` with `start` then set to `0`.
+ * it's set to `start`, and `start` is then set to `0`.
  *
  * **Note:** JavaScript follows the IEEE-754 standard for resolving
  * floating-point values which can produce unexpected results.


### PR DESCRIPTION
I found the explanation of range usage with a single argument to be a bit confusing. This rearranges slightly to reduce ambiguity.

Recreated PR to fix CLA-bot problem due to different emails in use.