### PR TITLE
Update `filterObject` docs to reference `pickBy`

### DIFF
--- a/filterObject.js
+++ b/filterObject.js
@@ -3,12 +3,14 @@
  * `predicate` returns truthy for. The predicate is invoked with three
  * arguments: (value, key, object).
  *
+ * **Note:** If you want an object in return, consider `pickBy`.
+ *
  * @since 5.0.0
  * @category Object
  * @param {Object} object The object to iterate over.
  * @param {Function} predicate The function invoked per iteration.
  * @returns {Array} Returns the new filtered array.
- * @see pull, pullAll, pullAllBy, pullAllWith, pullAt, remove, reject
+ * @see pickBy, pull, pullAll, pullAllBy, pullAllWith, pullAt, remove, reject
  * @example
  *
  * const object = { 'a': 5, 'b': 8, 'c': 10 }

--- a/filterObject.js
+++ b/filterObject.js
@@ -3,7 +3,7 @@
  * `predicate` returns truthy for. The predicate is invoked with three
  * arguments: (value, key, object).
  *
- * **Note:** If you want an object in return, consider `pickBy`.
+ * If you want an object in return, consider `pickBy`.
  *
  * @since 5.0.0
  * @category Object


### PR DESCRIPTION
This is clearly an area of confusion -- see [this question](https://stackoverflow.com/questions/30726830/how-to-filter-keys-of-an-object-with-lodash) as an example. Hopefully this helps.