### PR TITLE
isJSON Method

### DIFF
--- a/isJSON.js
+++ b/isJSON.js
@@ -1,0 +1,30 @@
+import isObjectLike from './isObjectLike.js'
+import isArrayLike from './isArrayLike.js'
+
+/**
+ * This method checks if `value` is JSON-formatted object.
+ *
+ * @since 4.18.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a JSON object,
+ *  else `false`.
+ * @example
+ *
+ * isJSON([1, 2, 3])
+ * // => false
+ *
+ * isJSON({'a': 1, 'b': 2, 'c': 3})
+ * // => true
+ *
+ * isJSON({})
+ * // => true
+ *
+ * isJSON(null)
+ * // => false
+ */
+function isJSON(value) {
+  return isObjectLike(value) && !isArrayLike(value) && obj.constructor === {}.constructor
+}
+
+export default isJSON

--- a/isJSON.js
+++ b/isJSON.js
@@ -24,7 +24,7 @@ import isArrayLike from './isArrayLike.js'
  * // => false
  */
 function isJSON(value) {
-  return isObjectLike(value) && !isArrayLike(value) && obj.constructor === {}.constructor
+  return isObjectLike(value) && !isArrayLike(value) && value.constructor === {}.constructor
 }
 
 export default isJSON


### PR DESCRIPTION
We know that `object` type may include several things but for confirming whether the object is JSON-like, having `isJSON` method is necessary.

There should not be any error regarding test and style but the importance of this matters, and I think by most `_` users this method is going to be loved.

Thanks in advance!