### PR TITLE
--save no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In a browser:
 Using npm:
 ```shell
 $ npm i -g npm
-$ npm i --save lodash
+$ npm i lodash
 ```
 
 In Node.js:


### PR DESCRIPTION
`--save` is on by default as of [npm 5](https://blog.npmjs.org/post/161081169345/v500), so `npm install aphrodite` is functionally equivalent to `npm install --save aphrodite` now