### PR TITLE
Curry fixes + tests for issue #3981

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1084,6 +1084,7 @@
         ++result;
       }
     }
+
     return result;
   }
 
@@ -1221,6 +1222,7 @@
         result[resIndex++] = index;
       }
     }
+
     return result;
   }
 
@@ -4680,14 +4682,17 @@
       while (++leftIndex < leftLength) {
         result[leftIndex] = partials[leftIndex];
       }
+
       while (++argsIndex < holdersLength) {
         if (isUncurried || argsIndex < argsLength) {
           result[holders[argsIndex]] = args[argsIndex];
         }
       }
+
       while (rangeLength--) {
         result[leftIndex++] = args[argsIndex++];
       }
+
       return result;
     }
 
@@ -5025,16 +5030,19 @@
         while (index--) {
           args[index] = arguments[index];
         }
+
         var holders = (length < 3 && args[0] !== placeholder && args[length - 1] !== placeholder)
           ? []
           : replaceHolders(args, placeholder);
 
         length -= holders.length;
-        if (length < arity) {
+
+        if (length < arity || holders.length) {
           return createRecurry(
             func, bitmask, createHybrid, wrapper.placeholder, undefined,
             args, holders, undefined, undefined, arity - length);
         }
+
         var fn = (this && this !== root && this instanceof wrapper) ? Ctor : func;
         return apply(fn, this, args);
       }
@@ -5157,6 +5165,7 @@
         while (index--) {
           args[index] = arguments[index];
         }
+
         if (isCurried) {
           var placeholder = getHolder(wrapper),
               holdersCount = countHolders(args, placeholder);
@@ -5167,9 +5176,12 @@
         if (partialsRight) {
           args = composeArgsRight(args, partialsRight, holdersRight, isCurried);
         }
+
         length -= holdersCount;
-        if (isCurried && length < arity) {
+
+        if ((isCurried && length < arity) || holdersCount) {
           var newHolders = replaceHolders(args, placeholder);
+
           return createRecurry(
             func, bitmask, createHybrid, wrapper.placeholder, thisArg,
             args, newHolders, argPos, ary, arity - length
@@ -5179,17 +5191,21 @@
             fn = isBindKey ? thisBinding[func] : func;
 
         length = args.length;
+
         if (argPos) {
           args = reorder(args, argPos);
         } else if (isFlip && length > 1) {
           args.reverse();
         }
+
         if (isAry && ary < length) {
           args.length = ary;
         }
+
         if (this && this !== root && this instanceof wrapper) {
           fn = Ctor || createCtor(fn);
         }
+
         return fn.apply(thisBinding, args);
       }
       return wrapper;
@@ -5391,15 +5407,18 @@
       if (!(bitmask & WRAP_CURRY_BOUND_FLAG)) {
         bitmask &= ~(WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG);
       }
+
       var newData = [
         func, bitmask, thisArg, newPartials, newHolders, newPartialsRight,
         newHoldersRight, argPos, ary, arity
       ];
 
       var result = wrapFunc.apply(undefined, newData);
+
       if (isLaziable(func)) {
         setData(result, newData);
       }
+
       result.placeholder = placeholder;
       return setWrapToString(result, func, bitmask);
     }
@@ -5487,10 +5506,12 @@
      */
     function createWrap(func, bitmask, thisArg, partials, holders, argPos, ary, arity) {
       var isBindKey = bitmask & WRAP_BIND_KEY_FLAG;
+
       if (!isBindKey && typeof func != 'function') {
         throw new TypeError(FUNC_ERROR_TEXT);
       }
       var length = partials ? partials.length : 0;
+
       if (!length) {
         bitmask &= ~(WRAP_PARTIAL_FLAG | WRAP_PARTIAL_RIGHT_FLAG);
         partials = holders = undefined;
@@ -10194,10 +10215,11 @@
     function curry(func, arity, guard) {
       arity = guard ? undefined : arity;
       var result = createWrap(func, WRAP_CURRY_FLAG, undefined, undefined, undefined, undefined, undefined, arity);
+
       result.placeholder = curry.placeholder;
       return result;
     }
-
+    
     /**
      * This method is like `_.curry` except that arguments are applied to `func`
      * in the manner of `_.partialRight` instead of `_.partial`.

--- a/test/test.js
+++ b/test/test.js
@@ -3855,7 +3855,7 @@
     });
 
     QUnit.test('should support placeholders', function(assert) {
-      assert.expect(4);
+      assert.expect(6);
 
       var curried = _.curry(fn),
           ph = curried.placeholder;
@@ -3864,6 +3864,26 @@
       assert.deepEqual(curried(ph, 2)(1)(ph, 4)(3), [1, 2, 3, 4]);
       assert.deepEqual(curried(ph, ph, 3)(ph, 2)(ph, 4)(1), [1, 2, 3, 4]);
       assert.deepEqual(curried(ph, ph, ph, 4)(ph, ph, 3)(ph, 2)(1), [1, 2, 3, 4]);
+      assert.deepEqual(curried(_, 2)(_, 3)(_, 4)(1), [1, 2, 3, 4]);
+      assert.deepEqual(curried(_, 3)(4, _)(_, 1)(2), [4, 3, 2, 1]);
+    });
+
+    QUnit.test('Should ignore arguments outside of original arity of fn', function(assert) {
+      assert.expect(5);
+
+      var returnsArgs = function(a, b) {
+        return [a, b];
+      }
+
+      var curried = _.curry(returnsArgs),
+          ph = curried.placeholder,
+          actual = [1, 2];
+
+      assert.deepEqual(actual, curried(1, ph)(2));
+      assert.deepEqual(actual, curried(1, ph, 0)(2));
+      assert.deepEqual(actual, curried(1, ph, 0, 2, 4)(2));
+      assert.deepEqual(actual, curried(1, ph, ph)(2));
+      assert.deepEqual(actual, curried(1, ph, ph)(ph, 2)(2));
     });
 
     QUnit.test('should persist placeholders', function(assert) {


### PR DESCRIPTION
## What does this PR do?

In a ***curry***, placeholder values were sometimes being passed to the original function like below:

```js
const triples = _.curry((a, b, c) => [a, b, c]);
triples(_, 2, _)(_, 3)(_, 1); // => [f, 2, 3]
triples(_, 2)(_, 3)(_, 1);    // => [f, 2, 3]
triples(_, 2)(3, _)(_, 1);    // => [f, 2, 3]
// Where f === lodash (placeholder)
```

Expected:

```js
const triples = curry((a, b, c) => [a, b, c]);
triples(_, 2, _)(_, 3)(_, 1);   // => triples
triples(_, 2, _)(_, 3)(_, 1)(1) // => [1, 2, 3]
```

Also, ***curry*** was taking into consideration arguments that were outside of the arity of the original function like below:

```js
const pairs = _.curry((a, b) => [a, b]);
pairs(1, _, 0) // => [1, "__lodash_placeholder__"]
```

Expected:

```js
const pairs = _.curry((a, b) => [a, b]);
pairs(1, _, 0);                       // pairs
pairs(1, _, 0)(2);                    // => [1, 2]
pairs(1, _, 0, 5, 50)(_, _, _, _)(2); // => [1, 2]
```

Issue: #3981 