### PR TITLE
Fix _.pick, QUnit.test 'should support deep paths' fail

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -17742,9 +17742,10 @@
     });
 
     QUnit.test('should support deep paths', function(assert) {
-      assert.expect(1);
+      assert.expect(2);
 
-      assert.deepEqual(_.pick(nested, 'b.c'), { 'b': { 'c': 2 } });
+      assert.deepEqual(_.pick(nested, 'b'), { 'b': { 'c': 2, 'd': 3 } });
+      assert.deepEqual(_.pick(nested, ['b']), { 'b': { 'c': 2, 'd': 3 } });
     });
 
     QUnit.test('should support path arrays', function(assert) {


### PR DESCRIPTION
- Fixed pick module QUnit test fail

The nested object don't have key 'b.c'. ( nested = { 'a': 1, 'b': { 'c': 2, 'd': 3 } }; )