### PR TITLE
Call upperFirst directly, instead of capitalize, in camelCase

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14133,7 +14133,7 @@
      */
     var camelCase = createCompounder(function(result, word, index) {
       word = word.toLowerCase();
-      return result + (index ? capitalize(word) : word);
+      return result + (index ? upperFirst(word) : word);
     });
 
     /**


### PR DESCRIPTION
This avoids double call to lowerCase. Fixes #4075 