### PR TITLE
Call clearTimeout on debounce.flush (#4074)

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -10390,7 +10390,11 @@
       }
 
       function flush() {
-        return timerId === undefined ? result : trailingEdge(now());
+        if (timerId !== undefined) {
+          clearTimeout(timerId);
+          return trailingEdge(now());
+        }
+        return result;
       }
 
       function debounced() {


### PR DESCRIPTION
Fixes #4074 but unlike proposed in the issue, calls clearTimeout outside of trailingEdge to avoid extra conditional check and unnecessary clearTimeout call, i.e., when timer is expired 