### PR TITLE
Remove unnecessary null check in arrayEach

### DIFF
--- a/.internal/arrayEach.js
+++ b/.internal/arrayEach.js
@@ -8,7 +8,7 @@
  */
 function arrayEach(array, iteratee) {
   let index = -1
-  const length = array == null ? 0 : array.length
+  const length = array.length
 
   while (++index < length) {
     if (iteratee(array[index], index, array) === false) {


### PR DESCRIPTION
`arrayEach` is called in three places: `baseClone`, `forEach` and `transform`. In each one, the call is preceded by a check that ensures the passed array is not null
