### PR TITLE
fix: limit the precision when the precision is negative

### DIFF
--- a/.internal/createRound.js
+++ b/.internal/createRound.js
@@ -8,7 +8,7 @@
 function createRound(methodName) {
   const func = Math[methodName]
   return (number, precision) => {
-    precision = precision == null ? 0 : Math.min(precision, 292)
+    precision = precision == null ? 0 : (precision >= 0 ? Math.min(precision, 292) : Math.max(precision, -292))
     if (precision) {
       // Shift with exponential notation to avoid floating-point issues.
       // See [MDN](https://mdn.io/round#Examples) for more details.


### PR DESCRIPTION
Signed-off-by: asilinwei <1021069119@qq.com>
There is a problem about _.floor():
`_.floor(12, Infinity)  // => 12`
But, when the precision is -Infinity:
`_.floor(12, -Infinity) // => NaN`
It is not very suitable because it is only limited the precision when the precision is positive.
It also should be limited the precision when the precision is negative.