### PR TITLE
Replace MapCache by Map in memoize (#4094)

### DIFF
--- a/memoize.js
+++ b/memoize.js
@@ -1,5 +1,3 @@
-import MapCache from './.internal/MapCache.js'
-
 /**
  * Creates a function that memoizes the result of `func`. If `resolver` is
  * provided, it determines the cache key for storing the result based on the
@@ -57,10 +55,10 @@ function memoize(func, resolver) {
     memoized.cache = cache.set(key, result) || cache
     return result
   }
-  memoized.cache = new (memoize.Cache || MapCache)
+  memoized.cache = new (memoize.Cache || Map)
   return memoized
 }
 
-memoize.Cache = MapCache
+memoize.Cache = Map
 
 export default memoize


### PR DESCRIPTION
Replaces MapCache by Map in memoize as stated in #4094

For the record i patched locally v4 and all tests passes