### PR TITLE
 Re-add keysIn module fixing baseClone and baseMerge (#4099) 

### DIFF
--- a/keysIn.js
+++ b/keysIn.js
@@ -1,0 +1,32 @@
+/**
+ * Creates an array of the own and inherited enumerable property names of `object`.
+ *
+ *
+ * @static
+ * @memberOf _
+ * @since 3.0.0
+ * @category Object
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ * @example
+ *
+ * function Foo() {
+ *   this.a = 1;
+ *   this.b = 2;
+ * }
+ *
+ * Foo.prototype.c = 3;
+ *
+ * _.keysIn(new Foo);
+ * // => ['a', 'b', 'c'] (iteration order is not guaranteed)
+ */
+function keysIn(object) {
+  const result = []
+  for (key in object) {
+    result.push(key)
+  }
+  return result
+}
+
+export default keysIn
+


### PR DESCRIPTION
Fixes #4099 

Since keysIn is passed along as a variable, i needed to create a local function instead of using key-in in place