### PR TITLE
Remove check for existence of getOwnPropertySymbols

### DIFF
--- a/.internal/getSymbols.js
+++ b/.internal/getSymbols.js
@@ -13,7 +13,7 @@ const nativeGetSymbols = Object.getOwnPropertySymbols
  * @param {Object} object The object to query.
  * @returns {Array} Returns the array of symbols.
  */
-const getSymbols = !nativeGetSymbols ? () => [] : (object) => {
+function getSymbols (object) {
   if (object == null) {
     return []
   }

--- a/.internal/getSymbolsIn.js
+++ b/.internal/getSymbolsIn.js
@@ -1,8 +1,5 @@
 import getSymbols from './getSymbols.js'
 
-/* Built-in method references for those with the same name as other `lodash` methods. */
-const nativeGetSymbols = Object.getOwnPropertySymbols
-
 /**
  * Creates an array of the own and inherited enumerable symbols of `object`.
  *
@@ -10,7 +7,7 @@ const nativeGetSymbols = Object.getOwnPropertySymbols
  * @param {Object} object The object to query.
  * @returns {Array} Returns the array of symbols.
  */
-const getSymbolsIn = !nativeGetSymbols ? () => [] : (object) => {
+function getSymbolsIn (object) {
   const result = []
   while (object) {
     result.push(...getSymbols(object))


### PR DESCRIPTION
Modern environments have it 