### PR TITLE
Use baseGetTag instead of getTag where possible

### DIFF
--- a/.internal/baseIsEqualDeep.js
+++ b/.internal/baseIsEqualDeep.js
@@ -2,7 +2,7 @@ import Stack from './Stack.js'
 import equalArrays from './equalArrays.js'
 import equalByTag from './equalByTag.js'
 import equalObjects from './equalObjects.js'
-import getTag from './getTag.js'
+import baseGetTag from './baseGetTag.js'
 import isBuffer from '../isBuffer.js'
 import isTypedArray from '../isTypedArray.js'
 
@@ -34,8 +34,8 @@ const hasOwnProperty = Object.prototype.hasOwnProperty
 function baseIsEqualDeep(object, other, bitmask, customizer, equalFunc, stack) {
   let objIsArr = Array.isArray(object)
   const othIsArr = Array.isArray(other)
-  let objTag = objIsArr ? arrayTag : getTag(object)
-  let othTag = othIsArr ? arrayTag : getTag(other)
+  let objTag = objIsArr ? arrayTag : baseGetTag(object)
+  let othTag = othIsArr ? arrayTag : baseGetTag(other)
 
   objTag = objTag == argsTag ? objectTag : objTag
   othTag = othTag == argsTag ? objectTag : othTag

--- a/isArguments.js
+++ b/isArguments.js
@@ -1,4 +1,4 @@
-import getTag from './.internal/getTag.js'
+import baseGetTag from './.internal/baseGetTag.js'
 import isObjectLike from './isObjectLike'
 
 /**
@@ -17,7 +17,7 @@ import isObjectLike from './isObjectLike'
  * // => false
  */
 function isArguments(value) {
-  return isObjectLike(value) && getTag(value) == '[object Arguments]'
+  return isObjectLike(value) && baseGetTag(value) == '[object Arguments]'
 }
 
 export default isArguments

--- a/isString.js
+++ b/isString.js
@@ -1,4 +1,4 @@
-import getTag from './.internal/getTag.js'
+import baseGetTag from './.internal/baseGetTag.js'
 
 /**
  * Checks if `value` is classified as a `String` primitive or object.
@@ -17,7 +17,7 @@ import getTag from './.internal/getTag.js'
  */
 function isString(value) {
   const type = typeof value
-  return type == 'string' || (type == 'object' && value != null && !Array.isArray(value) && getTag(value) == '[object String]')
+  return type == 'string' || (type == 'object' && value != null && !Array.isArray(value) && baseGetTag(value) == '[object String]')
 }
 
 export default isString

--- a/isSymbol.js
+++ b/isSymbol.js
@@ -1,4 +1,4 @@
-import getTag from './.internal/getTag.js'
+import baseGetTag from './.internal/baseGetTag.js'
 
 /**
  * Checks if `value` is classified as a `Symbol` primitive or object.
@@ -17,7 +17,7 @@ import getTag from './.internal/getTag.js'
  */
 function isSymbol(value) {
   const type = typeof value
-  return type == 'symbol' || (type == 'object' && value != null && getTag(value) == '[object Symbol]')
+  return type == 'symbol' || (type == 'object' && value != null && baseGetTag(value) == '[object Symbol]')
 }
 
 export default isSymbol

--- a/isTypedArray.js
+++ b/isTypedArray.js
@@ -1,4 +1,4 @@
-import getTag from './.internal/getTag.js'
+import baseGetTag from './.internal/baseGetTag.js'
 import nodeTypes from './.internal/nodeTypes.js'
 import isObjectLike from './isObjectLike'
 
@@ -25,6 +25,6 @@ const nodeIsTypedArray = nodeTypes && nodeTypes.isTypedArray
  */
 const isTypedArray = nodeIsTypedArray
   ? (value) => nodeIsTypedArray(value)
-  : (value) => isObjectLike(value) && reTypedTag.test(getTag(value))
+  : (value) => isObjectLike(value) && reTypedTag.test(baseGetTag(value))
 
 export default isTypedArray


### PR DESCRIPTION
Use baseGetTag instead of getTag where the fallbacks done in getTag are not relevant

This reduces the affected modules size significantly