### PR TITLE
Use native filter instead of custom one where possible

### DIFF
--- a/.internal/getSymbols.js
+++ b/.internal/getSymbols.js
@@ -1,5 +1,3 @@
-import filter from '../filter.js'
-
 /** Built-in value references. */
 const propertyIsEnumerable = Object.prototype.propertyIsEnumerable
 
@@ -18,7 +16,7 @@ function getSymbols (object) {
     return []
   }
   object = Object(object)
-  return filter(nativeGetSymbols(object), (symbol) => propertyIsEnumerable.call(object, symbol))
+  return nativeGetSymbols(object).filter((symbol) => propertyIsEnumerable.call(object, symbol))
 }
 
 export default getSymbols

--- a/xor.js
+++ b/xor.js
@@ -1,4 +1,3 @@
-import filter from './filter.js'
 import baseXor from './.internal/baseXor.js'
 import isArrayLikeObject from './isArrayLikeObject.js'
 
@@ -19,7 +18,7 @@ import isArrayLikeObject from './isArrayLikeObject.js'
  * // => [1, 3]
  */
 function xor(...arrays) {
-  return baseXor(filter(arrays, isArrayLikeObject))
+  return baseXor(arrays.filter(isArrayLikeObject))
 }
 
 export default xor

--- a/xorBy.js
+++ b/xorBy.js
@@ -1,4 +1,3 @@
-import filter from './filter.js'
 import baseXor from './.internal/baseXor.js'
 import isArrayLikeObject from './isArrayLikeObject.js'
 import last from './last.js'
@@ -26,7 +25,7 @@ function xorBy(...arrays) {
   if (isArrayLikeObject(iteratee)) {
     iteratee = undefined
   }
-  return baseXor(filter(arrays, isArrayLikeObject), iteratee)
+  return baseXor(arrays.filter(isArrayLikeObject), iteratee)
 }
 
 export default xorBy

--- a/xorWith.js
+++ b/xorWith.js
@@ -1,4 +1,3 @@
-import filter from './filter.js'
 import baseXor from './.internal/baseXor.js'
 import isArrayLikeObject from './isArrayLikeObject.js'
 import last from './last.js'
@@ -26,7 +25,7 @@ import last from './last.js'
 function xorWith(...arrays) {
   let comparator = last(arrays)
   comparator = typeof comparator == 'function' ? comparator : undefined
-  return baseXor(filter(arrays, isArrayLikeObject), undefined, comparator)
+  return baseXor(arrays.filter(isArrayLikeObject), undefined, comparator)
 }
 
 export default xorWith


### PR DESCRIPTION
This flattens the dependency tree making the size cost of some modules smaller

BTW: not related to the changes but xorBy and xorWith seems buggy (not tested) since is including the iteratee in the filtered array