### PR TITLE
Add _.attemptOr method

### DIFF
--- a/attemptOr.js
+++ b/attemptOr.js
@@ -1,0 +1,26 @@
+/**
+ * Attempts to invoke `func`, returning either the result or the default value.
+ * Any additional arguments are provided to `func` when it's invoked.
+ *
+ * @since 4.18.4
+ * @category Util
+ * @param {Function} func The function to attempt.
+ * @param {*} defaultValue Default value in case `func` throws some error.
+ * @param {...*} [args] The arguments to invoke `func` with.
+ * @returns {*} Returns the `func` result or error object.
+ * @example
+ *
+ * // Return document.body since argument is an invalid selector.
+ * const elements = attemptOr(selector =>
+ *   document.querySelectorAll(selector), document.body, '>_>')
+ *
+ */
+function attemptOr(func, defaultValue, ...args) {
+  try {
+    return func(...args)
+  } catch (e) {
+    return defaultValue
+  }
+}
+
+export default attemptOr

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lodash",
-  "version": "4.17.4",
+  "version": "4.18.4",
   "license": "MIT",
   "private": true,
   "main": "lodash.js",


### PR DESCRIPTION
In flavor of #3903
Adds `attemptOr` method. Pretty similar to `attempt`, but instead of returning error in case of throw, returns default value defined as second argument