### PR TITLE
sortBy: Only evaluate iteratees when needed

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4669,7 +4669,8 @@
      */
     function forceCriterion(criterion) {
       if (!criterion.computed) {
-        criterion.value = criterion.iteratee(criterion.element);
+        const iteratee = criterion.iteratee;
+        criterion.value = iteratee(criterion.element);
         criterion.computed = true;
       }
       return criterion.value;

--- a/lodash.js
+++ b/lodash.js
@@ -3724,7 +3724,7 @@
 
       var result = baseMap(collection, function(value, key, collection) {
         var criteria = arrayMap(iteratees, function(iteratee) {
-          return iteratee(value);
+          return { 'computed': false, 'iteratee': iteratee, 'element': value };
         });
         return { 'criteria': criteria, 'index': ++index, 'value': value };
       });
@@ -4637,7 +4637,9 @@
           ordersLength = orders.length;
 
       while (++index < length) {
-        var result = compareAscending(objCriteria[index], othCriteria[index]);
+        var result = compareAscending(
+            forceCriterion(objCriteria[index]),
+            forceCriterion(othCriteria[index]));
         if (result) {
           if (index >= ordersLength) {
             return result;
@@ -4654,6 +4656,23 @@
       // This also ensures a stable sort in V8 and other engines.
       // See https://bugs.chromium.org/p/v8/issues/detail?id=90 for more details.
       return object.index - other.index;
+    }
+
+    /**
+     * Used by `compareMultiple` to evaluate a criterion, either reusing its
+     * computed result or computing it for the first time and then caching the
+     * result.
+     *
+     * @private
+     * @param {Object} criterion The criterion to evaluate
+     * @return {*} The comparison key
+     */
+    function forceCriterion(criterion) {
+      if (!criterion.computed) {
+        criterion.value = criterion.iteratee(criterion.element);
+        criterion.computed = true;
+      }
+      return criterion.value;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -20650,6 +20650,16 @@
       assert.deepEqual(actual, [1, 2, 3, 4, undefined]);
     });
 
+    QUnit.test('should invoke iteratees with unbound `this`', function(assert) {
+      assert.expect(1);
+      var input = [1, 2];
+      var that = 'never invoked';
+      _.sortBy(input, function() {
+        that = this;
+      });
+      assert.strictEqual(that, function() { return this; }());
+    });
+
     QUnit.test('should not invoke iteratees not needed to break ties', function(assert) {
       // The behavior tested by this test case is an internal
       // performance optimization and is not guaranteed by the

--- a/test/test.js
+++ b/test/test.js
@@ -20650,6 +20650,45 @@
       assert.deepEqual(actual, [1, 2, 3, 4, undefined]);
     });
 
+    QUnit.test('should not invoke iteratees not needed to break ties', function(assert) {
+      // The behavior tested by this test case is an internal
+      // performance optimization and is not guaranteed by the
+      // specification.
+      assert.expect(1);
+
+      var input = [{ 'x': 2 }, { 'x': 1 }];
+      var actual = _.sortBy(input, 'x', function() {
+        throw new Error('should not be called');
+      });
+      var expected = [{ 'x': 1 }, { 'x': 2 }];
+      assert.deepEqual(actual, expected);
+    });
+
+    QUnit.test('should invoke tie-breaking iteratees selectively', function(assert) {
+      // The behavior tested by this test case is an internal
+      // performance optimization and is not guaranteed by the
+      // specification.
+      assert.expect(2);
+
+      var input = [
+        { 'x': 2, 'y': 2 },
+        { 'x': 2, 'y': 1 },
+        { 'x': 1, 'y': 3 },
+      ];
+      var invokedFallbackOnYValues = {};
+      var actual = _.sortBy(input, 'x', function(o) {
+        invokedFallbackOnYValues[o.y] = true;
+        return o.y;
+      });
+      var expected = [
+        { 'x': 1, 'y': 3 },
+        { 'x': 2, 'y': 1 },
+        { 'x': 2, 'y': 2 },
+      ];
+      assert.deepEqual(actual, expected);
+      assert.deepEqual(invokedFallbackOnYValues, { '1': true, '2': true });
+    });
+
     QUnit.test('should work with an object for `collection`', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Summary:
Resolves #4067. Performance-wise, this incurs some extra administrative
overhead on all invocations. In exchange, we can see order-of-magnitude
improvements in cases where there are expensive “fallback iteratees”
that are rarely hit (e.g., a `JSON.stringify`).

Running the `sortBy` benchmarks included in `perf/perf.js` gives the
following results on my laptop (Intel i5-4300U with Chrome 67 on Linux):

  - “`_.sortBy` with `callback`”:
      - before this patch: 59,249 ops/sec ±2.65% (56 runs sampled)
      - after this patch: 54,504 ops/sec ±2.91% (56 runs sampled)
      - (new / old) ratio: 0.92 ± 0.05 (0.87–0.97)

  - “`_.sortBy` with `property` name”:
      - before this patch: 98,956 ops/sec ±2.37% (58 runs sampled)
      - after this patch: 93,793 ops/sec ±1.46% (58 runs sampled)
      - (new / old) ratio: 0.94 ± 0.04 (0.91–0.98)

…and these on a workstation (Intel W-2135 with Chrome 71 on Linux):

  - “`_.sortBy` with `callback`”:
      - before this patch: 66,071 ops/sec ±2.39% (61 runs sampled)
      - after this patch: 58,707 ops/sec ±2.82% (58 runs sampled)
      - (new / old) ratio: 0.89 ± 0.05 (0.84–0.94)

  - “`_.sortBy` with `property` name”:
      - before this patch: 132,945 ops/sec ±2.71% (56 runs sampled)
      - after this patch: 129,162 ops/sec ±3.30% (61 runs sampled)
      - (new / old) ratio: 0.97 ± 0.06 (0.92–1.03)

(Best-of-3 timing used in each case.)

We can see that there is usually a statistically significant _decrease_
in the overall performance in these existing benchmarks.

This commit does not add a new benchmark to observe the best-case
behavior because the Underscore.js API does not support multiple
iteratees in `sortBy`, which would be needed for a fair comparison.

Test Plan:
The newly added test cases fail before this commit, but pass after it.
All existing tests pass (`npm run validate` passes).

wchargin-branch: sortBy-lazy