### PR TITLE
Use the exported functions

### DIFF
--- a/hasPathIn.js
+++ b/hasPathIn.js
@@ -3,6 +3,10 @@ import isArguments from './isArguments.js'
 import isIndex from './.internal/isIndex.js'
 import isLength from './isLength.js'
 import toKey from './.internal/toKey.js'
+import cloneDeep from './cloneDeep'
+import hasIn from './hasIn.js'
+import isNull from './isNull.js'
+import isObject from './isObject.js'
 
 /**
  * Checks if `path` is a direct property of `object`.
@@ -25,7 +29,11 @@ import toKey from './.internal/toKey.js'
  * // => true
  */
 function hasPathIn(object, path) {
-  path = castPath(path, object)
+  if (!isObject(object)) {
+    throw new TypeError('Expected an object')
+  }
+  let copyObj = cloneDeep(object)
+  path = castPath(path, copyObj)
 
   let index = -1
   let { length } = path
@@ -34,17 +42,17 @@ function hasPathIn(object, path) {
 
   while (++index < length) {
     key = toKey(path[index])
-    if (!(result = object != null && key in Object(object))) {
+    if (!(result = hasIn(copyObj, key))) {
       break
     }
-    object = object[key]
+    copyObj = copyObj[key]
   }
-  if (result || ++index != length) {
+  if (result || ++index !== length) {
     return result
   }
-  length = object == null ? 0 : object.length
+  length = isNull(copyObj) ? 0 : copyObj.length
   return !!length && isLength(length) && isIndex(key, length) &&
-    (Array.isArray(object) || isArguments(object))
+    (Array.isArray(copyObj) || isArguments(copyObj))
 }
 
 export default hasPathIn


### PR DESCRIPTION
Imported some functions that do the exactly the same things as the original codes.

* line 32 - It seems ```object``` must be an object or the error will be printed out. (According to the description of this function) For the better performance, check if ```object``` is an object at the very beginning of the codes.

* line 35 - The original code in ```while``` was below
```javascript
/* ... */
object = object[key]
```
Because of this part, ```object``` was not immutable, so ```cloneDeep``` was needed to create a 
new object for the immutability and the safety of the original variable.

* line 45, 53 - Replaced with the existing exported functions which do the same thing.

----

Further question
* Since ```isIndex()``` has ```!!length``` in its return statement, isn't ```!!length``` unnecessary in ```hasPathIn.js``` file's return statement? It seems redundant.
