### PR TITLE
Changed to arrow function

### DIFF
--- a/initial.js
+++ b/initial.js
@@ -12,9 +12,6 @@ import slice from './slice.js'
  * initial([1, 2, 3])
  * // => [1, 2]
  */
-function initial(array) {
-  const length = array == null ? 0 : array.length
-  return length ? slice(array, 0, -1) : []
-}
+const initial = array => Array.isArray(array) && array.length ? slice(array, 0, -1) : [];
 
 export default initial


### PR DESCRIPTION
MDN Link - [Array.isArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)

As long as the function only wants to check if the type of param is either ```null``` or ```undefined``` or ```Array```, I think this arrow function will work well too