### PR TITLE
Fix _.isFunction for async generator functions

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -92,6 +92,7 @@
   var argsTag = '[object Arguments]',
       arrayTag = '[object Array]',
       asyncTag = '[object AsyncFunction]',
+      asyncGenTag = '[object AsyncGeneratorFunction]',
       boolTag = '[object Boolean]',
       dateTag = '[object Date]',
       domExcTag = '[object DOMException]',
@@ -11646,7 +11647,7 @@
       // The use of `Object#toString` avoids issues with the `typeof` operator
       // in Safari 9 which returns 'object' for typed arrays and other constructors.
       var tag = baseGetTag(value);
-      return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag;
+      return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag || tag == asyncGenTag;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -374,6 +374,11 @@
     return Function('return function*(){}');
   });
 
+  /** Used to test async generator functions. */
+  var asyncGenFunc = lodashStable.attempt(function() {
+    return Function('return async function*(){}');
+  });
+
   /** Used to restore the `_` reference. */
   var oldDash = root._;
 
@@ -10618,13 +10623,19 @@
     QUnit.test('should return `true` for async functions', function(assert) {
       assert.expect(1);
 
-      assert.strictEqual(_.isFunction(asyncFunc), typeof asyncFunc == 'function');
+      assert.strictEqual(_.isFunction(asyncFunc()), typeof asyncFunc == 'function');
     });
 
     QUnit.test('should return `true` for generator functions', function(assert) {
       assert.expect(1);
 
-      assert.strictEqual(_.isFunction(genFunc), typeof genFunc == 'function');
+      assert.strictEqual(_.isFunction(genFunc()), typeof genFunc == 'function');
+    });
+
+    QUnit.test('should return `true` for async generator functions', function(assert) {
+      assert.expect(1);
+
+      assert.strictEqual(_.isFunction(asyncGenFunc()), typeof asyncGenFunc == 'function');
     });
 
     QUnit.test('should return `true` for the `Proxy` constructor', function(assert) {


### PR DESCRIPTION
async generator function have a string representation that `isFunction` did not check against.

While adding the test for this, I also noticed that all the tests for `isFunction` only tested if `Function('string of function to test')` is a function, not the actual function that was supposed to be tested. 