### PR TITLE
Cancel old timer, editing pr #4139

### DIFF
--- a/debounce.js
+++ b/debounce.js
@@ -101,7 +101,7 @@ function debounce(func, wait, options) {
 
   function startTimer(pendingFunc, wait) {
     if (useRAF) {
-      root.cancelAnimationFrame(pendingFunc);
+      root.cancelAnimationFrame(timerId);
       return root.requestAnimationFrame(pendingFunc)
     }
     return setTimeout(pendingFunc, wait)

--- a/debounce.js
+++ b/debounce.js
@@ -78,7 +78,7 @@ function debounce(func, wait, options) {
   // Bypass `requestAnimationFrame` by explicitly setting `wait=0`.
   const useRAF = (!wait && wait !== 0 && typeof root.requestAnimationFrame === 'function')
 
-  if (typeof func != 'function') {
+  if (typeof func !== 'function') {
     throw new TypeError('Expected a function')
   }
   wait = +wait || 0
@@ -101,6 +101,7 @@ function debounce(func, wait, options) {
 
   function startTimer(pendingFunc, wait) {
     if (useRAF) {
+      root.cancelAnimationFrame(pendingFunc);
       return root.requestAnimationFrame(pendingFunc)
     }
     return setTimeout(pendingFunc, wait)


### PR DESCRIPTION
Update PR: [#4139](https://github.com/lodash/lodash/pull/4139)

### Comments
I thought `setTimeout` basically also needs `clearTimeout` to clear its older time identifier, but according to this document, `setTimeout` does not seem to need to clear its timer.

> _6.1.2.4 Processing model_
> An event loop must continually run through the following steps for as long as it exists.
> ...
> 3. Remove that task from its task queue.

`requestAnimationFrame`, however, seems to need to clear the timer, using `cancelAnimationFrame` by the reason below.

> The cancelAnimationFrame(_handle_) method must run the following steps:
> ...
> 3. Remove callbacks[_handle_].

### References
[6.1.4.2 Processing model - event loop](https://www.w3.org/TR/2011/WD-html5-20110525/webappapis.html#event-loop)
[Animation frames](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames)

### Conclusion
But, to answer the question you asked in issue [#4138](https://github.com/lodash/lodash/issues/4138)
> What problems does this create

I do not honestly think that would cause any problems unless you use this codes on dashboard-like application which is supposed to be displayed 24/7 and the task queue of the event loop will end up being overflow. For even small but better performance, I still believe `cancelAnimationFrame` is required.