### PR TITLE
Updating due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^7.1.1",
     "istanbul": "0.4.5",
     "jquery": "^3.1.1",
-    "lodash": "4.17.3",
+    "lodash": "4.17.11",
     "lodash-doc-globals": "^0.1.1",
     "markdown-doctest": "^0.9.1",
     "optional-dev-dependency": "^2.0.0",


### PR DESCRIPTION
Version 4.17.10 was compromised if I recall. Should force users to use the version that is not compromised.