### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In a browser:
 Using npm:
 ```shell
 $ npm i -g npm
-$ npm i --save lodash
+$ npm i lodash
 ```
 
 In Node.js:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Using npm:
 $ npm i -g npm
 $ npm i lodash
 ```
+Note: add --save if you are using npm < 5.0.0
 
 In Node.js:
 ```js


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358