### PR TITLE
Simplifies toNumber and add tests

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -177,17 +177,8 @@
   /** Used to match `RegExp` flags from their coerced string values. */
   var reFlags = /\w*$/;
 
-  /** Used to detect bad signed hexadecimal string values. */
-  var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
-
-  /** Used to detect binary string values. */
-  var reIsBinary = /^0b[01]+$/i;
-
   /** Used to detect host constructors (Safari). */
   var reIsHostCtor = /^\[object .+?Constructor\]$/;
-
-  /** Used to detect octal string values. */
-  var reIsOctal = /^0o[0-7]+$/i;
 
   /** Used to detect unsigned integer values. */
   var reIsUint = /^(?:0|[1-9]\d*)$/;
@@ -409,8 +400,7 @@
   };
 
   /** Built-in method references without a dependency on `root`. */
-  var freeParseFloat = parseFloat,
-      freeParseInt = parseInt;
+  var freeParseFloat = parseFloat;
 
   /** Detect free variable `global` from Node.js. */
   var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
@@ -12464,11 +12454,7 @@
       if (typeof value != 'string') {
         return value === 0 ? value : +value;
       }
-      value = value.replace(reTrim, '');
-      var isBinary = reIsBinary.test(value);
-      return (isBinary || reIsOctal.test(value))
-        ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
-        : (reIsBadHex.test(value) ? NAN : +value);
+      return +value;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -23516,9 +23516,9 @@
     QUnit.test('`_.' + methodName + '` should convert binary/octal strings to numbers', function(assert) {
       assert.expect(1);
 
-      var numbers = [42, 5349, 1715004],
+      var numbers = [42, 5349, 1715004, 63, 42798, 27440068],
           transforms = [identity, pad],
-          values = ['0b101010', '0o12345', '0x1a2b3c'];
+          values = ['0b101010', '0o12345', '0x1a2b3c', '   0b111111 ', '  0o123456    ', '    0x1a2b3c4  ' ];
 
       var expected = lodashStable.map(numbers, function(n) {
         return lodashStable.times(8, lodashStable.constant(n));
@@ -23538,7 +23538,7 @@
       assert.expect(1);
 
       var transforms = [identity, pad, positive, negative],
-          values = ['0b', '0o', '0x', '0b1010102', '0o123458', '0x1a2b3x'];
+          values = ['0b', '0o', '0x', '0b1010102', '0o123458', '0x1a2b3x', '+0b101010', '+0o12345', '+0x1a2b3c'];
 
       var expected = lodashStable.map(values, function(n) {
         return lodashStable.times(8, lodashStable.constant(isToNumber ? NaN : 0));


### PR DESCRIPTION
Using `+value` to convert binary/octal/hexadecimal string and add some tests.
Issue https://github.com/lodash/lodash/issues/4228