### PR TITLE
Fix _.maxBy and _.minBy

### DIFF
--- a/maxBy.js
+++ b/maxBy.js
@@ -22,8 +22,8 @@ function maxBy(array, iteratee) {
   if (array == null) {
     return result
   }
+  let computed
   for (const value of array) {
-    let computed
     const current = iteratee(value)
 
     if (current != null && (computed === undefined

--- a/minBy.js
+++ b/minBy.js
@@ -22,8 +22,8 @@ function minBy(array, iteratee) {
   if (array == null) {
     return result
   }
+  let computed
   for (const value of array) {
-    let computed
     const current = iteratee(value)
 
     if (current != null && (computed === undefined


### PR DESCRIPTION
In the `master`, the  `_.maxBy` and `_.minBy` will work like this:
```js
const objects = [{ n: 1 }, { n: 3 }, { n: 2 }];

_.maxBy(objects, ({n}) => n)
// expect {n: 3}, but return {n: 2}

_.minBy(objects, ({n}) => n)
// expect {n: 1}, but return {n: 2}
```