### PR TITLE
mergeWith: stack passed to customizer should always be defined

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3588,8 +3588,8 @@
         return;
       }
       baseFor(source, function(srcValue, key) {
+        stack || (stack = new Stack);
         if (isObject(srcValue)) {
-          stack || (stack = new Stack);
           baseMergeDeep(object, source, key, srcIndex, baseMerge, customizer, stack);
         }
         else {

--- a/test/test.js
+++ b/test/test.js
@@ -15280,18 +15280,21 @@
     });
 
     QUnit.test('should provide `stack` to `customizer`', function(assert) {
-      assert.expect(1);
+      assert.expect(4);
 
-      var actual;
+      var actual = [];
 
-      _.mergeWith({}, { 'a': { 'b': 2 } }, function() {
-        actual = _.last(arguments);
+      _.mergeWith({}, { 'z': 1, 'a': { 'b': 2 } }, function() {
+        actual.push(_.last(arguments));
       });
 
-      assert.ok(isNpm
-        ? actual.constructor.name == 'Stack'
-        : actual instanceof mapCaches.Stack
-      );
+      assert.strictEqual(actual.length, 3);
+      _.each(actual, function(a) {
+        assert.ok(isNpm
+          ? a.constructor.name == 'Stack'
+          : a instanceof mapCaches.Stack
+        );
+      });
     });
 
     QUnit.test('should overwrite primitives with source object clones', function(assert) {


### PR DESCRIPTION
Summary:
If the first values encountered in the `object` in mergeWith are not objects, `stack` is undefined when passed to the `customizer`. Once the first object-ish value is encountered, `stack` gets initialized, and all further calls to `customizer` include a defined `stack`. This PR makes `stack` always defined, even before the first object-ish value is encountered.