### PR TITLE
Add optional resolveEmpty parameter to defaultTo

### DIFF
--- a/defaultTo.js
+++ b/defaultTo.js
@@ -1,12 +1,17 @@
+import isNaN from './isNaN.js'
+import isNil from './isNil.js'
+import overSome from './overSome.js'
+
 /**
  * Checks `value` to determine whether a default value should be returned in
  * its place. The `defaultValue` is returned if `value` is `NaN`, `null`,
- * or `undefined`.
+ * or `undefined`, or if `resolveEmpty` returns `true`.
  *
  * @since 4.14.0
  * @category Util
  * @param {*} value The value to check.
  * @param {*} defaultValue The default value.
+ * @param {Function} resolveEmpty The function to determine if the value is empty.
  * @returns {*} Returns the resolved value.
  * @example
  *
@@ -15,9 +20,15 @@
  *
  * defaultTo(undefined, 10)
  * // => 10
+ *
+ * defaultTo('', 'default', isEmpty)
+ * // => 'default'
+ *
+ * defaultTo(new Error(), 'default', isError)
+ * // => 'default'
  */
-function defaultTo(value, defaultValue) {
-  return (value == null || value !== value) ? defaultValue : value
+function defaultTo(value, defaultValue, resolveEmpty = overSome([isNaN, isNil])) {
+  return resolveEmpty(value) ? defaultValue : value
 }
 
 export default defaultTo

--- a/test/defaultTo.test.js
+++ b/test/defaultTo.test.js
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import lodashStable from 'lodash';
-import { falsey } from './utils.js';
+import { errors, falsey } from './utils.js';
 import defaultTo from '../defaultTo.js';
+import isError from '../isError.js';
 
 describe('defaultTo', function() {
   it('should return a default value if `value` is `NaN` or nullish', function() {
@@ -11,6 +12,16 @@ describe('defaultTo', function() {
 
     var actual = lodashStable.map(falsey, function(value) {
       return defaultTo(value, 1);
+    });
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it('should return a default value if `resolveEmpty` returns true for `value`', function() {
+    var expected = new Array(errors.length).fill(1);
+
+    var actual = lodashStable.map(errors, function(value) {
+      return defaultTo(value, 1, isError);
     });
 
     assert.deepStrictEqual(actual, expected);


### PR DESCRIPTION
This is an enhancement to Lodash that extends `defaultTo` with an optional `resolveEmpty` parameter. If supplied, `resolveEmpty` will be used to determine whether the passed `value` is empty and that `defaultValue` should be returned.

This would allow the following usage examples, amongst many others:

1. Default to a value when given a value considered empty by `lodash.isEmpty`:

```js
defaultTo('', defaultValue, isEmpty);
```

2. Default to a value after running `lodash.attempt` on a statement that may return an error using `lodash.isError`.

```js
defaultTo(attempt(require, filePath), defaultValue, isError);
```