### PR TITLE
Round Infinity with a precision argument returns Infinity

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5406,7 +5406,7 @@
       return function(number, precision) {
         number = toNumber(number);
         precision = precision == null ? 0 : nativeMin(toInteger(precision), 292);
-        if (precision && Math.abs(number) !== Infinity) {
+        if (precision && Number.isFinite(number)) {
           // Shift with exponential notation to avoid floating-point issues.
           // See [MDN](https://mdn.io/round#Examples) for more details.
           var pair = (toString(number) + 'e').split('e'),

--- a/lodash.js
+++ b/lodash.js
@@ -5406,7 +5406,7 @@
       return function(number, precision) {
         number = toNumber(number);
         precision = precision == null ? 0 : nativeMin(toInteger(precision), 292);
-        if (precision) {
+        if (precision && Math.abs(number) !== Infinity) {
           // Shift with exponential notation to avoid floating-point issues.
           // See [MDN](https://mdn.io/round#Examples) for more details.
           var pair = (toString(number) + 'e').split('e'),

--- a/test/test.js
+++ b/test/test.js
@@ -19854,6 +19854,30 @@
       actual = func(-Infinity, 2);
       assert.strictEqual(actual, isCeil ? -Infinity : -Infinity);
     });
+
+    QUnit.test('`_.' + methodName + '` should return `NaN` given `NaN` regardless of `precision`', function(assert) {
+      assert.expect(6);
+
+      var actual = func(NaN)
+      assert.deepEqual(actual, NaN);
+
+      actual = func(NaN, 0)
+      assert.deepEqual(actual, NaN);
+
+      actual = func(NaN, 2)
+      assert.deepEqual(actual, NaN);
+
+      actual = func(NaN, -2)
+      assert.deepEqual(actual, NaN);
+
+      actual = func(NaN, 2);
+      assert.deepEqual(actual, isFloor ? NaN : NaN);
+
+      actual = func(NaN, 2);
+      assert.deepEqual(actual, isCeil ? NaN : NaN);
+    });
+
+
   });
 
   /*--------------------------------------------------------------------------*/

--- a/test/test.js
+++ b/test/test.js
@@ -19810,6 +19810,50 @@
 
       assert.deepEqual(actual, expected);
     });
+
+    QUnit.test('`_.' + methodName + '` should return `Infinity` given `Infinity` regardless of `precision`', function(assert) {
+      assert.expect(6);
+
+      var actual = func(Infinity);
+      assert.strictEqual(actual, Infinity);
+
+      actual = func(Infinity, 0)
+      assert.strictEqual(actual, Infinity);
+
+      actual = func(Infinity, 2)
+      assert.strictEqual(actual, Infinity);
+
+      actual = func(Infinity, -2)
+      assert.strictEqual(actual, Infinity);
+
+      actual = func(Infinity, 2);
+      assert.strictEqual(actual, isFloor ? Infinity : Infinity);
+
+      actual = func(Infinity, 2);
+      assert.strictEqual(actual, isCeil ? Infinity : Infinity);
+    });
+
+    QUnit.test('`_.' + methodName + '` should return `-Infinity` given `-Infinity` regardless of `precision`', function(assert) {
+      assert.expect(6);
+
+      var actual = func(-Infinity);
+      assert.strictEqual(actual, -Infinity);
+
+      actual = func(-Infinity, 0)
+      assert.strictEqual(actual, -Infinity);
+
+      actual = func(-Infinity, 2)
+      assert.strictEqual(actual, -Infinity);
+
+      actual = func(-Infinity, -2)
+      assert.strictEqual(actual, -Infinity);
+
+      actual = func(-Infinity, 2);
+      assert.strictEqual(actual, isFloor ? -Infinity : -Infinity);
+
+      actual = func(-Infinity, 2);
+      assert.strictEqual(actual, isCeil ? -Infinity : -Infinity);
+    });
   });
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
This fixes https://github.com/lodash/lodash/issues/4266

Tested with Infinity, -Infinity, _.round(), _.floor() and _.ceil().

This is a second PR for the same issue. I'm closing the previous PR because I messed up somehow and there were other commits (not mine) in there.

This was branched off of 4.17.12-pre.

Happy to updates with any improvements needed.