### PR TITLE
realNames failing to check .hasOwnProperty()

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -17020,9 +17020,10 @@
     baseForOwn(LazyWrapper.prototype, function(func, methodName) {
       var lodashFunc = lodash[methodName];
       if (lodashFunc) {
-        var key = (lodashFunc.name + ''),
-            names = realNames[key] || (realNames[key] = []);
+        var key = lodashFunc.name + '';
+        if (!hasOwnProperty.call(realNames, key)) return;
 
+        var names = realNames[key] || (realNames[key] = []);
         names.push({ 'name': methodName, 'func': lodashFunc });
       }
     });


### PR DESCRIPTION
this patch fixes a problem that breaks lodash in the presence of object prototype functions.  the issue arises from lodash's failure to check the .hasOwnProperty() on keys within the realNames object, which pulls up these methods when it shouldn't

WARNING: there may be other places in the code failing this but so far this is the only instance I've discovered