### PR TITLE
Fix stringToPath bug for consecutive []

### DIFF
--- a/.internal/stringToPath.js
+++ b/.internal/stringToPath.js
@@ -8,7 +8,7 @@ const rePropName = RegExp(
   // Or match property names within brackets.
   '\\[(?:' +
     // Match a non-string expression.
-    '([^"\'].*)' + '|' +
+    '([^"\'][^[]*)' + '|' +
     // Or match strings (supports escaping characters).
     '(["\'])((?:(?!\\2)[^\\\\]|\\\\.)*?)\\2' +
   ')\\]'+ '|' +


### PR DESCRIPTION
This PR fix the bug for cases like `stringToPath('d[0][0]')`,

**Before** the PR the output is:

```js
['d', '0][0']
```

**After** the PR the output is:
```js
['d', '0', '0']
```

I cannot run test on master, applied this PR into `4.17.11` and all the tests have **passed**, see:

https://github.com/futurist/lodash/blob/c4fd1d90dc9020324ec481977289e4d173097e24/lodash.js#L146



