### PR TITLE
Fix typo in merge test

### DIFF
--- a/test/merge.js
+++ b/test/merge.js
@@ -325,7 +325,7 @@ describe('merge', function() {
     assert.deepStrictEqual(actual, { 'a': [] });
   });
 
-  it('should not convert strings to arrays when merging arrays of `source`', function() {
+  it('should convert strings to arrays when merging arrays of `source`', function() {
     var object = { 'a': 'abcde' },
         actual = merge(object, { 'a': ['x', 'y', 'z'] });
 


### PR DESCRIPTION
It seems like `merge` does convert strings to arrays when merging arrays of `source`. 
But the test description implies currently the opposite. It's probably a typo and this PR fixes it.

```js
_.merge({ a: 'abcde' }, {a: []})
// returns {a: []} 	
```

