### PR TITLE
fix: prototype pollution in _.defaultsDeep

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6589,7 +6589,7 @@
     }
 
     /**
-     * Gets the value at `key`, unless `key` is "__proto__".
+     * Gets the value at `key`, unless `key` is "__proto__" or "constructor".
      *
      * @private
      * @param {Object} object The object to query.
@@ -6597,6 +6597,10 @@
      * @returns {*} Returns the property value.
      */
     function safeGet(object, key) {
+      if (key === 'constructor' && typeof object[key] === 'function') {
+        return;
+      }
+      
       if (key == '__proto__') {
         return;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -4712,6 +4712,17 @@
       var actual = _.defaultsDeep({ 'a': ['abc'] }, { 'a': 'abc' });
       assert.deepEqual(actual.a, ['abc']);
     });
+
+    QUnit.test('should not indirectly merge `Object` properties', function(assert) {
+      assert.expect(1);
+
+      _.defaultsDeep({}, { 'constructor': { 'a': 1 } });
+
+      var actual = 'a' in Object;
+      delete Object.a;
+
+      assert.notOk(actual);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
The PR is fixing a Prototype Pollution vulnerability in `_.defaultsDeep`.

You can see details about similar vulnerability here: https://snyk.io/vuln/SNYK-JS-LODASH-73638
