### PR TITLE
fix: prototype pollution in several npm packages

### DIFF
--- a/lodash.defaultsdeep/index.js
+++ b/lodash.defaultsdeep/index.js
@@ -1131,6 +1131,26 @@ function baseMerge(object, source, srcIndex, customizer, stack) {
 }
 
 /**
+ * Gets the value at `key`, unless `key` is "__proto__" or "constructor".
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @param {string} key The key of the property to get.
+ * @returns {*} Returns the property value.
+ */
+function safeGet(object, key) {
+  if (key === 'constructor' && typeof object[key] === 'function') {
+    return;
+  }
+
+  if (key == '__proto__') {
+    return;
+  }
+
+  return object[key];
+}
+
+/**
  * A specialized version of `baseMerge` for arrays and objects which performs
  * deep merges and tracks traversed objects enabling objects with circular
  * references to be merged.
@@ -1146,8 +1166,8 @@ function baseMerge(object, source, srcIndex, customizer, stack) {
  *  counterparts.
  */
 function baseMergeDeep(object, source, key, srcIndex, mergeFunc, customizer, stack) {
-  var objValue = object[key],
-      srcValue = source[key],
+  var objValue = safeGet(object, key),
+      srcValue = safeGet(source, key),
       stacked = stack.get(srcValue);
 
   if (stacked) {

--- a/lodash.merge/index.js
+++ b/lodash.merge/index.js
@@ -1001,7 +1001,7 @@ function baseMergeDeep(object, source, key, srcIndex, mergeFunc, customizer, sta
       if (isArguments(objValue)) {
         newValue = toPlainObject(objValue);
       }
-      else if (!isObject(objValue) || (srcIndex && isFunction(objValue))) {
+      else if (!isObject(objValue) || isFunction(objValue)) {
         newValue = initCloneObject(srcValue);
       }
     }

--- a/lodash.mergewith/index.js
+++ b/lodash.mergewith/index.js
@@ -1001,7 +1001,7 @@ function baseMergeDeep(object, source, key, srcIndex, mergeFunc, customizer, sta
       if (isArguments(objValue)) {
         newValue = toPlainObject(objValue);
       }
-      else if (!isObject(objValue) || (srcIndex && isFunction(objValue))) {
+      else if (!isObject(objValue) || isFunction(objValue)) {
         newValue = initCloneObject(srcValue);
       }
     }


### PR DESCRIPTION
The PR is fixing a Prototype Pollution vulnerability in:

- https://www.npmjs.com/package/lodash.defaultsdeep
- https://www.npmjs.com/package/lodash.merge
- https://www.npmjs.com/package/lodash.mergewith

You can see details about similar vulnerability here: https://snyk.io/vuln/SNYK-JS-LODASH-73638
