### PR TITLE
fix reTypedTag error

### DIFF
--- a/isTypedArray.js
+++ b/isTypedArray.js
@@ -3,7 +3,7 @@ import nodeTypes from './.internal/nodeTypes.js'
 import isObjectLike from './isObjectLike.js'
 
 /** Used to match `toStringTag` values of typed arrays. */
-const reTypedTag = /^\[object (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)\]$/
+const reTypedTag = /^\[object (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)Array\]$/
 
 /* Node.js helper references. */
 const nodeIsTypedArray = nodeTypes && nodeTypes.isTypedArray


### PR DESCRIPTION
/^\[object (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)Array\]$/ or / (?:Float(?:32|64)|(?:Int|Uint)(?:8|16|32)|Uint8Clamped)/ is ok.