### PR TITLE
Prevent prototype pollution chaining to code execution via _.template

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14789,7 +14789,7 @@
       // A newline wouldn't be a valid sourceURL anyway, and it'd enable code injection.
       var sourceURL = '//# sourceURL=' +
         (hasOwnProperty.call(options, 'sourceURL')
-          ? options.sourceURL.replace(/[\r\n]/g, ' ')
+          ? (options.sourceURL + '').replace(/[\r\n]/g, ' ')
           : ('lodash.templateSources[' + (++templateCounter) + ']')
         ) + '\n';
 

--- a/lodash.js
+++ b/lodash.js
@@ -14784,9 +14784,12 @@
       , 'g');
 
       // Use a sourceURL for easier debugging.
+      // The sourceURL gets injected into the source that's eval-ed, so be careful
+      // with lookup (in case of e.g. prototype pollution), and strip newlines if any.
+      // A newline wouldn't be a valid sourceURL anyway, and it'd enable code injection.
       var sourceURL = '//# sourceURL=' +
-        ('sourceURL' in options
-          ? options.sourceURL
+        (hasOwnProperty.call(options, 'sourceURL')
+          ? options.sourceURL.replace(/\n/g, ' ')
           : ('lodash.templateSources[' + (++templateCounter) + ']')
         ) + '\n';
 
@@ -14819,7 +14822,9 @@
 
       // If `variable` is not specified wrap a with-statement around the generated
       // code to add the data object to the top of the scope chain.
-      var variable = options.variable;
+      // Like with sourceURL, we take care to not check the option's prototype,
+      // as this configuration is a code injection vector.
+      var variable = hasOwnProperty.call(options, 'variable') && options.variable;
       if (!variable) {
         source = 'with (obj) {\n' + source + '\n}\n';
       }

--- a/lodash.js
+++ b/lodash.js
@@ -14789,7 +14789,7 @@
       // A newline wouldn't be a valid sourceURL anyway, and it'd enable code injection.
       var sourceURL = '//# sourceURL=' +
         (hasOwnProperty.call(options, 'sourceURL')
-          ? options.sourceURL.replace(/\n/g, ' ')
+          ? options.sourceURL.replace(/[\r\n]/g, ' ')
           : ('lodash.templateSources[' + (++templateCounter) + ']')
         ) + '\n';
 


### PR DESCRIPTION
Prototype pollution is a common problem for Javascript applications.

[This paper (PDF-link)](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf) is a reasonably comprehensive resource on the subject. It demonstrates that the problem is quite ubiquitous, and how it can turn into an unauthenticated RCE in Ghost, where the attack chain starts with a prototype pollution vulnerability in lodash.merge. Handlebars is used as the code execution gadget, but as Ghost also uses _.template it could have targeted that as well.

Lodash has had multiple prototype pollution vulnerabilities, [including recently](https://github.com/lodash/lodash/commit/1f8ea07746963a535385a5befc19fa687a627d2b).

If `_.template` is ever invoked after the prototype has been polluted, an attacker can execute any Javascript, as `sourceURL` and `variable` are looked up via an `options` object and injected into the Javascript that gets executed. If the caller is not passing those options (which is the most common usage), then the values from the potentially polluted prototype would be used instead. Here's the smallest possible POC:

```
// If the prototype is polluted via some other vulnerability
> ({}).__proto__.sourceURL = '\nconsole.log("injected code here")'
'\nconsole.log("injected code here")'
// ... then arbitrary code can be injected
> _.template('hey')({})
injected code here
'hey'
```

**I initially reached out via npm security**, and got the feedback that this is not considered an issue. (In the thread with NPM security I also provided examples of how to weaponise this against real applications instead of just the repl example. I can provide additional examples privately.)

I think it's worth fixing, as the fix is simple. Applications that are susceptible to prototype pollution will still need fixing, but at least the commonly used `_.template` shouldn't provide easy code execution.

(I've signed the CLA.)





