### PR TITLE
Fix: clone certain regexps in Microsoft Edge

### DIFF
--- a/.internal/cloneRegExp.js
+++ b/.internal/cloneRegExp.js
@@ -9,7 +9,8 @@ const reFlags = /\w*$/
  * @returns {Object} Returns the cloned regexp.
  */
 function cloneRegExp(regexp) {
-  const result = new regexp.constructor(regexp.source, reFlags.exec(regexp))
+  const flags = reFlags.exec(regexp);
+  const result = new regexp.constructor(regexp.source, flags[0] === 'undefined' ? undefined : flags);
   result.lastIndex = regexp.lastIndex
   return result
 }

--- a/test/clone-methods.js
+++ b/test/clone-methods.js
@@ -62,6 +62,7 @@ describe('clone methods', function() {
     'numbers': 0,
     'number objects': Object(0),
     'regexes': /a/gim,
+    'regexes without flags': /a/,
     'sets': set,
     'strings': 'a',
     'string objects': Object('a'),


### PR DESCRIPTION
Cloning a `RegExp` _without flags_ failed in Microsoft Edge (observed in Edge 42.17134.1.0 / EdgeHTML 17.17134).

The `RegExp` stringifies its flags as "undefined", causing `cloneRegExp` to pass the string `"undefined"` as second argument to the `RegExp` constructor (which blows up with a `SyntaxError`).