### PR TITLE
Do not use property shorthand in countBy documentation

### DIFF
--- a/countBy.js
+++ b/countBy.js
@@ -23,7 +23,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty
  *   { 'user': 'fred', 'active': false }
  * ]
  *
- * countBy(users, 'active');
+ * countBy(users, value => value.active);
  * // => { 'true': 2, 'false': 1 }
  */
 function countBy(collection, iteratee) {


### PR DESCRIPTION
property shorthand support is removed in master / v5