### PR TITLE
Coerce drop and dropRight n param using toInteger

### DIFF
--- a/drop.js
+++ b/drop.js
@@ -1,4 +1,5 @@
 import slice from './slice.js'
+import toInteger from './toInteger.js'
 
 /**
  * Creates a slice of `array` with `n` elements dropped from the beginning.
@@ -25,7 +26,7 @@ import slice from './slice.js'
 function drop(array, n=1) {
   const length = array == null ? 0 : array.length
   return length
-    ? slice(array, n < 0 ? 0 : n, length)
+    ? slice(array, n < 0 ? 0 : toInteger(n), length)
     : []
 }
 

--- a/dropRight.js
+++ b/dropRight.js
@@ -1,4 +1,5 @@
 import slice from './slice.js'
+import toInteger from './toInteger.js'
 
 /**
  * Creates a slice of `array` with `n` elements dropped from the end.
@@ -24,7 +25,8 @@ import slice from './slice.js'
  */
 function dropRight(array, n=1) {
   const length = array == null ? 0 : array.length
-  return length ? slice(array, 0, n < 0 ? 0 : -n) : []
+  n = length - toInteger(n)
+  return length ? slice(array, 0, n < 0 ? 0 : n) : []
 }
 
 export default dropRight

--- a/test/drop.test.js
+++ b/test/drop.test.js
@@ -38,13 +38,6 @@ describe('drop', function() {
     assert.deepStrictEqual(drop(array, 1.6), [2, 3]);
   });
 
-  it('should work as an iteratee for methods like `_.map`', function() {
-    var array = [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
-        actual = lodashStable.map(array, drop);
-
-    assert.deepStrictEqual(actual, [[2, 3], [5, 6], [8, 9]]);
-  });
-
   it('should work in a lazy sequence', function() {
     var array = lodashStable.range(1, LARGE_ARRAY_SIZE + 1),
         predicate = function(value) { values.push(value); return isEven(value); },

--- a/test/dropRight.test.js
+++ b/test/dropRight.test.js
@@ -38,13 +38,6 @@ describe('dropRight', function() {
     assert.deepStrictEqual(dropRight(array, 1.6), [1, 2]);
   });
 
-  it('should work as an iteratee for methods like `_.map`', function() {
-    var array = [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
-        actual = lodashStable.map(array, dropRight);
-
-    assert.deepStrictEqual(actual, [[1, 2], [4, 5], [7, 8]]);
-  });
-
   it('should work in a lazy sequence', function() {
     var array = lodashStable.range(1, LARGE_ARRAY_SIZE + 1),
         predicate = function(value) { values.push(value); return isEven(value); },


### PR DESCRIPTION
It fixes n param coercion along side with some edge cases in dropRight

Enable the respective tests

Notes
 * i removed the tests that checks iteratee support since this feature is removed and is not working anymore
 * the lazy sequence tests passes but seems is not testing the actual code since chaining support is removed. Should i remove these tests