### PR TITLE
Enable create tests and adapt it for the new primitive prototype behavior

### DIFF
--- a/test/create.test.js
+++ b/test/create.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import lodashStable from 'lodash';
-import { falsey, stubObject, primitives, stubTrue } from './utils.js';
+import { falsey, primitives, stubTrue } from './utils.js';
 import create from '../create.js';
 import keys from '../keys.js';
 
@@ -33,7 +33,10 @@ describe('create', function() {
 
     assert.ok(actual instanceof Circle);
     assert.ok(actual instanceof Shape);
-    assert.deepStrictEqual(Circle.prototype, expected);
+    assert.deepStrictEqual(Object.keys(Circle.prototype), Object.keys(expected));
+    Object.keys(expected).forEach(property => {
+      assert.strictEqual(Circle.prototype[property], expected[property]);
+    });
   });
 
   it('should assign own properties', function() {
@@ -43,7 +46,13 @@ describe('create', function() {
     }
     Foo.prototype.b = 2;
 
-    assert.deepStrictEqual(create({}, new Foo), { 'a': 1, 'c': 3 });
+    var actual = create({}, new Foo);
+    var expected = { 'a': 1, 'c': 3 };
+
+    assert.deepStrictEqual(Object.keys(actual), Object.keys(expected));
+    Object.keys(expected).forEach(property => {
+      assert.strictEqual(actual[property], expected[property]);
+    });    
   });
 
   it('should assign properties that shadow those of `prototype`', function() {
@@ -55,23 +64,23 @@ describe('create', function() {
   });
 
   it('should accept a falsey `prototype`', function() {
-    var expected = lodashStable.map(falsey, stubObject);
-
     var actual = lodashStable.map(falsey, function(prototype, index) {
       return index ? create(prototype) : create();
     });
 
-    assert.deepStrictEqual(actual, expected);
+    actual.forEach(value => {
+      assert.ok(value && typeof value === 'object');
+    });
   });
 
-  it('should ignore a primitive `prototype` and use an empty object instead', function() {
-    var expected = lodashStable.map(primitives, stubTrue);
-
+  it('should accept a primitive `prototype`', function() {
     var actual = lodashStable.map(primitives, function(value, index) {
-      return lodashStable.isPlainObject(index ? create(value) : create());
+      return index ? create(value) : create();
     });
 
-    assert.deepStrictEqual(actual, expected);
+    actual.forEach(value => {
+      assert.ok(value && typeof value === 'object');
+    });
   });
 
   it('should work as an iteratee for methods like `_.map`', function() {

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -27,14 +27,15 @@ describe('create', function() {
 
   it('should assign `properties` to the created object', function() {
     var expected = { 'constructor': Circle, 'radius': 0 };
+    var properties = Object.keys(expected);
     Circle.prototype = create(Shape.prototype, expected);
 
     var actual = new Circle;
 
     assert.ok(actual instanceof Circle);
     assert.ok(actual instanceof Shape);
-    assert.deepStrictEqual(Object.keys(Circle.prototype), Object.keys(expected));
-    Object.keys(expected).forEach(property => {
+    assert.deepStrictEqual(Object.keys(Circle.prototype), properties);
+    properties.forEach(property => {
       assert.strictEqual(Circle.prototype[property], expected[property]);
     });
   });
@@ -48,9 +49,10 @@ describe('create', function() {
 
     var actual = create({}, new Foo);
     var expected = { 'a': 1, 'c': 3 };
+    var properties = Object.keys(expected);
 
-    assert.deepStrictEqual(Object.keys(actual), Object.keys(expected));
-    Object.keys(expected).forEach(property => {
+    assert.deepStrictEqual(Object.keys(actual), properties);
+    properties.forEach(property => {
       assert.strictEqual(actual[property], expected[property]);
     });    
   });

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -69,7 +69,7 @@ describe('create', function() {
     });
 
     actual.forEach(value => {
-      assert.ok(value && typeof value === 'object');
+      assert.ok(lodashStable.isObject(value));
     });
   });
 
@@ -79,7 +79,7 @@ describe('create', function() {
     });
 
     actual.forEach(value => {
-      assert.ok(value && typeof value === 'object');
+      assert.ok(lodashStable.isObject(value));
     });
   });
 

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -35,7 +35,7 @@ describe('create', function() {
     assert.ok(actual instanceof Circle);
     assert.ok(actual instanceof Shape);
     assert.deepStrictEqual(Object.keys(Circle.prototype), properties);
-    properties.forEach(property => {
+    properties.forEach((property) => {
       assert.strictEqual(Circle.prototype[property], expected[property]);
     });
   });
@@ -52,7 +52,7 @@ describe('create', function() {
     var properties = Object.keys(expected);
 
     assert.deepStrictEqual(Object.keys(actual), properties);
-    properties.forEach(property => {
+    properties.forEach((property) => {
       assert.strictEqual(actual[property], expected[property]);
     });    
   });
@@ -70,7 +70,7 @@ describe('create', function() {
       return index ? create(prototype) : create();
     });
 
-    actual.forEach(value => {
+    actual.forEach((value) => {
       assert.ok(lodashStable.isObject(value));
     });
   });
@@ -80,7 +80,7 @@ describe('create', function() {
       return index ? create(value) : create();
     });
 
-    actual.forEach(value => {
+    actual.forEach((value) => {
       assert.ok(lodashStable.isObject(value));
     });
   });


### PR DESCRIPTION
It enables the create tests and adapt it to match new behavior

Had to change how created objects are compared because node `assert.deepStrictEqual` takes into consideration to prototype

For falsey and primitive as prototype, just check if is a object

Let me know if there's a better way to handle these tests