### PR TITLE
merge: copy function values independent of source index 

### DIFF
--- a/.internal/baseMergeDeep.js
+++ b/.internal/baseMergeDeep.js
@@ -71,7 +71,7 @@ function baseMergeDeep(object, source, key, srcIndex, mergeFunc, customizer, sta
       if (isArguments(objValue)) {
         newValue = toPlainObject(objValue)
       }
-      else if ((srcIndex && typeof objValue == 'function') || !isObject(objValue)) {
+      else if (typeof objValue == 'function' || !isObject(objValue)) {
         newValue = initCloneObject(srcValue)
       }
     }

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import lodashStable from 'lodash';
-import { args, typedArrays, stubTrue, defineProperty, document } from './utils.js';
+import { args, typedArrays, stubTrue, defineProperty, document, root } from './utils.js';
 import merge from '../merge.js';
 import isArguments from '../isArguments.js';
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -733,6 +733,7 @@ export {
   params,
   push,
   realm,
+  root,
   slice,
   strictArgs,
   arrayBuffer,


### PR DESCRIPTION
This is port of a fix introduced in 4.7.11

Enabled tests. The sparse array tests fails but is related to changes in `keysIn` 

