### PR TITLE
Simplify toString

### DIFF
--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -28,24 +28,12 @@ describe('toString', function() {
     assert.deepStrictEqual(toString(values), '-0,-0,0,0');
   });
 
-  it('should not error on symbols', function() {
-    if (Symbol) {
-      try {
-        assert.strictEqual(toString(symbol), 'Symbol(a)');
-      } catch (e) {
-        assert.ok(false, e.message);
-      }
-    }
+  it('should handle symbols', function() {
+    assert.strictEqual(toString(symbol), 'Symbol(a)');
   });
 
-  it('should not error on an array of symbols', function() {
-    if (Symbol) {
-      try {
-        assert.strictEqual(toString([symbol]), 'Symbol(a)');
-      } catch (e) {
-        assert.ok(false, e.message);
-      }
-    }
+  it('should handle an array of symbols', function() {
+    assert.strictEqual(toString([symbol]), 'Symbol(a)');
   });
 
   it('should return the `toString` result of the wrapped value', function() {

--- a/toString.js
+++ b/toString.js
@@ -1,4 +1,3 @@
-import map from './map.js'
 import isSymbol from './isSymbol.js'
 
 /** Used as references for various `Number` constants. */
@@ -36,7 +35,7 @@ function toString(value) {
   }
   if (Array.isArray(value)) {
     // Recursively convert values (susceptible to call stack limits).
-    return `${map(value, (other) => other == null ? other : toString(other))}`
+    return `${value.map((other) => other == null ? other : toString(other))}`
   }
   if (isSymbol(value)) {
     return symbolToString ? symbolToString.call(value) : ''

--- a/toString.js
+++ b/toString.js
@@ -3,9 +3,6 @@ import isSymbol from './isSymbol.js'
 /** Used as references for various `Number` constants. */
 const INFINITY = 1 / 0
 
-/** Used to convert symbols to primitives and strings. */
-const symbolToString = Symbol.prototype.toString
-
 /**
  * Converts `value` to a string. An empty string is returned for `null`
  * and `undefined` values. The sign of `-0` is preserved.
@@ -38,7 +35,7 @@ function toString(value) {
     return `${value.map((other) => other == null ? other : toString(other))}`
   }
   if (isSymbol(value)) {
-    return symbolToString ? symbolToString.call(value) : ''
+    return value.toString()
   }
   const result = `${value}`
   return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result


### PR DESCRIPTION
It uses native array map instead of custom one and assumes Symbol.prototype.toString exists
