### PR TITLE
handled return default value for falsy result from baseGet - used isU…

### DIFF
--- a/get.js
+++ b/get.js
@@ -1,4 +1,6 @@
 import baseGet from './.internal/baseGet.js'
+import isNumber from './isNumber.js'
+import isUndefined from './isUndefined.js'
 
 /**
  * Gets the value at `path` of `object`. If the resolved value is
@@ -24,9 +26,12 @@ import baseGet from './.internal/baseGet.js'
  * get(object, 'a.b.c', 'default')
  * // => 'default'
  */
-function get(object, path, defaultValue) {
+function get(object, path, defaultValue, returnDefaultValueForFalsyResult) {
   const result = object == null ? undefined : baseGet(object, path)
-  return result === undefined ? defaultValue : result
+  if (returnDefaultValueForFalsyResult) {
+    return !result && !isNumber(result) ? defaultValue : result
+  }
+  return isUndefined(result) ? defaultValue : result
 }
 
 export default get


### PR DESCRIPTION
- handled return default value for falsy result from baseGet
- used isUndefined function

example:
```
const obj = {
  a: {
    b: {
      c: "Hi",
      d: null
    }
  }
};

get(obj, 'a.b.c')
output // => Hi

get(obj, 'a.b.d', '--default-value--')
currently it'll return null
output // => null

but with this pull request
get(obj, 'a.b.d', '--default-value--', true)
output // => '--default-value--'
````