### PR TITLE
Added filler option for chunk method

### DIFF
--- a/chunk.js
+++ b/chunk.js
@@ -13,42 +13,39 @@ import toInteger from './toInteger.js'
  * @returns {Array} Returns the new array of chunks.
  * @example
  *
- * chunk({
- *    array: ['a','b','c','d'],
- *    size: 2
- * })
+ * chunk(['a','b','c','d'], 2)
  * // => [['a', 'b'], ['c', 'd']]
  *
- * chunk({
- *    array: ['a','b','c','d'],
- *    size: 3
- * })
+ * chunk(['a','b','c','d'], 3)
  * // => [['a', 'b', 'c'], ['d']]
  *
- * chunk({
- *    array: ['a','b','c','d'],
+ * chunk(['a','b','c','d'],{
  *    size: 3,
  *    filler: 'e'
  * })
  * // => [['a', 'b', 'c'], ['d', 'e', 'e']]
  *
- * chunk({
- *    array: ['a','b','c','d'],
+ * chunk(['a','b','c','d'],{
  *    size: 3,
  *    filler: null
  * })
  * // => [['a', 'b', 'c'], ['d', null, null]]
  *
- * chunk({
- *    array: ['a','b','c','d'],
+ * chunk(['a','b','c','d'],{
  *    size: 3,
  *    filler: undefined
  * })
  * // => [[ 'a', 'b', 'c' ], [ 'd', undefined, undefined ]]
  */
-function chunk(options) {
-  const size = Math.max(toInteger(options.size), 0)
-  const length = options.array == null ? 0 : options.array.length
+function chunk(array, options) {
+  let size
+  if (typeof options !== 'object') {
+    size = Math.max(toInteger(options), 0)
+  }
+  else {
+    size = Math.max(toInteger(options.size), 0)
+  }
+  const length = array == null ? 0 : array.length
   if (!length || size < 1) {
     return []
   }
@@ -56,7 +53,7 @@ function chunk(options) {
   let resIndex = 0
   const result = new Array(Math.ceil(length / size))
   while (index < length) {
-    const arrayChunk = slice(options.array, index, (index += size))
+    const arrayChunk = slice(array, index, (index += size))
     const arrayChunkLength = arrayChunk.length
     if (arrayChunkLength < size && options.hasOwnProperty('filler')) {
       for (let i = 0; i < (size-(arrayChunkLength)); i++) {

--- a/chunk.js
+++ b/chunk.js
@@ -1,7 +1,7 @@
 import slice from './slice.js'
 import toInteger from './toInteger.js'
 
-/**
+/*
  * Creates an array of elements split into groups the length of `size`.
  * If `array` can't be split evenly, the final chunk will be the remaining
  * elements.
@@ -13,22 +13,42 @@ import toInteger from './toInteger.js'
  * @returns {Array} Returns the new array of chunks.
  * @example
  *
- * chunk(['a', 'b', 'c', 'd'], 2)
+ * chunk({
+ *    array: ['a','b','c','d'],
+ *    size: 2
+ * })
  * // => [['a', 'b'], ['c', 'd']]
  *
- * chunk(['a', 'b', 'c', 'd'], 3)
+ * chunk({
+ *    array: ['a','b','c','d'],
+ *    size: 3
+ * })
  * // => [['a', 'b', 'c'], ['d']]
  *
- * chunk(['a', 'b', 'c', 'd'], 3, 'e')
+ * chunk({
+ *    array: ['a','b','c','d'],
+ *    size: 3,
+ *    filler: 'e'
+ * })
  * // => [['a', 'b', 'c'], ['d', 'e', 'e']]
  *
- * chunk(['a', 'b', 'c', 'd'], 3, null)
+ * chunk({
+ *    array: ['a','b','c','d'],
+ *    size: 3,
+ *    filler: null
+ * })
  * // => [['a', 'b', 'c'], ['d', null, null]]
  *
+ * chunk({
+ *    array: ['a','b','c','d'],
+ *    size: 3,
+ *    filler: undefined
+ * })
+ * // => [[ 'a', 'b', 'c' ], [ 'd', undefined, undefined ]]
  */
-function chunk(array, size = 1,filler) {
-  size = Math.max(toInteger(size), 0)
-  const length = array == null ? 0 : array.length
+function chunk(options) {
+  const size = Math.max(toInteger(options.size), 0)
+  const length = options.array == null ? 0 : options.array.length
   if (!length || size < 1) {
     return []
   }
@@ -36,11 +56,11 @@ function chunk(array, size = 1,filler) {
   let resIndex = 0
   const result = new Array(Math.ceil(length / size))
   while (index < length) {
-    const arrayChunk = slice(array, index, (index += size))
+    const arrayChunk = slice(options.array, index, (index += size))
     const arrayChunkLength = arrayChunk.length
-    if (arrayChunkLength < size && filler !== undefined) {
+    if (arrayChunkLength < size && options.hasOwnProperty('filler')) {
       for (let i = 0; i < (size-(arrayChunkLength)); i++) {
-        arrayChunk.push(filler)
+        arrayChunk.push(options.filler)
       }
     }
     result[resIndex++] = arrayChunk

--- a/chunk.js
+++ b/chunk.js
@@ -18,8 +18,15 @@ import toInteger from './toInteger.js'
  *
  * chunk(['a', 'b', 'c', 'd'], 3)
  * // => [['a', 'b', 'c'], ['d']]
+ *
+ * chunk(['a', 'b', 'c', 'd', 3, 'e')
+ * // => [['a', 'b', 'c'], ['d', 'e', 'e']]
+ *
+ * chunk(['a', 'b', 'c', 'd', 3, null)
+ * // => [['a', 'b', 'c'], ['d', null, null]]
+ *
  */
-function chunk(array, size = 1) {
+function chunk(array, size = 1,filler) {
   size = Math.max(toInteger(size), 0)
   const length = array == null ? 0 : array.length
   if (!length || size < 1) {
@@ -28,9 +35,15 @@ function chunk(array, size = 1) {
   let index = 0
   let resIndex = 0
   const result = new Array(Math.ceil(length / size))
-
   while (index < length) {
-    result[resIndex++] = slice(array, index, (index += size))
+    const arrayChunk = slice(array, index, (index += size))
+    const arrayChunkLength = arrayChunk.length
+    if (arrayChunkLength < size && filler !== undefined) {
+      for (let i = 0; i < (size-(arrayChunkLength)); i++) {
+        arrayChunk.push(filler)
+      }
+    }
+    result[resIndex++] = arrayChunk
   }
   return result
 }

--- a/chunk.js
+++ b/chunk.js
@@ -19,10 +19,10 @@ import toInteger from './toInteger.js'
  * chunk(['a', 'b', 'c', 'd'], 3)
  * // => [['a', 'b', 'c'], ['d']]
  *
- * chunk(['a', 'b', 'c', 'd', 3, 'e')
+ * chunk(['a', 'b', 'c', 'd'], 3, 'e')
  * // => [['a', 'b', 'c'], ['d', 'e', 'e']]
  *
- * chunk(['a', 'b', 'c', 'd', 3, null)
+ * chunk(['a', 'b', 'c', 'd'], 3, null)
  * // => [['a', 'b', 'c'], ['d', null, null]]
  *
  */


### PR DESCRIPTION
Behaviour shown by addition is as follows:-
1.chunk(['a', 'b', 'c', 'd'], 2)
 // => [['a', 'b'], ['c', 'd']]

2.chunk(['a', 'b', 'c', 'd'], 3)
// => [['a', 'b', 'c'], ['d']]

3.chunk(['a', 'b', 'c', 'd', 3, 'e')
// => [['a', 'b', 'c'], ['d', 'e', 'e']]

4.chunk(['a', 'b', 'c', 'd', 3, null)
// => [['a', 'b', 'c'], ['d', null, null]]