### PR TITLE
avoid +0/-0 compare when key not in object

### DIFF
--- a/.internal/assignValue.js
+++ b/.internal/assignValue.js
@@ -13,11 +13,13 @@ const hasOwnProperty = Object.prototype.hasOwnProperty
  * @param {*} value The value to assign.
  */
 function assignValue(object, key, value) {
-  const objValue = object[key]
+  const objValue = object[key];
 
-  if (!(hasOwnProperty.call(object, key) && eq(objValue, value))) {
+  if (!hasOwnProperty.call(object, key)) {
+    baseAssignValue(object, key, value);
+  } else if (!eq(objValue, value)) {
     if (value !== 0 || (1 / value) == (1 / objValue)) {
-      baseAssignValue(object, key, value)
+      baseAssignValue(object, key, value);
     }
   } else if (value === undefined && !(key in object)) {
     baseAssignValue(object, key, value)


### PR DESCRIPTION
to FIX: _.cloneDeep([{'a':1, 'b':0}]) => [{'a':1}]