### PR TITLE
:bug defaultValue when the get parameter is null

### DIFF
--- a/get.js
+++ b/get.js
@@ -26,7 +26,7 @@ import baseGet from './.internal/baseGet.js'
  */
 function get(object, path, defaultValue) {
   const result = object == null ? undefined : baseGet(object, path)
-  return result === undefined ? defaultValue : result
+  return (result === undefined || result === null) ? defaultValue : result
 }
 
 export default get


### PR DESCRIPTION
### Problem
When the parameter of the get method is null, the defaultValue setting is not entered.
This is not the normal process we expect

E.g
```
import { get } from 'lodash'

const params = {
  a: null
}

get(params, 'a', 'defaultValue')   // return null

```