### PR TITLE
feat: Allow toString to stringify JSON Objects

### DIFF
--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -32,6 +32,10 @@ describe('toString', function() {
     assert.strictEqual(toString(symbol), 'Symbol(a)');
   });
 
+  it('should handle objects', () => {
+    assert.strictEqual(toString({ a: 'b' }), '{"a":"b"}')
+  })
+
   it('should handle an array of symbols', function() {
     assert.strictEqual(toString([symbol]), 'Symbol(a)');
   });

--- a/toString.js
+++ b/toString.js
@@ -1,4 +1,5 @@
 import isSymbol from './isSymbol.js'
+import isPlainObject from './isPlainObject.js'
 
 /** Used as references for various `Number` constants. */
 const INFINITY = 1 / 0
@@ -36,6 +37,9 @@ function toString(value) {
   }
   if (isSymbol(value)) {
     return value.toString()
+  }
+  if (isPlainObject(value)) {
+    return JSON.stringify(value)
   }
   const result = `${value}`
   return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result


### PR DESCRIPTION
Old behaviour:

```js
> _.toString({a: 'b'})
"[object Object]"
```

New behaviour:

```js
> _.toString({a: 'b'})
"{"a":"b"}"
```