### PR TITLE
Short circuit sortedIndexBy methods for empty arrays

### DIFF
--- a/.internal/baseSortedIndexBy.js
+++ b/.internal/baseSortedIndexBy.js
@@ -18,10 +18,14 @@ const MAX_ARRAY_INDEX = MAX_ARRAY_LENGTH - 1
  *  into `array`.
  */
 function baseSortedIndexBy(array, value, iteratee, retHighest) {
-  value = iteratee(value)
-
   let low = 0
   let high = array == null ? 0 : array.length
+  if (high == 0) {
+    return 0
+  }
+
+  value = iteratee(value)
+
   const valIsNaN = value !== value
   const valIsNull = value === null
   const valIsSymbol = isSymbol(value)

--- a/test/sortedIndexBy-methods.js
+++ b/test/sortedIndexBy-methods.js
@@ -24,6 +24,13 @@ describe('sortedIndexBy methods', function() {
       assert.strictEqual(actual, 1);
     });
 
+    it('`_.' + methodName + '` should avoid calling iteratee when length is 0', function() {
+      var objects = [],
+          actual = func(objects, { 'x': 50 }, assert.fail);
+
+      assert.strictEqual(actual, 0);
+    });
+
     it('`_.' + methodName + '` should support arrays larger than `MAX_ARRAY_LENGTH / 2`', function() {
       lodashStable.each([Math.ceil(MAX_ARRAY_LENGTH / 2), MAX_ARRAY_LENGTH], function(length) {
         var array = [],


### PR DESCRIPTION
I have a use case that involves building many smallish sorted arrays so I'm using `sortedIndexBy` as part of an insertion sort logic. As empty arrays are a common condition for me, I figured I should reach out and see if we could get them short circuited. Cheers.