### PR TITLE
(4.17) Short circuit sortedIndexBy methods for empty arrays

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4129,11 +4129,14 @@
      *  into `array`.
      */
     function baseSortedIndexBy(array, value, iteratee, retHighest) {
-      value = iteratee(value);
-
       var low = 0,
-          high = array == null ? 0 : array.length,
-          valIsNaN = value !== value,
+          high = array == null ? 0 : array.length;
+      if (high === 0) {
+        return 0;
+      }
+
+      value = iteratee(value);
+      var valIsNaN = value !== value,
           valIsNull = value === null,
           valIsSymbol = isSymbol(value),
           valIsUndefined = value === undefined;

--- a/test/test.js
+++ b/test/test.js
@@ -20998,6 +20998,16 @@
       assert.strictEqual(actual, 1);
     });
 
+    QUnit.test('`_.' + methodName + '` should avoid calling iteratee when length is 0', function(assert) {
+      var objects = [],
+          iteratee = function() {
+            throw new Error;
+          },
+          actual = func(objects, { 'x': 50 }, iteratee);
+
+      assert.strictEqual(actual, 0);
+    });
+
     QUnit.test('`_.' + methodName + '` should support arrays larger than `MAX_ARRAY_LENGTH / 2`', function(assert) {
       assert.expect(12);
 


### PR DESCRIPTION
Backport of https://github.com/lodash/lodash/pull/4496 to 4.17