### PR TITLE
Fix issue where _getTag() fails with "TypeError: Expected at least one argument"

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -6046,7 +6046,7 @@
     // Fallback for data views, maps, sets, and weak maps in IE 11 and promises in Node.js < 6.
     if ((DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
         (Map && getTag(new Map) != mapTag) ||
-        (Promise && getTag(Promise.resolve()) != promiseTag) ||
+        (Promise && getTag(Promise.resolve(undefined)) != promiseTag) ||
         (Set && getTag(new Set) != setTag) ||
         (WeakMap && getTag(new WeakMap) != weakMapTag)) {
       getTag = function(value) {


### PR DESCRIPTION
Fixes https://github.com/lodash/lodash/issues/4500

On PlayStation 4 and LG WebOS 2, the `Promise.require()` API throws an exception if the argument list is empty.  This causes the application to crash, because the Lodash bundle fails to evaluate.

The fix is to call `Promise.resolve(undefined)` instead.  This is the same solution used by https://github.com/zloirock/core-js/issues/396.