### PR TITLE
Fix an issue where _.pick makes multiple calls to property getter

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -6119,20 +6119,32 @@
     function hasPath(object, path, hasFunc) {
       path = castPath(path, object);
 
-      var index = -1,
+      var index = 0,
           length = path.length,
-          result = false;
+          key = undefined;
 
-      while (++index < length) {
-        var key = toKey(path[index]);
-        if (!(result = object != null && hasFunc(object, key))) {
+      if (length == 0) {
+        return false;
+      }
+
+      while (true) {
+        key = toKey(path[index]);
+        if (object == null || !hasFunc(object, key)) {
           break;
+        }
+        if (++index >= length) {
+          // We traversed the entire path and hasFunc() succeeded at each step
+          return true;
         }
         object = object[key];
       }
-      if (result || ++index != length) {
-        return result;
+
+      if (index != length - 1) {
+        // The loop exited before we reached the last step of the path
+        return false;
       }
+
+      // We traversed the entire path, but the last object did not match.  Check for an array index.
       length = object == null ? 0 : object.length;
       return !!length && isLength(length) && isIndex(key, length) &&
         (isArray(object) || isArguments(object));


### PR DESCRIPTION
Fixes https://github.com/lodash/lodash/issues/4491

@jdalton [suggested](https://github.com/lodash/lodash/issues/4491#issuecomment-536827117) that this is a breaking change:

> Commit it against master. That's where all the breaking changes can occur.

I'm not sure this is a breaking change. The Lodash docs don't make any guarantees about when reads occur, so this is arguably just fixing a performance regression.

I can't figure out how to build/run the master branch (see issue notes), so I've tentatively opened this PR against `4.17.15-post`.  The priority is to fix this for Lodash 4, since that's the version we just upgraded to, and Lodash 5 is unreleased.

If someone could provide some contributor guidance, that would be great.