### PR TITLE
Ensure `orderBy` will accept iteratee path arrays #4438

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3719,8 +3719,21 @@
      * @returns {Array} Returns the new sorted array.
      */
     function baseOrderBy(collection, iteratees, orders) {
+      if (iteratees.length) {
+        iteratees = arrayMap(iteratees, function(iteratee) {
+          if (isArray(iteratee)) {
+            return function(value) {
+              return baseGet(value, iteratee.length === 1 ? iteratee[0] : iteratee);
+            }
+          }
+          return iteratee;
+        });
+      } else {
+        iteratees = [identity];
+      }
+
       var index = -1;
-      iteratees = arrayMap(iteratees.length ? iteratees : [identity], baseUnary(getIteratee()));
+      iteratees = arrayMap(iteratees, baseUnary(getIteratee()));
 
       var result = baseMap(collection, function(value, key, collection) {
         var criteria = arrayMap(iteratees, function(iteratee) {

--- a/test/test.js
+++ b/test/test.js
@@ -16020,11 +16020,30 @@
       { 'a': 'y', 'b': 2 }
     ];
 
+    var nestedObj = [
+      { id: '4', address: { zipCode: 4, streetName: 'Beta' } },
+      { id: '3', address: { zipCode: 3, streetName: 'Alpha' } },
+      { id: '1', address: { zipCode: 1, streetName: 'Alpha' } },
+      { id: '2', address: { zipCode: 2, streetName: 'Alpha' } },
+      { id: '5', address: { zipCode: 4, streetName: 'Alpha' } },
+    ];
+
     QUnit.test('should sort by a single property by a specified order', function(assert) {
       assert.expect(1);
 
       var actual = _.orderBy(objects, 'a', 'desc');
       assert.deepEqual(actual, [objects[1], objects[3], objects[0], objects[2]]);
+    });
+
+    QUnit.test('should sort by nested key in array format', function(assert) {
+      assert.expect(1);
+
+      var actual = _.orderBy(
+        nestedObj,
+        [['address', 'zipCode'], ['address.streetName']],
+        ['asc', 'desc'],
+      );
+      assert.deepEqual(actual, [nestedObj[2], nestedObj[3], nestedObj[1], nestedObj[0], nestedObj[4]]);
     });
 
     QUnit.test('should sort by multiple properties by specified orders', function(assert) {


### PR DESCRIPTION
While backporting https://github.com/lodash/lodash/pull/4453 for #4438 I noticed it just don't work, we didn't catch it because tests for `orderBy` were disabled. This contains necessary fixes (I will forward port it to master later on).