### PR TITLE
Fix lodash.isEqual for circular references #4320

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5618,10 +5618,11 @@
       if (arrLength != othLength && !(isPartial && othLength > arrLength)) {
         return false;
       }
-      // Assume cyclic values are equal.
-      var stacked = stack.get(array);
-      if (stacked && stack.get(other)) {
-        return stacked == other;
+      // Check that cyclic values are equal.
+      var arrStacked = stack.get(array);
+      var othStacked = stack.get(other);
+      if (arrStacked && othStacked) {
+        return arrStacked == other && othStacked == array;
       }
       var index = -1,
           result = true,
@@ -5783,10 +5784,11 @@
           return false;
         }
       }
-      // Assume cyclic values are equal.
-      var stacked = stack.get(object);
-      if (stacked && stack.get(other)) {
-        return stacked == other;
+      // Check that cyclic values are equal.
+      var objStacked = stack.get(object);
+      var othStacked = stack.get(other);
+      if (objStacked && othStacked) {
+        return objStacked == other && othStacked == object;
       }
       var result = true;
       stack.set(object, other);

--- a/test/test.js
+++ b/test/test.js
@@ -9741,7 +9741,7 @@
     });
 
     QUnit.test('should compare arrays with circular references', function(assert) {
-      assert.expect(4);
+      assert.expect(6);
 
       var array1 = [],
           array2 = [];
@@ -9766,6 +9766,14 @@
       array2 = ['a', ['a', 'b', 'c'], 'c'];
 
       assert.strictEqual(_.isEqual(array1, array2), false);
+
+      array1 = [[[]]];
+      array1[0][0][0] = array1;
+      array2 = [];
+      array2[0] = array2;
+
+      assert.strictEqual(_.isEqual(array1, array2), false);
+      assert.strictEqual(_.isEqual(array2, array1), false);
     });
 
     QUnit.test('should have transitive equivalence for circular references of arrays', function(assert) {
@@ -9783,7 +9791,7 @@
     });
 
     QUnit.test('should compare objects with circular references', function(assert) {
-      assert.expect(4);
+      assert.expect(6);
 
       var object1 = {},
           object2 = {};
@@ -9808,6 +9816,14 @@
       object2 = { 'a': 1, 'b': { 'a': 1, 'b': 2, 'c': 3 }, 'c': 3 };
 
       assert.strictEqual(_.isEqual(object1, object2), false);
+
+      object1 = {self: {self: {self: {}}}};
+      object1.self.self.self = object1;
+      object2 = {self: {}};
+      object2.self = object2; 
+
+      assert.strictEqual(_.isEqual(object1, object2), false);
+      assert.strictEqual(_.isEqual(object2, object1), false);
     });
 
     QUnit.test('should have transitive equivalence for circular references of objects', function(assert) {


### PR DESCRIPTION
`lodash.isEqual` for circular reference in objects/arrays returned different results based on order of arguments. More detail can be found here:  #4320

![image](https://user-images.githubusercontent.com/7350476/66698168-941bf880-eca9-11e9-8bfa-9b7c6e3aa1f5.png)
