### PR TITLE
Prevent prototype pollution chaining to code execution via _.template, part 2

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -87,6 +87,7 @@ exports.aryMethod = {
     'every', 'filter', 'find', 'findIndex', 'findKey', 'findLast', 'findLastIndex',
     'findLastKey', 'flatMap', 'flatMapDeep', 'flattenDepth', 'forEach',
     'forEachRight', 'forIn', 'forInRight', 'forOwn', 'forOwnRight', 'get',
+    'getOwnValue',
     'groupBy', 'gt', 'gte', 'has', 'hasIn', 'includes', 'indexOf', 'intersection',
     'invertBy', 'invoke', 'invokeMap', 'isEqual', 'isMatch', 'join', 'keyBy',
     'lastIndexOf', 'lt', 'lte', 'map', 'mapKeys', 'mapValues', 'matchesProperty',

--- a/lodash.js
+++ b/lodash.js
@@ -1130,6 +1130,19 @@
   }
 
   /**
+   * Gets the value at `key` of `object`, if it's an "own property" and
+   * not coming from the object's prototype.
+   *
+   * @private
+   * @param {Object} [object] The object to query.
+   * @param {string} key The key of the property to get.
+   * @returns {*} Returns the property value if it's the object's own property.
+   */
+  function getOwnValue(object, key) {
+    return object == null ? undefined : (hasOwnProperty.call(object, key) && object[key] || undefined)
+  }
+
+  /**
    * Checks if `string` contains Unicode symbols.
    *
    * @private
@@ -16762,6 +16775,7 @@
     lodash.forOwn = forOwn;
     lodash.forOwnRight = forOwnRight;
     lodash.get = get;
+    lodash.getOwnValue = getOwnValue;
     lodash.gt = gt;
     lodash.gte = gte;
     lodash.has = has;

--- a/test/test.js
+++ b/test/test.js
@@ -22652,6 +22652,27 @@
       assert.deepEqual(actual, expected);
     });
 
+    QUnit.test('should not let a polluted prototype affect generated code', function(assert) {
+      assert.expect(1);
+
+      // Intentionally pollute the prototype. These will cause a compilation error if part of the code
+      Object.prototype['sourceURL'] = '\u2028\n!err, please!';
+      Object.prototype['variable'] = '}{!?';
+      Object.prototype['imports'] = {',),': ''};
+
+      var actual,
+          expected = 'no error';
+      try {
+        actual = _.template(expected)();
+      } catch (e) {}
+
+      delete Object.prototype['sourceURL'];
+      delete Object.prototype['variable'];
+      delete Object.prototype['imports'];
+
+      assert.equal(actual, expected);
+    });
+
     QUnit.test('should work as an iteratee for methods like `_.map`', function(assert) {
       assert.expect(1);
 

--- a/test/test.js
+++ b/test/test.js
@@ -1489,6 +1489,33 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.getOwnValue');
+
+  (function() {
+
+    var obj = {'foo': 'bar', 'falsy-0': 0, 'falsy-false': false};
+    obj.__proto__ = {'sourceURL': 'does not belong to a'};
+
+    QUnit.test('should return `undefined` for keys that only exist in the prototype', function (assert) {
+      assert.expect(1);
+      assert.equal(_.getOwnValue(obj, 'sourceURL'), undefined);
+    });
+
+    QUnit.test('should return values that exist', function (assert) {
+      assert.expect(1);
+      assert.equal(_.getOwnValue(obj, 'foo'), 'bar');
+    });
+
+    QUnit.test('should return falsy values properly', function (assert) {
+      assert.expect(2);
+      assert.equal(_.getOwnValue(obj, 'falsy-0'), 0);
+      assert.equal(_.getOwnValue(obj, 'falsy-false'), false);
+    });
+
+  });
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.at');
 
   (function() {
@@ -26851,7 +26878,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(316);
+      assert.expect(317);
 
       var arrays = lodashStable.map(falsey, stubArray);
 


### PR DESCRIPTION
This is a followup to #4355 which unfortunately was incomplete, because of …

```
options = assignInWith({}, options, settings, customDefaultsAssignIn);
```

... which happens prior to the `hasOwnProperty` guard would merge in whatever happens to be on the prototype into `options`, so it'd all be considered as part of `options` "own" properties. That might be a bug in `assignInWith`, it's not clear whether that's intentional behaviour.

My testing focused on the `sourceURL` part (which was easier to inject with than `variable`), and it got stopped by the newline stripping. The newline stripping was also incomplete, as you can provide a unicode newline.

I added a utility to get a property without looking at the prototype, which I guess might be a bit too much for this PR. Happy to remove that, but I think it'd be nice to have a utility like that in lodash. :)



