### PR TITLE
Sanitize sourceURL so it cannot affect evaled code

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14821,11 +14821,11 @@
 
       // Use a sourceURL for easier debugging.
       // The sourceURL gets injected into the source that's eval-ed, so be careful
-      // with lookup (in case of e.g. prototype pollution), and strip newlines if any.
-      // A newline wouldn't be a valid sourceURL anyway, and it'd enable code injection.
+      // to normalize all kinds of whitespace, so e.g. newlines (and unicode versions of it) can't sneak in
+      // and escape the comment, thus injecting code that gets evaled.
       var sourceURL = '//# sourceURL=' +
         (hasOwnProperty.call(options, 'sourceURL')
-          ? (options.sourceURL + '').replace(/[\r\n]/g, ' ')
+          ? (options.sourceURL + '').replace(/\s/g, ' ')
           : ('lodash.templateSources[' + (++templateCounter) + ']')
         ) + '\n';
 
@@ -14858,8 +14858,6 @@
 
       // If `variable` is not specified wrap a with-statement around the generated
       // code to add the data object to the top of the scope chain.
-      // Like with sourceURL, we take care to not check the option's prototype,
-      // as this configuration is a code injection vector.
       var variable = hasOwnProperty.call(options, 'variable') && options.variable;
       if (!variable) {
         source = 'with (obj) {\n' + source + '\n}\n';

--- a/test/test.js
+++ b/test/test.js
@@ -22641,6 +22641,18 @@
       assert.deepEqual(actual, expected);
     });
 
+    QUnit.test('should not let a sourceURL inject code', function(assert) {
+      assert.expect(1);
+
+      var actual,
+          expected = 'no error';
+      try {
+          actual = _.template(expected, {'sourceURL': '\u2028\u2029\n!this would err if it was executed!'})();
+      } catch (e) {}
+
+      assert.equal(actual, expected);
+    });
+
     QUnit.test('should work as an iteratee for methods like `_.map`', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Wherever it comes from, `sourceURL` should not be allowed to contain code that gets eval()-ed.

`/\s/` should cover all the bases as far as I know, including the various unicode-y ways of encoding newlines.

```
> sourceURL = '\u2028\u2029\nconsole.log("o hai")'
'  \nconsole.log("o hai")'
> eval('//# sourceURL=' + sourceURL)
o hai
undefined
> eval('//# sourceURL=' + sourceURL.replace(/\s/g, ' '))
undefined
```