### PR TITLE
Remove extraneous conditional

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -21,7 +21,7 @@
  * // => 9
  */
 function flow(...funcs) {
-  const length = funcs ? funcs.length : 0
+  const length = funcs.length
   let index = length
   while (index--) {
     if (typeof funcs[index] !== 'function') {


### PR DESCRIPTION
Since `function flow(funcs)` changed to `function flow(...funcs)` this ternary became unnecessary, since funcs will always have a length now.