### PR TITLE
handle emoji flag tag sequence

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -247,8 +247,7 @@
       rsOptTag = '(?:' + rsTagSpec + rsTagCancel + ')?',
       rsOrdLower = '\\d*(?:1st|2nd|3rd|(?![123])\\dth)(?=\\b|[A-Z_])',
       rsOrdUpper = '\\d*(?:1ST|2ND|3RD|(?![123])\\dTH)(?=\\b|[a-z_])',
-      rsCoreZwjSeq = '(?:' + rsOptVar + reOptMod + rsOptJoin + ')',
-      rsSeq = '(?:' + rsOptTag + '|' + rsCoreZwjSeq + ')?'
+      rsSeq = rsOptVar + reOptMod + rsOptJoin + rsOptTag,
       rsEmoji = '(?:' + [rsDingbat, rsRegional, rsSurrPair].join('|') + ')' + rsSeq,
       rsSymbol = '(?:' + [rsNonAstral + rsCombo + '?', rsCombo, rsRegional, rsSurrPair, rsAstral].join('|') + ')';
 

--- a/lodash.js
+++ b/lodash.js
@@ -231,6 +231,8 @@
       rsNonAstral = '[^' + rsAstralRange + ']',
       rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}',
       rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]',
+      rsTagSpec = '(?:\\udb40[\\udc20-\\udc7e])+',
+      rsTagCancel = '\\udb40\\udc7f',
       rsUpper = '[' + rsUpperRange + ']',
       rsZWJ = '\\u200d';
 
@@ -242,9 +244,11 @@
       reOptMod = rsModifier + '?',
       rsOptVar = '[' + rsVarRange + ']?',
       rsOptJoin = '(?:' + rsZWJ + '(?:' + [rsNonAstral, rsRegional, rsSurrPair].join('|') + ')' + rsOptVar + reOptMod + ')*',
+      rsOptTag = '(?:' + rsTagSpec + rsTagCancel + ')?',
       rsOrdLower = '\\d*(?:1st|2nd|3rd|(?![123])\\dth)(?=\\b|[A-Z_])',
       rsOrdUpper = '\\d*(?:1ST|2ND|3RD|(?![123])\\dTH)(?=\\b|[a-z_])',
-      rsSeq = rsOptVar + reOptMod + rsOptJoin,
+      rsCoreZwjSeq = '(?:' + rsOptVar + reOptMod + rsOptJoin + ')',
+      rsSeq = '(?:' + rsOptTag + '|' + rsCoreZwjSeq + ')?'
       rsEmoji = '(?:' + [rsDingbat, rsRegional, rsSurrPair].join('|') + ')' + rsSeq,
       rsSymbol = '(?:' + [rsNonAstral + rsCombo + '?', rsCombo, rsRegional, rsSurrPair, rsAstral].join('|') + ')';
 

--- a/test/test.js
+++ b/test/test.js
@@ -9820,7 +9820,7 @@
       object1 = {self: {self: {self: {}}}};
       object1.self.self.self = object1;
       object2 = {self: {}};
-      object2.self = object2; 
+      object2.self = object2;
 
       assert.strictEqual(_.isEqual(object1, object2), false);
       assert.strictEqual(_.isEqual(object2, object1), false);
@@ -24400,7 +24400,10 @@
         noMic = mic + '\u20e0',
         raisedHand = '\u270B' + emojiVar,
         rocket = '\ud83d\ude80',
-        thumbsUp = '\ud83d\udc4d';
+        thumbsUp = '\ud83d\udc4d',
+        wavingFlag = '\ud83c\udff4',
+        scottishFlag = wavingFlag + '\udb40\udc67\udb40\udc62\udb40\udc73\udb40\udc63\udb40\udc74\udb40\udc7f';
+
 
     QUnit.test('should account for astral symbols', function(assert) {
       assert.expect(34);
@@ -24520,6 +24523,14 @@
       assert.deepEqual(_.toArray(heart), [heart]);
       assert.deepEqual(_.words(heart), [heart]);
     });
+
+    QUnit.test('should account for emoji tag sequence', function(assert){
+      assert.expect(3);
+
+      assert.strictEqual(_.size(scottishFlag), 1);
+      assert.deepEqual(_.toArray(scottishFlag), [scottishFlag]);
+      assert.deepEqual(_.words(scottishFlag), [scottishFlag]);
+    })
 
     QUnit.test('should account for variation selectors with fitzpatrick modifiers', function(assert) {
       assert.expect(1);


### PR DESCRIPTION
Noticed that the emoji flag tag sequences are not handled correctly by `toArrray`. 

This updates the emoji regex to allow for an emoji sequence of the following form:

```
emoji_tag_sequence := tag_base tag_spec tag_term
tag_base           := emoji_character
                    | emoji_modifier_sequence
                    | emoji_presentation_sequence
tag_spec           := [\x{E0020}-\x{E007E}]+
tag_term           := \x{E007F}
```

This handles the generic emoji tag sequence defined in the [Unicode Technical Standard](https://unicode.org/reports/tr51/#def_emoji_tag_sequence) instead of only the specific currently valid emoji tag sequences [here](https://unicode.org/reports/tr51/#valid-emoji-tag-sequences).