### PR TITLE
add _.insert()

### DIFF
--- a/fp/_mapping.js
+++ b/fp/_mapping.js
@@ -87,7 +87,7 @@ exports.aryMethod = {
     'every', 'filter', 'find', 'findIndex', 'findKey', 'findLast', 'findLastIndex',
     'findLastKey', 'flatMap', 'flatMapDeep', 'flattenDepth', 'forEach',
     'forEachRight', 'forIn', 'forInRight', 'forOwn', 'forOwnRight', 'get',
-    'groupBy', 'gt', 'gte', 'has', 'hasIn', 'includes', 'indexOf', 'intersection',
+    'groupBy', 'gt', 'gte', 'has', 'hasIn', 'includes', 'indexOf', 'insert', 'intersection',
     'invertBy', 'invoke', 'invokeMap', 'isEqual', 'isMatch', 'join', 'keyBy',
     'lastIndexOf', 'lt', 'lte', 'map', 'mapKeys', 'mapValues', 'matchesProperty',
     'maxBy', 'meanBy', 'merge', 'mergeAllWith', 'minBy', 'multiply', 'nth', 'omit',

--- a/lodash.js
+++ b/lodash.js
@@ -7497,6 +7497,34 @@
     }
 
     /**
+     * Inserts `item` to an `array`
+     *
+     * @static
+     * @memberof _
+     * @since 4.17.16
+     * @category Array
+     * @param {Array} array The array to insert the item into
+     * @param {*} item The item to be inserted
+     * @param {number} [index=0] The index in which the item will be inserted
+     * @returns {Array} Return the new array with the inserted item
+     * @example
+     *
+     * _.insert([2,3], 1);
+     * // => [1,2,3]
+     *
+     * _.insert(['Sunday', 'Monday', 'Wednesday', 'Thursday'], 'Tuesday', 2);
+     * // => ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday']
+     */
+
+    function insert(array, item, index) {
+      var length = array == null ? 0 : array.length;
+      var insertopnIndex = index == null ? length : parseInt(index);
+      return !isUndefined(item)
+        ? concat(slice(array, 0, insertopnIndex), item, slice(array, insertopnIndex))
+        : array;
+    }
+
+    /**
      * Creates an array of unique values that are included in all given arrays
      * using [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
      * for equality comparisons. The order and references of result values are
@@ -16620,6 +16648,7 @@
     lodash.functionsIn = functionsIn;
     lodash.groupBy = groupBy;
     lodash.initial = initial;
+    lodash.insert = insert;
     lodash.intersection = intersection;
     lodash.intersectionBy = intersectionBy;
     lodash.intersectionWith = intersectionWith;

--- a/lodash.js
+++ b/lodash.js
@@ -7497,7 +7497,7 @@
     }
 
     /**
-     * Inserts `item` to an `array`
+     * Inserts an `item` to an `array`
      *
      * @static
      * @memberof _
@@ -7505,7 +7505,7 @@
      * @category Array
      * @param {Array} array The array to insert the item into
      * @param {*} item The item to be inserted
-     * @param {number} [index=0] The index in which the item will be inserted
+     * @param {number} [index=array.length] The index in which the item will be inserted
      * @returns {Array} Return the new array with the inserted item
      * @example
      *

--- a/lodash.js
+++ b/lodash.js
@@ -7518,9 +7518,9 @@
 
     function insert(array, item, index) {
       var length = array == null ? 0 : array.length;
-      var insertopnIndex = index == null ? length : parseInt(index);
+      var itemIndex = index == null ? length : parseInt(index);
       return !isUndefined(item)
-        ? concat(slice(array, 0, insertopnIndex), item, slice(array, insertopnIndex))
+        ? concat(slice(array, 0, itemIndex), item, slice(array, itemIndex))
         : array;
     }
 

--- a/lodash.js
+++ b/lodash.js
@@ -7509,8 +7509,8 @@
      * @returns {Array} Return the new array with the inserted item
      * @example
      *
-     * _.insert([2,3], 1);
-     * // => [1,2,3]
+     * _.insert([1, 2], 3);
+     * // => [1, 2, 3]
      *
      * _.insert(['Sunday', 'Monday', 'Wednesday', 'Thursday'], 'Tuesday', 2);
      * // => ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday']

--- a/test/test.js
+++ b/test/test.js
@@ -8369,6 +8369,59 @@
 
   /*--------------------------------------------------------------------------*/
 
+  QUnit.module('lodash.insert');
+
+  (function() {  
+    QUnit.test('should insert an `item` at the given `index`', function(assert) {
+      var array = [ 1, 2, 3, 4 ];
+      var item = 2.5;
+      var index = 2;
+      var result = [ 1, 2, 2.5, 3, 4 ];
+      assert.deepEqual(_.insert(array, item, index), result);
+    });
+    
+    QUnit.test('should work with a negative `index`', function(assert) {
+      var array = [ 1, 2, 3, 4 ];
+      var item = 2.5;
+      var index = -1;
+      var result = [1, 2, 3, 2.5, 4];
+      assert.deepEqual(_.insert(array, item, index), result);
+    });
+
+    QUnit.test('should fallback to _.concat() when no `index` given', function(assert) {
+      var array = [ 1, 2, 3, 4 ];
+      var item = 2.5;
+      var result = [1, 2, 3, 4, 2.5];
+      assert.deepEqual(_.insert(array, item), result);
+    });
+
+    QUnit.test('should place `item` at beginning or ending if `index` is out of bounds', function(assert) {
+      var array = [ 1, 2, 3, 4 ];
+      var item = 2.5;
+      var index = -10;
+      var result = [2.5, 1, 2, 3, 4];
+      assert.deepEqual(_.insert(array, item, index), result);
+
+      var array = [ 1, 2, 3, 4 ];
+      var item = 2.5;
+      var index = 60; 
+      var result = [1, 2, 3, 4, 2.5];
+      assert.deepEqual(_.insert(array, item, index), result);
+    });
+    
+    QUnit.test('should return original `array` if no `item` given', function(assert) {
+      var array = [ 1, 2, 3, 4 ];
+      var result = [ 1, 2, 3, 4 ];
+      assert.deepEqual(_.insert(array), result);
+    });
+
+    QUnit.test('should return undefined when no arguments passed', function(assert) {
+      assert.notOk(_.insert());
+    });
+  }());
+
+  /*--------------------------------------------------------------------------*/
+
   QUnit.module('lodash.inRange');
 
   (function() {
@@ -26867,7 +26920,7 @@
     var acceptFalsey = lodashStable.difference(allMethods, rejectFalsey);
 
     QUnit.test('should accept falsey arguments', function(assert) {
-      assert.expect(316);
+      assert.expect(317);
 
       var arrays = lodashStable.map(falsey, stubArray);
 


### PR DESCRIPTION
## Add `_.insert(array, item, [index])`

- Returns a new `array` with the added `item` in the given `index`
- If no `index` the new `item`, falling back to `_.concat()`
- If no item sent, returns a copy of the array

resolves #89 