### PR TITLE
Fixed faulty example for uniqBy and sortedUniqBy

### DIFF
--- a/sortedUniqBy.js
+++ b/sortedUniqBy.js
@@ -12,7 +12,7 @@ import baseSortedUniq from './.internal/baseSortedUniq.js'
  * @example
  *
  * sortedUniqBy([1.1, 1.2, 2.3, 2.4], Math.floor)
- * // => [1.1, 2.3]
+ * // => [1, 2]
  */
 function sortedUniqBy(array, iteratee) {
   return (array != null && array.length)

--- a/uniqBy.js
+++ b/uniqBy.js
@@ -16,7 +16,7 @@ import baseUniq from './.internal/baseUniq.js'
  * @example
  *
  * uniqBy([2.1, 1.2, 2.3], Math.floor)
- * // => [2.1, 1.2]
+ * // => [2, 1]
  */
 function uniqBy(array, iteratee) {
   return (array != null && array.length)


### PR DESCRIPTION
`Math.floor` will resolve to intergers, compare https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor

