### PR TITLE
Handle leading zeros in quote html entity

### DIFF
--- a/test/unescape.js
+++ b/test/unescape.js
@@ -26,6 +26,12 @@ describe('unescape', function() {
     assert.strictEqual(unescape(escape(unescaped)), unescaped);
   });
 
+  it('should handle leading zeros in html entities', function() {
+    assert.strictEqual(unescape('&#39;'), "'");
+    assert.strictEqual(unescape('&#039;'), "'");
+    assert.strictEqual(unescape('&#000039;'), "'");
+  });
+
   lodashStable.each(['&#96;', '&#x2F;'], function(entity) {
     it('should not unescape the "' + entity + '" entity', function() {
       assert.strictEqual(unescape(entity), entity);

--- a/unescape.js
+++ b/unescape.js
@@ -8,7 +8,7 @@ const htmlUnescapes = {
 }
 
 /** Used to match HTML entities and HTML characters. */
-const reEscapedHtml = /&(?:amp|lt|gt|quot|#39);/g
+const reEscapedHtml = /&(?:amp|lt|gt|quot|#(0+)?39);/g
 const reHasEscapedHtml = RegExp(reEscapedHtml.source)
 
 /**
@@ -31,7 +31,7 @@ const reHasEscapedHtml = RegExp(reEscapedHtml.source)
  */
 function unescape(string) {
   return (string && reHasEscapedHtml.test(string))
-    ? string.replace(reEscapedHtml, (entity) => htmlUnescapes[entity])
+    ? string.replace(reEscapedHtml, (entity) => (htmlUnescapes[entity] || "'") )
     : (string || '')
 }
 


### PR DESCRIPTION
HTML entities may have [leading zeros](https://en.wikipedia.org/wiki/Character_encodings_in_HTML), so in this case `#39` `#039` both refer to the same character `'`

We noticed this while fixing this issue https://github.com/WordPress/gutenberg/pull/19187

I ran into trouble building and running tests locally, so I'm happy to follow up if there are more detailed instructions elsewhere for running this locally.

### Testing Instructions

- Verify that tests still pass
- No other regressions