### PR TITLE
Resurrect #4011 Fix _.omit mutating objects w/ Arrays (#4007)

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5614,7 +5614,7 @@
      * @returns {*} Returns the uncloned value or `undefined` to defer cloning to `_.cloneDeep`.
      */
     function customOmitClone(value) {
-      return isPlainObject(value) ? undefined : value;
+      return isPlainObject(value) || isArray(value) ? undefined : value;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -16565,12 +16565,12 @@
     });
 
     QUnit.test('should not mutate `object`', function(assert) {
-      assert.expect(4);
+      assert.expect(5);
 
-      lodashStable.each(['a', ['a'], 'a.b', ['a.b']], function(path) {
-        var object = { 'a': { 'b': 2 } };
+      lodashStable.each(['a', ['a'], 'a.b', ['a.b'], 'c[0]'], function(path) {
+        var object = { 'a': { 'b': 2 }, c: [{ 'd': 0 }, { 'd': 1 }] };
         _.omit(object, path);
-        assert.deepEqual(object, { 'a': { 'b': 2 } });
+        assert.deepEqual(object, { 'a': { 'b': 2 }, c: [{ 'd': 0 }, { 'd': 1 }] });
       });
     });
   }());


### PR DESCRIPTION
#4648 inspired me to do some search and I also found that #4011 is missing in `4.17.12` and above.