### PR TITLE
refactor: Move unicode regex to a seperate file and support matching the black flag

### DIFF
--- a/.internal/reUnicode.js
+++ b/.internal/reUnicode.js
@@ -1,0 +1,31 @@
+/** Used to compose unicode character classes. */
+const rsAstralRange = '\\ud800-\\udfff'
+const rsComboMarksRange = '\\u0300-\\u036f'
+const reComboHalfMarksRange = '\\ufe20-\\ufe2f'
+const rsComboSymbolsRange = '\\u20d0-\\u20ff'
+const rsComboMarksExtendedRange = '\\u1ab0-\\u1aff'
+const rsComboMarksSupplementRange = '\\u1dc0-\\u1dff'
+const rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange + rsComboMarksExtendedRange + rsComboMarksSupplementRange
+const rsVarRange = '\\ufe0e\\ufe0f'
+
+/** Used to compose unicode capture groups. */
+const rsAstral = `[${rsAstralRange}]`
+const rsCombo = `[${rsComboRange}]`
+const rsFitz = '\\ud83c[\\udffb-\\udfff]'
+const rsModifier = `(?:${rsCombo}|${rsFitz})`
+const rsNonAstral = `[^${rsAstralRange}]`
+const rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}'
+const rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]'
+const rsZWJ = '\\u200d'
+const rsBlackFlag = "(?:\\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40(?:\\udc65|\\udc73|\\udc77)\\udb40(?:\\udc6e|\\udc63|\\udc6c)\\udb40(?:\\udc67|\\udc74|\\udc73)\\udb40\\udc7f)"
+
+/** Used to compose unicode regexes. */
+const reOptMod = `${rsModifier}?`
+const rsOptVar = `[${rsVarRange}]?`
+const rsOptJoin = `(?:${rsZWJ}(?:${[rsNonAstral, rsRegional, rsSurrPair].join('|')})${rsOptVar + reOptMod})*`
+const rsSeq = rsOptVar + reOptMod + rsOptJoin
+const rsNonAstralCombo = `${rsNonAstral}${rsCombo}?`
+const rsSymbol = `(?:${[rsBlackFlag, rsNonAstralCombo, rsCombo, rsRegional, rsSurrPair, rsAstral].join('|')})`
+
+/** Used to match [string symbols](https://mathiasbynens.be/notes/javascript-unicode). */
+export default RegExp(`${rsFitz}(?=${rsFitz})|${rsSymbol + rsSeq}`, 'g')

--- a/.internal/unicodeSize.js
+++ b/.internal/unicodeSize.js
@@ -1,33 +1,4 @@
-/** Used to compose unicode character classes. */
-const rsAstralRange = '\\ud800-\\udfff'
-const rsComboMarksRange = '\\u0300-\\u036f'
-const reComboHalfMarksRange = '\\ufe20-\\ufe2f'
-const rsComboSymbolsRange = '\\u20d0-\\u20ff'
-const rsComboMarksExtendedRange = '\\u1ab0-\\u1aff'
-const rsComboMarksSupplementRange = '\\u1dc0-\\u1dff'
-const rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange + rsComboMarksExtendedRange + rsComboMarksSupplementRange
-const rsVarRange = '\\ufe0e\\ufe0f'
-
-/** Used to compose unicode capture groups. */
-const rsAstral = `[${rsAstralRange}]`
-const rsCombo = `[${rsComboRange}]`
-const rsFitz = '\\ud83c[\\udffb-\\udfff]'
-const rsModifier = `(?:${rsCombo}|${rsFitz})`
-const rsNonAstral = `[^${rsAstralRange}]`
-const rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}'
-const rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]'
-const rsZWJ = '\\u200d'
-
-/** Used to compose unicode regexes. */
-const reOptMod = `${rsModifier}?`
-const rsOptVar = `[${rsVarRange}]?`
-const rsOptJoin = `(?:${rsZWJ}(?:${[rsNonAstral, rsRegional, rsSurrPair].join('|')})${rsOptVar + reOptMod})*`
-const rsSeq = rsOptVar + reOptMod + rsOptJoin
-const rsNonAstralCombo = `${rsNonAstral}${rsCombo}?`
-const rsSymbol = `(?:${[rsNonAstralCombo, rsCombo, rsRegional, rsSurrPair, rsAstral].join('|')})`
-
-/** Used to match [string symbols](https://mathiasbynens.be/notes/javascript-unicode). */
-const reUnicode = RegExp(`${rsFitz}(?=${rsFitz})|${rsSymbol + rsSeq}`, 'g')
+import reUnicode from "./reUnicode"
 
 /**
  * Gets the size of a Unicode `string`.

--- a/.internal/unicodeToArray.js
+++ b/.internal/unicodeToArray.js
@@ -1,33 +1,4 @@
-/** Used to compose unicode character classes. */
-const rsAstralRange = '\\ud800-\\udfff'
-const rsComboMarksRange = '\\u0300-\\u036f'
-const reComboHalfMarksRange = '\\ufe20-\\ufe2f'
-const rsComboSymbolsRange = '\\u20d0-\\u20ff'
-const rsComboMarksExtendedRange = '\\u1ab0-\\u1aff'
-const rsComboMarksSupplementRange = '\\u1dc0-\\u1dff'
-const rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange + rsComboMarksExtendedRange + rsComboMarksSupplementRange
-const rsVarRange = '\\ufe0e\\ufe0f'
-
-/** Used to compose unicode capture groups. */
-const rsAstral = `[${rsAstralRange}]`
-const rsCombo = `[${rsComboRange}]`
-const rsFitz = '\\ud83c[\\udffb-\\udfff]'
-const rsModifier = `(?:${rsCombo}|${rsFitz})`
-const rsNonAstral = `[^${rsAstralRange}]`
-const rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}'
-const rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]'
-const rsZWJ = '\\u200d'
-
-/** Used to compose unicode regexes. */
-const reOptMod = `${rsModifier}?`
-const rsOptVar = `[${rsVarRange}]?`
-const rsOptJoin = `(?:${rsZWJ}(?:${[rsNonAstral, rsRegional, rsSurrPair].join('|')})${rsOptVar + reOptMod})*`
-const rsSeq = rsOptVar + reOptMod + rsOptJoin
-const rsNonAstralCombo = `${rsNonAstral}${rsCombo}?`
-const rsSymbol = `(?:${[rsNonAstralCombo, rsCombo, rsRegional, rsSurrPair, rsAstral].join('|')})`
-
-/** Used to match [string symbols](https://mathiasbynens.be/notes/javascript-unicode). */
-const reUnicode = RegExp(`${rsFitz}(?=${rsFitz})|${rsSymbol + rsSeq}`, 'g')
+import reUnicode from "./reUnicode"
 
 /**
  * Converts a Unicode `string` to an array.


### PR DESCRIPTION
- Moved the Unicode regex to a separate file.
- Fixed this black flag behaviour:

```js
const _ = require("lodash")

_.size("🏴󠁧󠁢󠁥󠁮󠁧󠁿")
//=> 7
```