### PR TITLE
Update isNil.js documentation

### DIFF
--- a/isNil.js
+++ b/isNil.js
@@ -9,6 +9,9 @@
  *
  * isNil(null)
  * // => true
+  *
+ * isNil(undefined)
+ * // => true
  *
  * isNil(void 0)
  * // => true


### PR DESCRIPTION
Since undefined == null returns true, this function is also returns true for undefined variable. So this example should be added to the documentation.