### PR TITLE
Changing font-style to monospace for '--save' option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Using npm:
 $ npm i -g npm
 $ npm i lodash
 ```
-Note: add --save if you are using npm < 5.0.0
+Note: add `--save` if you are using npm < 5.0.0
 
 In Node.js:
 ```js


### PR DESCRIPTION
--save is a command-line option and it should be monospaced