### PR TITLE
Avoid skipping set of 0 or -0 when the other one is existing

### DIFF
--- a/.internal/assignValue.js
+++ b/.internal/assignValue.js
@@ -15,11 +15,11 @@ const hasOwnProperty = Object.prototype.hasOwnProperty
 function assignValue(object, key, value) {
   const objValue = object[key]
 
-  if (!(hasOwnProperty.call(object, key) && eq(objValue, value))) {
-    if (value !== 0 || (1 / value) === (1 / objValue)) {
-      baseAssignValue(object, key, value)
-    }
-  } else if (value === undefined && !(key in object)) {
+  if (
+    !(hasOwnProperty.call(object, key) && eq(objValue, value)) || 
+    (value === 0 && (1 / value !== 1 / objValue)) || 
+    (value === undefined && !(key in object))
+  ) {
     baseAssignValue(object, key, value)
   }
 }


### PR DESCRIPTION
I dont think #3798 is fixed.
Because when the `objValue` is `0` and `value` is `-0`。`hasOwnProperty.call(object, key) && eq(objValue, value)` should be `true` , it would ship this branch.