### PR TITLE
Add Unicode line terminators for sourceURL sanitization

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14825,7 +14825,7 @@
       // A newline wouldn't be a valid sourceURL anyway, and it'd enable code injection.
       var sourceURL = '//# sourceURL=' +
         (hasOwnProperty.call(options, 'sourceURL')
-          ? (options.sourceURL + '').replace(/[\r\n]/g, ' ')
+          ? (options.sourceURL + '').replace(/[\r\n\u2028\u2029]/g, ' ')
           : ('lodash.templateSources[' + (++templateCounter) + ']')
         ) + '\n';
 


### PR DESCRIPTION
U+2028 and U+2029 were missing in #4355.