### PR TITLE
fix: fix the params of Hash#delete in in jsdoc

### DIFF
--- a/.internal/Hash.js
+++ b/.internal/Hash.js
@@ -35,7 +35,6 @@ class Hash {
    * Removes `key` and its value from the hash.
    *
    * @memberOf Hash
-   * @param {Object} hash The hash to modify.
    * @param {string} key The key of the value to remove.
    * @returns {boolean} Returns `true` if the entry was removed, else `false`.
    */


### PR DESCRIPTION
Remove the unused param `hash` from the jsdoc of `Hash#delete`