### PR TITLE
Simplify isPlainObject

### DIFF
--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -31,14 +31,8 @@ function isPlainObject(value) {
   if (!isObjectLike(value) || getTag(value) != '[object Object]') {
     return false
   }
-  if (Object.getPrototypeOf(value) === null) {
-    return true
-  }
-  let proto = value
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
-  }
-  return Object.getPrototypeOf(value) === proto
+  const proto = Object.getPrototypeOf(proto)
+  return proto === null || Object.getPrototypeOf(proto) === null
 }
 
 export default isPlainObject

--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -31,7 +31,7 @@ function isPlainObject(value) {
   if (!isObjectLike(value) || getTag(value) != '[object Object]') {
     return false
   }
-  const proto = Object.getPrototypeOf(proto)
+  const proto = Object.getPrototypeOf(value)
   return proto === null || Object.getPrototypeOf(proto) === null
 }
 


### PR DESCRIPTION
Recently I'm learning how to write a `isPlainObject` function, and find following codes really confusing:
```js
  let proto = value
  while (Object.getPrototypeOf(proto) !== null) {
    proto = Object.getPrototypeOf(proto)
  }
  return Object.getPrototypeOf(value) === proto
```

As mentioned in feature explanation:
> check if `value` is an object created by **`Object` constructor or one with a `[[Prototype]]` of `null`**

Why we have to "while loop" the  `Object.getPrototypeOf(proto) `, it equals with:
```js
const proto = Object.getPrototypeOf(value)
return proto === null || Object.getPrototypeOf(proto) === null
```
So I propose this update or just make a suggestion to make codes more simplified and understandable.