### PR TITLE
xorBy documentation - duplicative text

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -8563,7 +8563,7 @@
     /**
      * This method is like `_.xor` except that it accepts `iteratee` which is
      * invoked for each element of each `arrays` to generate the criterion by
-     * which by which they're compared. The order of result values is determined
+     * which they're compared. The order of result values is determined
      * by the order they occur in the arrays. The iteratee is invoked with one
      * argument: (value).
      *


### PR DESCRIPTION
Cleaning up the xorBy documentation 