### PR TITLE
Escape the character '-' in _.escapeRegExp.js

### DIFF
--- a/escapeRegExp.js
+++ b/escapeRegExp.js
@@ -2,7 +2,7 @@
  * Used to match `RegExp`
  * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
  */
-const reRegExpChar = /[\\^$.*+?()[\]{}|]/g
+const reRegExpChar = /[\\^$.*+?()[\]{}|\-]/g
 const reHasRegExpChar = RegExp(reRegExpChar.source)
 
 /**

--- a/test/escapeRegExp.test.js
+++ b/test/escapeRegExp.test.js
@@ -4,8 +4,8 @@ import { stubString } from './utils.js';
 import escapeRegExp from '../escapeRegExp.js';
 
 describe('escapeRegExp', function() {
-  var escaped = '\\^\\$\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\\\',
-      unescaped = '^$.*+?()[]{}|\\';
+  var escaped = '\\^\\$\\.\\*\\+\\-\\?\\(\\)\\[\\]\\{\\}\\|\\\\',
+      unescaped = '^$.*+-?()[]{}|\\';
 
   it('should escape values', function() {
     assert.strictEqual(escapeRegExp(unescaped + unescaped), escaped + escaped);


### PR DESCRIPTION
This pull request makes _.escapeRegExp to also escape `-`, the RegExp range character. More information about this in the issue https://github.com/lodash/lodash/issues/4807