### PR TITLE
fixed isFlattenable return bug

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6263,6 +6263,9 @@
      * @returns {boolean} Returns `true` if `value` is flattenable, else `false`.
      */
     function isFlattenable(value) {
+      if(value&&value[spreadableSymbol]===false){
+        return false;
+      }
       return isArray(value) || isArguments(value) ||
         !!(spreadableSymbol && value && value[spreadableSymbol]);
     }


### PR DESCRIPTION
如果当value[spreadableSymbol]为false的时候,数组也是无法展开，函数依然会返回true
If the value [spreadableSymbol] is false, the array cannot be expanded, the function will still return true