### PR TITLE
[issue-4822] - merge() doesn't throw any Error when object is frozen

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -10,7 +10,7 @@ import createAssigner from './.internal/createAssigner.js'
  * assignment. Source objects are applied from left to right. Subsequent
  * sources overwrite property assignments of previous sources.
  *
- * **Note:** This method mutates `object`.
+ * **Note:** This method mutates `object`. If `object` is frozen an error is thrown.
  *
  * @since 0.5.0
  * @category Object
@@ -31,6 +31,9 @@ import createAssigner from './.internal/createAssigner.js'
  * // => { 'a': [{ 'b': 2, 'c': 3 }, { 'd': 4, 'e': 5 }] }
  */
 const merge = createAssigner((object, source, srcIndex) => {
+  if (Object.isFrozen(object)) {
+    throw new TypeError('`object` is frozen. Please provide a non-frozen input instead.')
+  };
   baseMerge(object, source, srcIndex)
 })
 

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -346,4 +346,15 @@ describe('merge', function() {
 
     assert.deepStrictEqual(actual, expected);
   });
+
+  it('should throw an error if object is frozen', () => {
+    const object = {a: 1};
+    Object.freeze(object);
+    const source = {b: 2};
+
+    assert.throws(
+      () => merge(object, source),
+      'merge should have thrown an error, since the object is frozen.'
+    );
+  });
 });


### PR DESCRIPTION
Fix for #4824. 
Added extra check to make sure an error is thrown.
Added a test case too and run it manually (since `npm test` is broken).