### PR TITLE
Update links in CONTRIBUTING.md & README.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ not be working. Thank you for your patience.
 # Contributing to Lodash
 
 Contributions are always welcome. Before contributing please read the
-[code of conduct](https://js.foundation/community/code-of-conduct) &
+[code of conduct](https://code-of-conduct.openjsf.org) &
 [search the issue tracker](https://github.com/lodash/lodash/issues); your issue
 may have already been discussed or fixed in `master`. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) Lodash, commit your changes,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [FP Guide](https://github.com/lodash/lodash/wiki/FP-Guide) |
 [Contributing](https://github.com/lodash/lodash/blob/master/.github/CONTRIBUTING.md) |
 [Wiki](https://github.com/lodash/lodash/wiki "Changelog, Roadmap, etc.") |
-[Code of Conduct](https://js.foundation/community/code-of-conduct) |
+[Code of Conduct](https://code-of-conduct.openjsf.org) |
 [Twitter](https://twitter.com/bestiejs) |
 [Chat](https://gitter.im/lodash/lodash)
 


### PR DESCRIPTION
The link of `code of conduct` in [CONTRIBUTING.md](https://github.com/lodash/lodash/blob/86a852fe763935bb64c12589df5391fd7d3bb14d/.github/CONTRIBUTING.md)  and [README.md](https://github.com/lodash/lodash/blob/86a852fe763935bb64c12589df5391fd7d3bb14d/README.md) is no longer valid. When clicking on the [old link](https://js.foundation/community/code-of-conduct),  it will redirect to [openjsf](https://openjsf.org/) . So I updated them to [new link](https://code-of-conduct.openjsf.org).