### PR TITLE
Jsdoc nullity

### DIFF
--- a/.internal/baseGet.js
+++ b/.internal/baseGet.js
@@ -5,7 +5,7 @@ import toKey from './toKey.js'
  * The base implementation of `get` without support for default values.
  *
  * @private
- * @param {Object} object The object to query.
+ * @param {Object|null|undefined} object The object to query.
  * @param {Array|string} path The path of the property to get.
  * @returns {*} Returns the resolved value.
  */

--- a/chunk.js
+++ b/chunk.js
@@ -8,7 +8,7 @@ import toInteger from './toInteger.js'
  *
  * @since 3.0.0
  * @category Array
- * @param {Array} array The array to process.
+ * @param {Array|null|undefined} array The array to process.
  * @param {number} [size=1] The length of each chunk
  * @returns {Array} Returns the new array of chunks.
  * @example

--- a/compact.js
+++ b/compact.js
@@ -4,7 +4,7 @@
  *
  * @since 0.1.0
  * @category Array
- * @param {Array} array The array to compact.
+ * @param {Array|null|undefined} array The array to compact.
  * @returns {Array} Returns the new array of filtered values.
  * @example
  *

--- a/get.js
+++ b/get.js
@@ -6,7 +6,7 @@ import baseGet from './.internal/baseGet.js'
  *
  * @since 3.7.0
  * @category Object
- * @param {Object} object The object to query.
+ * @param {Object|null|undefined} object The object to query.
  * @param {Array|string} path The path of the property to get.
  * @param {*} [defaultValue] The value returned for `undefined` resolved values.
  * @returns {*} Returns the resolved value.

--- a/pick.js
+++ b/pick.js
@@ -5,7 +5,7 @@ import basePick from './.internal/basePick.js'
  *
  * @since 0.1.0
  * @category Object
- * @param {Object} object The source object.
+ * @param {Object|null|undefined} object The source object.
  * @param {...(string|string[])} [paths] The property paths to pick.
  * @returns {Object} Returns the new object.
  * @example

--- a/pickBy.js
+++ b/pickBy.js
@@ -8,7 +8,7 @@ import getAllKeysIn from './.internal/getAllKeysIn.js'
  *
  * @since 4.0.0
  * @category Object
- * @param {Object} object The source object.
+ * @param {Object|null|undefined} object The source object.
  * @param {Function} predicate The function invoked per property.
  * @returns {Object} Returns the new object.
  * @example

--- a/slice.js
+++ b/slice.js
@@ -7,7 +7,7 @@
  *
  * @since 3.0.0
  * @category Array
- * @param {Array} array The array to slice.
+ * @param {Array|null|undefined} array The array to slice.
  * @param {number} [start=0] The start position. A negative index will be treated as an offset from the end.
  * @param {number} [end=array.length] The end position. A negative index will be treated as an offset from the end.
  * @returns {Array} Returns the slice of `array`.


### PR DESCRIPTION
This PR aims to fix #4699;
A number of functions which allow for null/undefined as a parameter type did not properly declare them as such in the JSDocs.
There are other functions with this issue which are not included in this PR, if desired I can submit another PR for those.