### PR TITLE
Updated .internal/baseSum.js and added tests to fixes issue #4878

### DIFF
--- a/.internal/baseSum.js
+++ b/.internal/baseSum.js
@@ -7,12 +7,12 @@
  * @returns {number} Returns the sum.
  */
 function baseSum(array, iteratee) {
-  let result
+  let result = 0
 
   for (const value of array) {
     const current = iteratee(value)
-    if (current !== undefined) {
-      result = result === undefined ? current : (result + current)
+    if(current != null){
+      result += +current
     }
   }
   return result

--- a/test/baseSum.test.js
+++ b/test/baseSum.test.js
@@ -1,0 +1,30 @@
+import assert from 'assert'
+import baseSum from '../.internal/baseSum.js'
+import { identity } from './utils.js'
+
+describe('baseSum', () => {
+  it('should return 0 for an empty array', () => {
+    const actual = baseSum([], identity)
+    assert.strictEqual(actual, 0)
+  })
+  it('should coerce the iteratee return value to a number', () => {
+    const actual = baseSum([true], (i) => i === true)
+    assert.strictEqual(actual, 1)
+  })
+  it('should not sum the iteratee return value of undefined or null', () => {
+    const actual = baseSum([, null], identity)
+    assert.strictEqual(actual, 0)
+  })
+  it('should return the sum of numbers when provided as strings', () => {
+    const actual = baseSum(['-1', '0', '1', '2', '3'], identity)
+    assert.strictEqual(actual, 5)
+  })
+  it('should return the sum of numbers', () => {
+    const actual = baseSum([-1, 0, 1, 2, 3], identity)
+    assert.strictEqual(actual, 5)
+  })
+  it('should return NaN when unable to coerce the iteratee return value to a number', () => {
+    const actual = baseSum([{}], identity)
+    assert.strictEqual(isNaN(actual), true)
+  })
+})


### PR DESCRIPTION
## Description
For baseSum(), coerce the return value of the iteratee function to a number if not undefined or null.
This is in response to https://github.com/lodash/lodash/issues/4878

## Related Issues:
https://github.com/lodash/lodash/issues/1602


## Tests results for lodash 5.0.0 off the master branch
```
  baseSum
    1) should return 0 for an empty array
    2) should coerce the iteratee return value to a number
    3) should not sum the iteratee return value of undefined or null
    4) should return the sum of numbers when provided as strings
    ✓ should return the sum of numbers
    ✓ should return NaN when unable to coerce the iteratee return value to a number


  2 passing (6ms)
  4 failing

  1) baseSum
       should return 0 for an empty array:
     AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

undefined !== 0

  2) baseSum
       should coerce the iteratee return value to a number:
     AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

true !== 1

  3) baseSum
       should not sum the iteratee return value of undefined or null:
     AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

null !== 0

  4) baseSum
       should return the sum of numbers when provided as strings:
     AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

'-10123' !== 5
```

## TODO
- [ ] Find out how to run all the tests? `npm install && npm test` fails