### PR TITLE
added negative index support for at. Fix for #4865

### DIFF
--- a/.internal/baseAt.js
+++ b/.internal/baseAt.js
@@ -1,4 +1,5 @@
 import get from '../get.js'
+import isNumber from '../isNumber'
 
 /**
  * The base implementation of `at` without support for individual paths.
@@ -11,10 +12,14 @@ import get from '../get.js'
 function baseAt(object, paths) {
   let index = -1
   const length = paths.length
+  const objLength = object ? object.length : 0;
   const result = new Array(length)
   const skip = object == null
 
   while (++index < length) {
+    if(isNumber(paths[index]) && paths[index] < 0){
+      paths[index] += objLength
+    }
     result[index] = skip ? undefined : get(object, paths[index])
   }
   return result

--- a/test/at.test.js
+++ b/test/at.test.js
@@ -12,6 +12,11 @@ describe('at', function() {
     assert.deepStrictEqual(actual, ['a', 'c']);
   });
 
+  it('should return the elements for negative indexes', function() {
+    var actual = at(array, [0, -1]);
+    assert.deepStrictEqual(actual, ['a', 'c']);
+  });
+
   it('should return `undefined` for nonexistent keys', function() {
     var actual = at(array, [2, 4, 0]);
     assert.deepStrictEqual(actual, ['c', undefined, 'a']);


### PR DESCRIPTION
Added negative index support for `at` as per #4865 . I could do the same for `pullAt` but cannot get the test cases to run for `pullAt`.