### PR TITLE
Optimization: avoid checking null proto twice

### DIFF
--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -35,9 +35,9 @@ function isPlainObject(value) {
     return true
   }
   let proto = value
-  while (Object.getPrototypeOf(proto) !== null) {
+  do {
     proto = Object.getPrototypeOf(proto)
-  }
+  } while (Object.getPrototypeOf(proto) !== null)
   return Object.getPrototypeOf(value) === proto
 }
 


### PR DESCRIPTION
When the loop is run for the first time, we already know that the protoype is not null (because of the if before). We can thus make one fewer evaluation of `Object.getPrototypeOf(proto) !== null ` by performing a `do while` loop