### PR TITLE
Fix: isArrayLIke returns incorrectly for {length: 1}

### DIFF
--- a/isArrayLike.js
+++ b/isArrayLike.js
@@ -24,7 +24,7 @@ import isLength from './isLength.js'
  * // => false
  */
 function isArrayLike(value) {
-  return value != null && typeof value !== 'function' && isLength(value.length)
+  return value != null && typeof value !== 'function' && isLength(value.length) && typeof value[Symbol.iterator] === 'function';
 }
 
 export default isArrayLike


### PR DESCRIPTION
isArrayLike returns true for objects containing 'length' property
This PR fixes the issue https://github.com/lodash/lodash/issues/4927