### PR TITLE
feat: add isStrictObject for strict object boolean checking

### DIFF
--- a/isStrictObject.js
+++ b/isStrictObject.js
@@ -1,0 +1,28 @@
+/**
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is strictly object, else `false`.
+ * @example
+ *
+ * isStrictObject({})
+ * // => true
+ *
+ * isStrictObject([1, 2, 3])
+ * // => false
+ *
+ * isStrictObject(Function)
+ * // => false
+ *
+ * isStrictObject(null)
+ * // => false
+ */
+function isStrictObject(value) {
+  const type = typeof value
+  return value !== null && type === 'object' && Object.prototype
+    .toString
+    .call(value)
+    .replace(/\[|object\s|\]/g, '')
+    .toLowerCase() === 'object'
+}
+
+export default isStrictObject

--- a/test/isStrictObject.test.js
+++ b/test/isStrictObject.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+describe('isStrictObject', function() {
+  it('should return `true` for objects', function() {
+  assert.deepStrictEqual(isStrictObject({}), true);
+  assert.deepStrictEqual(isStrictObject(Object.create({})), true);
+  assert.deepStrictEqual(isStrictObject({ wow: 'wow-again' }), true)
+  });
+
+  it('should return `false` for arrays', function() {
+    assert.deepStrictEqual(isStrictObject(['beaver', 'alpaca', 'zebra', 'duck']), false);
+    assert.deepStrictEqual(isStrictObject([]), false);
+    assert.deepStrictEqual(isStrictObject(new Array(0)), false);
+    assert.deepStrictEqual(isStrictObject(Array.from(0)), false);
+  });
+
+  it('should return `false` for other data types', function() {
+    assert.deepStrictEqual(isStrictObject('string'), false);
+    assert.deepStrictEqual(isStrictObject(Number(0)), false);
+    assert.deepStrictEqual(isStrictObject(new Map()), false);
+    assert.deepStrictEqual(isStrictObject(new WeakMap()), false);
+    assert.deepStrictEqual(isStrictObject(new Set()), false);
+    assert.deepStrictEqual(isStrictObject(true), false);
+    assert.deepStrictEqual(isStrictObject(/x/), false);
+  });
+});


### PR DESCRIPTION
### add `isStrictObject` function 

```javascript 
 isStrictObject([200, 100, 250, 150])
 // => false
 
 isStrictObject({})
 // => true
```

 