### PR TITLE
Add toMap function

### DIFF
--- a/test/toMap.test.js
+++ b/test/toMap.test.js
@@ -13,19 +13,19 @@ describe('toMap', function() {
     assert.deepStrictEqual(map, expect);
   });
 
-  it('should convert array without path', function() {
+  it('should convert array to Map', function() {
     var map = toMap(demoArr);
     var expect = new Map();
     expect.set(0, { key: 'first', b: 2 });
     expect.set(1, { key: 'second', b: 5});
     assert.deepStrictEqual(map, expect);
-  })
+  });
 
   it('should use path as key of new Map', function() {
     var map = toMap(demoArr, 'key');
     var expect = new Map();
     expect.set('first', { key: 'first', b: 2 });
     expect.set('second', { key: 'second', b: 5 });
-    assert.deepStrictEqual(map, expect)
-  })
-})
+    assert.deepStrictEqual(map, expect);
+  });
+});

--- a/test/toMap.test.js
+++ b/test/toMap.test.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import toMap from '../toMap.js';
+
+describe('toMap', function() {
+  var demoArr = [{ key: 'first', b: 2 }, { key: 'second', b: 5}];
+  var demoObj = { key: 'first', b: 2 };
+
+  it('should convert object to Map', function() {
+    var map = toMap(demoObj);
+    var expect = new Map();
+    expect.set('key', 'first');
+    expect.set('b', 2);
+    assert.deepStrictEqual(map, expect);
+  });
+
+  it('should convert array without path', function() {
+    var map = toMap(demoArr);
+    var expect = new Map();
+    expect.set(0, { key: 'first', b: 2 });
+    expect.set(1, { key: 'second', b: 5});
+    assert.deepStrictEqual(map, expect);
+  })
+
+  it('should use path as key of new Map', function() {
+    var map = toMap(demoArr, 'key');
+    var expect = new Map();
+    expect.set('first', { key: 'first', b: 2 });
+    expect.set('second', { key: 'second', b: 5 });
+    assert.deepStrictEqual(map, expect)
+  })
+})

--- a/toMap.js
+++ b/toMap.js
@@ -1,0 +1,46 @@
+import get from './get.js'
+import map from './map.js'
+import isArrayLike from './isArrayLike.js'
+import isNull from './isNull.js'
+import isUndefined from './isUndefined.js'
+
+/**
+ * Converts `value` to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+ * If value is Array and has params path, use path value as key of Map object.
+ *
+ * @since 5.0.0
+ * @category Lang
+ * @param {*} value The value to convert.
+ * @param path: Array | string - The key path to new Map object
+ * @returns {Map} Returns the converted Map object.
+ * @example
+ *
+ * toMap([1, 2])
+ * // => Map(4) {1 => 1, 2 => 2}
+ *
+ * toMap({a: 1, b: 2})
+ * // => Map(2) { 'a' => 1, 'b' => 2 }
+ *
+ * toMap([{a: 1, b: 2}, {a:2, c: 3}], 'a')
+ * // => Map(2) {1 => {a: 1, b: 2}, 2 => {a:2, c: 3}}
+ *
+ * assign({ 'a': 1 }, toPlainObject(new Foo))
+ * // => { 'a': 1, 'b': 2, 'c': 3 }
+ */
+function toMap(value, path) {
+  if (isNull(value) || isUndefined(value)) {
+    return value
+  }
+
+  if (isArrayLike(value)) {
+    const res = new Map()
+    map(value, (cur, i) => {
+      res.set(path ? get(cur, path) : i, cur)
+    })
+    return res
+  }
+
+  return new Map(Object.entries(value))
+}
+
+export default toMap

--- a/toMap.js
+++ b/toMap.js
@@ -21,11 +21,8 @@ import isUndefined from './isUndefined.js'
  * toMap({a: 1, b: 2})
  * // => Map(2) { 'a' => 1, 'b' => 2 }
  *
- * toMap([{a: 1, b: 2}, {a:2, c: 3}], 'a')
- * // => Map(2) {1 => {a: 1, b: 2}, 2 => {a:2, c: 3}}
- *
- * assign({ 'a': 1 }, toPlainObject(new Foo))
- * // => { 'a': 1, 'b': 2, 'c': 3 }
+ * toMap([{a: 'first', b: 2}, {a: 'second', c: 3}], 'a')
+ * // => Map(2) {'first' => {a: 1, b: 2}, 'second' => {a:2, c: 3}}
  */
 function toMap(value, path) {
   if (isNull(value) || isUndefined(value)) {


### PR DESCRIPTION
Converts `value` to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object
If value is `Array` and has params path, use path value as key of Map object.

```javascript
  toMap([1, 2])
  // => Map(4) {1 => 1, 2 => 2}

  toMap({a: 1, b: 2})
  // => Map(2) { 'a' => 1, 'b' => 2 }

  toMap([{a: 'first', b: 2}, {a: 'second', c: 3}], 'a')
  // => Map(2) {'first' => {a: 1, b: 2}, 'second' => {a:2, c: 3}}
```