### PR TITLE
Reflect prefixed map in uniqueId documentation

### DIFF
--- a/uniqueId.js
+++ b/uniqueId.js
@@ -15,7 +15,7 @@ const idCounter = {}
  * // => 'contact_104'
  *
  * uniqueId()
- * // => '105'
+ * // => '63'
  */
 function uniqueId(prefix='$lodash$') {
   if (!idCounter[prefix]) {


### PR DESCRIPTION
This PR updates the documentation in `uniqueId()` to reflect the different counters used for each prefix by using clearly distinct numbers.

The current documentation implies that all prefixed IDs are incremented on the same counter, incrementing from `uniqueId('contact_'); // contact_104` to `uniqueId(); //105`. This behaviour was changed in #3644 with the introduction of the prefix map, and so this documentation could be misleading to users.