### PR TITLE
refactor: use internal functions in _.words

### DIFF
--- a/words.js
+++ b/words.js
@@ -1,15 +1,4 @@
-import unicodeWords from './.internal/unicodeWords.js'
-
-const hasUnicodeWord = RegExp.prototype.test.bind(
-  /[a-z][A-Z]|[A-Z]{2}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9 ]/
-)
-
-/** Used to match words composed of alphanumeric characters. */
-const reAsciiWord = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g
-
-function asciiWords(string) {
-  return string.match(reAsciiWord)
-}
+import stringToArray from './.internal/stringToArray.js'
 
 /**
  * Splits `string` into an array of its words.
@@ -29,8 +18,7 @@ function asciiWords(string) {
  */
 function words(string, pattern) {
   if (pattern === undefined) {
-    const result = hasUnicodeWord(string) ? unicodeWords(string) : asciiWords(string)
-    return result || []
+    return stringToArray(string);
   }
   return string.match(pattern) || []
 }


### PR DESCRIPTION
Use internal functions instead of isolated functions declared in the same file