### PR TITLE
Optimization: _.sum does not return correct output for [null] #4971

### DIFF
--- a/.internal/baseSum.js
+++ b/.internal/baseSum.js
@@ -15,7 +15,7 @@ function baseSum(array, iteratee) {
       result = result === undefined ? current : (result + current)
     }
   }
-  return result
+  return result || 0
 }
 
 export default baseSum


### PR DESCRIPTION
_.sum([null]) or _sum([undefined]) returns expected 0