### PR TITLE
FIXED _.size,_.isEmpty behavoir on ArrayBuffer and SharedArrayBuffer

### DIFF
--- a/isEmpty.js
+++ b/isEmpty.js
@@ -54,23 +54,22 @@ function isEmpty(value) {
     return !value.length
   }
 
- if (value instanceof ArrayBuffer) {
-    let view = new DataView(value)
+  if (value instanceof ArrayBuffer) {
+    const view = new DataView(value)
     if (view.byteOffset == 0) {
-        return true
+      return true
     }
     return false
- }
-
-if(value instanceof SharedArrayBuffer) {
-    let view = new DataView(value)
-    if(view.byteOffset ==0) {
-        return true
+  }
+  
+  if (value instanceof SharedArrayBuffer) {
+    const view = new DataView(value)
+    if (view.byteOffset ==0) {
+      return true
     }
     return false
 
- }
-
+  }
 
 
   const tag = getTag(value)

--- a/isEmpty.js
+++ b/isEmpty.js
@@ -46,11 +46,33 @@ function isEmpty(value) {
   if (value == null) {
     return true
   }
+
+
   if (isArrayLike(value) &&
       (Array.isArray(value) || typeof value === 'string' || typeof value.splice === 'function' ||
         isBuffer(value) || isTypedArray(value) || isArguments(value))) {
     return !value.length
   }
+
+ if (value instanceof ArrayBuffer) {
+    let view = new DataView(value)
+    if (view.byteOffset == 0) {
+        return true
+    }
+    return false
+ }
+
+if(value instanceof SharedArrayBuffer) {
+    let view = new DataView(value)
+    if(view.byteOffset ==0) {
+        return true
+    }
+    return false
+
+ }
+
+
+
   const tag = getTag(value)
   if (tag == '[object Map]' || tag == '[object Set]') {
     return !value.size

--- a/size.js
+++ b/size.js
@@ -30,20 +30,18 @@ function size(collection) {
   if (collection == null) {
     return 0
   }
-
-  if(collection instanceof (ArrayBuffer)) {
+  
+  if (collection instanceof (ArrayBuffer)) {
     return collection.byteLength
   }
 
- if(collection instanceof (SharedArrayBuffer)) {
+  if (collection instanceof (SharedArrayBuffer)) {
     return collection.byteLength
- }
+  }
 
   if (isArrayLike(collection)) {
     return isString(collection) ? stringSize(collection) : collection.length
   }
-
-
 
 
   const tag = getTag(collection)

--- a/size.js
+++ b/size.js
@@ -30,9 +30,22 @@ function size(collection) {
   if (collection == null) {
     return 0
   }
+
+  if(collection instanceof (ArrayBuffer)) {
+    return collection.byteLength
+  }
+
+ if(collection instanceof (SharedArrayBuffer)) {
+    return collection.byteLength
+ }
+
   if (isArrayLike(collection)) {
     return isString(collection) ? stringSize(collection) : collection.length
   }
+
+
+
+
   const tag = getTag(collection)
   if (tag == mapTag || tag == setTag) {
     return collection.size

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -42,7 +42,7 @@ describe('isEmpty', function() {
   it("should return true for SharedBufferArray if byteOffset of Dateview of SharedBufferArray is 0",function(){
     assert.strictEqual(isEmpty(new SharedArrayBuffer(8)),true)
   })
-
+  
 
   it('should return `false` for non-empty values', function() {
     assert.strictEqual(isEmpty([0]), false);

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -35,6 +35,14 @@ describe('isEmpty', function() {
       assert.strictEqual(isEmpty(new Buffer(1)), false);
     }
   });
+  it("should return true for BufferArray  if byteOffset of Dataview of bufferArray is 0",function() { 
+      assert.strictEqual(isEmpty(new ArrayBuffer(8)),true)
+  })
+
+  it("should return true for SharedBufferArray if byteOffset of Dateview of SharedBufferArray is 0",function(){
+    assert.strictEqual(isEmpty(new SharedArrayBuffer(8)),true)
+  })
+
 
   it('should return `false` for non-empty values', function() {
     assert.strictEqual(isEmpty([0]), false);
@@ -116,4 +124,6 @@ describe('isEmpty', function() {
   it('should return a wrapped value when explicitly chaining', function() {
     assert.ok(_({}).chain().isEmpty() instanceof _);
   });
+
+
 });

--- a/test/size.test.js
+++ b/test/size.test.js
@@ -14,6 +14,15 @@ describe('size', function() {
     assert.strictEqual(size(array), 3);
   });
 
+  it('should return the byteLength of the ArrayBuffer',function() {
+    let arrTest = new ArrayBuffer(9)
+    assert.strictEqual(size(arrTeset),arrTest.byteLength)
+  })
+  it('should return the byteLength of the SharedArrayBuffer',function() { 
+    let arrTest = new ArrayBuffer(9)
+    assert.strictEqual(size(arrTest),arrTest.byteLength)
+  });
+
   it('should accept a falsey `object`', function() {
     var expected = lodashStable.map(falsey, stubZero);
 

--- a/test/size.test.js
+++ b/test/size.test.js
@@ -16,9 +16,9 @@ describe('size', function() {
 
   it('should return the byteLength of the ArrayBuffer',function() {
     let arrTest = new ArrayBuffer(9)
-    assert.strictEqual(size(arrTeset),arrTest.byteLength)
+    assert.strictEqual(size(arrTest),arrTest.byteLength)
   })
-  it('should return the byteLength of the SharedArrayBuffer',function() { 
+  it('should return the byteLength of the SharedArrayBuffer',function() {
     let arrTest = new ArrayBuffer(9)
     assert.strictEqual(size(arrTest),arrTest.byteLength)
   });

--- a/test/size.test.js
+++ b/test/size.test.js
@@ -13,13 +13,14 @@ describe('size', function() {
   it('should return the length of an array', function() {
     assert.strictEqual(size(array), 3);
   });
+  
 
   it('should return the byteLength of the ArrayBuffer',function() {
     let arrTest = new ArrayBuffer(9)
     assert.strictEqual(size(arrTest),arrTest.byteLength)
   })
   it('should return the byteLength of the SharedArrayBuffer',function() {
-    let arrTest = new ArrayBuffer(9)
+    let arrTest = new SharedArrayBuffer(9)
     assert.strictEqual(size(arrTest),arrTest.byteLength)
   });
 


### PR DESCRIPTION
FIXED the behavior of _.size and _.isEmpty methods on ArrayBuffer and SharedArrayBuffer instances