### PR TITLE
Fixed the escaping of minus in _.escapeRegExp and behavior of some functions with BigInts

### DIFF
--- a/escapeRegExp.js
+++ b/escapeRegExp.js
@@ -2,11 +2,11 @@
  * Used to match `RegExp`
  * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
  */
-const reRegExpChar = /[\\^$.*+?()[\]{}|]/g
+const reRegExpChar = /[\\^$.*+?\-()[\]{}|]/g
 const reHasRegExpChar = RegExp(reRegExpChar.source)
 
 /**
- * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+ * Escapes the `RegExp` special characters "-", "^", "$", "\", ".", "*", "+",
  * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
  *
  * @since 3.0.0

--- a/gt.js
+++ b/gt.js
@@ -21,8 +21,8 @@
  */
 function gt(value, other) {
   if (!(typeof value === 'string' && typeof other === 'string')) {
-    value = +value
-    other = +other
+    value = Number(value)
+    other = Number(other)
   }
   return value > other
 }

--- a/gte.js
+++ b/gte.js
@@ -21,8 +21,8 @@
  */
 function gte(value, other) {
   if (!(typeof value === 'string' && typeof other === 'string')) {
-    value = +value
-    other = +other
+    value = Number(value)
+    other = Number(other)
   }
   return value >= other
 }

--- a/lt.js
+++ b/lt.js
@@ -21,8 +21,8 @@
  */
 function lt(value, other) {
   if (!(typeof value === 'string' && typeof other === 'string')) {
-    value = +value
-    other = +other
+    value = Number(value)
+    other = Number(other)
   }
   return value < other
 }

--- a/lte.js
+++ b/lte.js
@@ -21,8 +21,8 @@
  */
 function lte(value, other) {
   if (!(typeof value === 'string' && typeof other === 'string')) {
-    value = +value
-    other = +other
+    value = Number(value)
+    other = Number(other)
   }
   return value <= other
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,9 +4205,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash-doc-globals": {

--- a/test/escapeRegExp.test.js
+++ b/test/escapeRegExp.test.js
@@ -11,6 +11,10 @@ describe('escapeRegExp', function() {
     assert.strictEqual(escapeRegExp(unescaped + unescaped), escaped + escaped);
   });
 
+  it('should handle strings including a minus', function() {
+    assert.strictEqual(escapeRegExp('_-+$'), '_\\-\\+\\$');
+  });
+
   it('should handle strings with nothing to escape', function() {
     assert.strictEqual(escapeRegExp('abc'), 'abc');
   });

--- a/test/gt.test.js
+++ b/test/gt.test.js
@@ -13,4 +13,10 @@ describe('gt', function() {
     assert.strictEqual(gt('abc', 'def'), false);
     assert.strictEqual(gt('def', 'def'), false);
   });
+
+  it('should work with the BigInts', function() {
+    assert.strictEqual(gt(3n, 1), true);
+    assert.strictEqual(gt(1n, 3n), false);
+  });
+
 });

--- a/test/gte.test.js
+++ b/test/gte.test.js
@@ -13,4 +13,9 @@ describe('gte', function() {
     assert.strictEqual(gte(1, 3), false);
     assert.strictEqual(gte('abc', 'def'), false);
   });
+
+  it('should work with the BigInts', function() {
+    assert.strictEqual(gte(1000000000000n, 3000000000000n), false);
+    assert.strictEqual(gte(1000000000000n, 1000000000000n), true);
+  });
 });

--- a/test/lt.test.js
+++ b/test/lt.test.js
@@ -13,4 +13,9 @@ describe('lt', function() {
     assert.strictEqual(lt('def', 'abc'), false);
     assert.strictEqual(lt('def', 'def'), false);
   });
+
+  it('should work with the BigInts', function() {
+    assert.strictEqual(lt(3n, 1), false);
+    assert.strictEqual(lt(1n, 3n), true);
+  });
 });

--- a/test/lte.test.js
+++ b/test/lte.test.js
@@ -14,4 +14,9 @@ describe('lte', function() {
     assert.strictEqual(lt(3, 1), false);
     assert.strictEqual(lt('def', 'abc'), false);
   });
+
+  it('should work with the BigInts', function() {
+    assert.strictEqual(lte(1000000000000n, 3000000000000n), true);
+    assert.strictEqual(lte(1000000000000n, 1000000000000n), true);
+  });
 });

--- a/test/toInteger-methods.js
+++ b/test/toInteger-methods.js
@@ -21,5 +21,9 @@ describe('toInteger methods', function() {
     it('`_.' + methodName + '` should support `value` of `-0`', function() {
       assert.strictEqual(1 / func(-0), -Infinity);
     });
+
+    it('`_.' + methodName + '` should support BigInts', function() {
+      assert.strictEqual(func(100000000000n), 100000000000);
+    });
   });
 });

--- a/toNumber.js
+++ b/toNumber.js
@@ -45,6 +45,9 @@ function toNumber(value) {
   if (typeof value === 'number') {
     return value
   }
+  if (typeof value === 'bigint'){
+    return Number(value)
+  }
   if (isSymbol(value)) {
     return NAN
   }


### PR DESCRIPTION
The problem mentioned in issues #4760 and #4925 are fixed.