### PR TITLE
Added support for `BigInt64Array` and `BigUint64Array`.

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -113,6 +113,8 @@
       weakSetTag = '[object WeakSet]';
 
   var arrayBufferTag = '[object ArrayBuffer]',
+      bigInt64Tag = '[object BigInt64Array]',
+      bigUint64Tag = '[object BigUint64Array]',
       dataViewTag = '[object DataView]',
       float32Tag = '[object Float32Array]',
       float64Tag = '[object Float64Array]',
@@ -280,7 +282,7 @@
 
   /** Used to assign default `context` object properties. */
   var contextProps = [
-    'Array', 'Buffer', 'DataView', 'Date', 'Error', 'Float32Array', 'Float64Array',
+    'Array', 'BigInt64Array', 'BigUint64Array', 'Buffer', 'DataView', 'Date', 'Error', 'Float32Array', 'Float64Array',
     'Function', 'Int8Array', 'Int16Array', 'Int32Array', 'Map', 'Math', 'Object',
     'Promise', 'RegExp', 'Set', 'String', 'Symbol', 'TypeError', 'Uint8Array',
     'Uint8ClampedArray', 'Uint16Array', 'Uint32Array', 'WeakMap',
@@ -292,6 +294,7 @@
 
   /** Used to identify `toStringTag` values of typed arrays. */
   var typedArrayTags = {};
+  typedArrayTags[bigInt64Tag] = typedArrayTags[bigUint64Tag] =
   typedArrayTags[float32Tag] = typedArrayTags[float64Tag] =
   typedArrayTags[int8Tag] = typedArrayTags[int16Tag] =
   typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] =
@@ -310,6 +313,7 @@
   var cloneableTags = {};
   cloneableTags[argsTag] = cloneableTags[arrayTag] =
   cloneableTags[arrayBufferTag] = cloneableTags[dataViewTag] =
+  cloneableTags[bigInt64Tag] = cloneableTags[bigUint64Tag] =
   cloneableTags[boolTag] = cloneableTags[dateTag] =
   cloneableTags[float32Tag] = cloneableTags[float64Tag] =
   cloneableTags[int8Tag] = cloneableTags[int16Tag] =
@@ -6217,6 +6221,7 @@
         case dataViewTag:
           return cloneDataView(object, isDeep);
 
+        case bigInt64Tag: case bigUint64Tag:
         case float32Tag: case float64Tag:
         case int8Tag: case int16Tag: case int32Tag:
         case uint8Tag: case uint8ClampedTag: case uint16Tag: case uint32Tag:

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,7 @@
       strictArgs = (function() { 'use strict'; return arguments; }(1, 2, 3));
 
   var ArrayBuffer = root.ArrayBuffer,
+      BigInt = root.BigInt,
       Buffer = root.Buffer,
       Map = root.Map,
       Promise = root.Promise,
@@ -194,6 +195,8 @@
 
   /** Used to check whether methods support typed arrays. */
   var typedArrays = [
+    'BigInt64Array',
+    'BigUint64Array',
     'Float32Array',
     'Float64Array',
     'Int8Array',
@@ -15048,9 +15051,10 @@
       var array1 = [0],
           array2 = [0, 0],
           array3 = [0, 0, 0, 0],
-          array4 = [0, 0, 0, 0, 0, 0, 0, 0];
+          array4 = [0, 0, 0, 0, 0, 0, 0, 0],
+          array5 = [BigInt ? BigInt(0) : 0];
 
-      var arrays = [array2, array1, array4, array3, array2, array4, array4, array3, array2],
+      var arrays = [array5, array5, array2, array1, array4, array3, array2, array4, array4, array3, array2],
           buffer = ArrayBuffer && new ArrayBuffer(8);
 
       var expected = lodashStable.map(typedArrays, function(type, index) {
@@ -24277,7 +24281,7 @@
         if (result === object) {
           return false;
         }
-        if (lodashStable.isTypedArray(object)) {
+        if (_.isTypedArray(object)) {
           return result instanceof Array;
         }
         return result instanceof Ctor || !(new Ctor instanceof Ctor);


### PR DESCRIPTION
Fixes #4646 and #4998 

Some notes/questions:
1. I have a bit of doubt about the line https://github.com/anseal/lodash/blob/c663406d32ae6ce72bac2f84bb4cba55eb1f9761/test/test.js#L24284
The test `should create an object from the same realm as 'object'` obviously can't ever pass while it uses old `lodashStable` version of `isTypedArray`. So I changed it. But not totally sure if it's OK to change the test like I did.
1. I haven't changed test at https://github.com/lodash/lodash/blob/ded9bc66583ed0b4e3b7dc906206d40757b4a90a/vendor/underscore/test/objects.js#L797 as it seems like I'm not suppose to.
1. I haven't tested it in all environments (only in Node v14.15.1, Chrome 87, FF 83) but followed the general principle and think that everything, including tests, should work even in environments where `BigInt` is not supported.
1. There is also a follow up commit https://github.com/anseal/lodash/commit/17f9e12eaca42666248d12fe2995d394dc571c86  with changes in the test `should deep clone array/typed-array/plain-object source values` that prove `_.clone` works for `BigInt`. But there I had to switch from `lodashStable` to `_` also. And not sure if it's really needed, and if it is, if I should adapt it to check all `typedArrays`, not only `Uint8Array` and `BigUint64Array`