### PR TITLE
fixed `isFunction` tests and added `isFunction(async gen)` test

### DIFF
--- a/test/clone-methods.js
+++ b/test/clone-methods.js
@@ -7,6 +7,7 @@ import {
   realm,
   body,
   asyncFunc,
+  asyncGenFunc,
   genFunc,
   errors,
   _,
@@ -74,6 +75,7 @@ describe('clone methods', function() {
     'DOM elements': body,
     'functions': Foo,
     'async functions': asyncFunc,
+    'async generator functions': asyncGenFunc,
     'generator functions': genFunc,
     'the `Proxy` constructor': Proxy
   };

--- a/test/isArrayLike.test.js
+++ b/test/isArrayLike.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import lodashStable from 'lodash';
-import { args, stubTrue, falsey, asyncFunc, genFunc, slice, symbol, realm } from './utils.js';
+import { args, stubTrue, falsey, asyncFunc, asyncGenFunc, genFunc, slice, symbol, realm } from './utils.js';
 import isArrayLike from '../isArrayLike.js';
 
 describe('isArrayLike', function() {
@@ -28,6 +28,7 @@ describe('isArrayLike', function() {
     assert.strictEqual(isArrayLike(new Error), false);
     assert.strictEqual(isArrayLike(_), false);
     assert.strictEqual(isArrayLike(asyncFunc), false);
+    assert.strictEqual(isArrayLike(asyncGenFunc), false);
     assert.strictEqual(isArrayLike(genFunc), false);
     assert.strictEqual(isArrayLike(slice), false);
     assert.strictEqual(isArrayLike({ 'a': 1 }), false);

--- a/test/isFunction.js
+++ b/test/isFunction.js
@@ -4,6 +4,7 @@ import lodashStable from 'lodash';
 import {
   slice,
   asyncFunc,
+  asyncGenFunc,
   genFunc,
   arrayViews,
   objToString,
@@ -25,11 +26,15 @@ describe('isFunction', function() {
   });
 
   it('should return `true` for async functions', function() {
-    assert.strictEqual(isFunction(asyncFunc), typeof asyncFunc === 'function');
+    assert.strictEqual(isFunction(asyncFunc), ! lodashStable.isEqualWith(asyncFunc));
   });
 
   it('should return `true` for generator functions', function() {
-    assert.strictEqual(isFunction(genFunc), typeof genFunc === 'function');
+    assert.strictEqual(isFunction(genFunc), ! lodashStable.isEqualWith(genFunc));
+  });
+
+  it('should return `true` for async generator functions', function() {
+    assert.strictEqual(isFunction(asyncGenFunc), ! lodashStable.isEqualWith(asyncGenFunc));
   });
 
   it('should return `true` for the `Proxy` constructor', function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -310,12 +310,17 @@ var coverage = root.__coverage__ || root[lodashStable.find(lodashStable.keys(roo
 
 /** Used to test async functions. */
 var asyncFunc = lodashStable.attempt(function() {
-  return Function('return async () => {}');
+  return Function('return async () => {}')();
 });
 
 /** Used to test generator functions. */
 var genFunc = lodashStable.attempt(function() {
-  return Function('return function*(){}');
+  return Function('return function*(){}')();
+});
+
+/** Used to test generator functions. */
+var asyncGenFunc = lodashStable.attempt(function() {
+  return Function('return async function* fn(){}')();
 });
 
 /** Used to restore the `_` reference. */
@@ -786,6 +791,7 @@ export {
   mapCaches,
   coverage,
   asyncFunc,
+  asyncGenFunc,
   genFunc,
   oldDash,
   whitespace,


### PR DESCRIPTION
Same as #5002 but for lodash v5 with test's fixes only.

By the way, is there any other reason why some test files (like `test/isFunction.js`) miss the `.test` suffix, except for the fact that there're faulty tests in them?

Because if I'll rename `test/isFunction.js` to `test/isFunction.test.js` I'll get an error in `should return 'true' for array view constructors` but it seems like it can be easily fixed with a simple `import { ..., root } from './utils.js'`. Or am I missing something? In case I do, I left its name unchanged and didn't `import { ...root }`