### PR TITLE
Remove outdated contributor tips

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -71,14 +71,3 @@ Guidelines are enforced using [ESLint](https://www.npmjs.com/package/eslint):
 ```bash
 $ npm run style
 ```
-
-## Tips
-
-You can opt-in to a pre-push git hook by adding an `.opt-in` file to the root of
-the project containing:
-```txt
-pre-push
-```
-
-With that, when you `git push`, the pre-push git hook will trigger and execute
-`npm run validate`.


### PR DESCRIPTION
The `opt-cli` pre-push functionality documented in the "tips" section of `CONTRIBUTING.md` was [removed in March 2016](https://github.com/lodash/lodash/commit/2cd12c38e32c76aca6396df617d79ac752d81935),
but the documentation encouraging contributors to use it still remains. Remove to avoid confusion for new contributors.