### PR TITLE
no-unneeded-ternary

### DIFF
--- a/.internal/nodeTypes.js
+++ b/.internal/nodeTypes.js
@@ -18,10 +18,8 @@ const nodeTypes = ((() => {
     /* Detect public `util.types` helpers for Node.js v10+. */
     /* Node.js deprecation code: DEP0103. */
     const typesHelper = freeModule && freeModule.require && freeModule.require('util').types
-    return typesHelper
-      ? typesHelper
-      /* Legacy process.binding('util') for Node.js earlier than v10. */
-      : freeProcess && freeProcess.binding && freeProcess.binding('util')
+    /* Legacy process.binding('util') for Node.js earlier than v10. */
+    return typesHelper || (freeProcess && freeProcess.binding && freeProcess.binding('util'))
   } catch (e) {}
 })())
 


### PR DESCRIPTION
Unnecessary use of conditional expression for default assignment.