### PR TITLE
feat: import lodash from lodash/fp.js

### DIFF
--- a/lib/fp/template/modules/fp.jst
+++ b/lib/fp/template/modules/fp.jst
@@ -1,2 +1,2 @@
-var _ = require('./lodash.min').runInContext();
+var _ = require('lodash').runInContext();
 module.exports = require('./fp/_baseConvert')(_, _);


### PR DESCRIPTION
To support bundlers with minifying and tree-shaking the fp.js should
import the package by its name instead of the minified version.

This will enable a few optimisations in modern bundlers:

- Tracking the usage of functions (e.g. to allow proper tree-shaking)
- Allowing to override the package (e.g. with webpack alias or
  externals)

Otherwise we might end up in a situation like this #3079