### PR TITLE
Update to actions/setup-node@v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
## Changes:

- Use version 2 of `actions/setup-node`

## Context:

`actions/setup-node` is stable as of version 2.14, using the `v2` tag will point to the latest `v2` release.
See the change-logs for the `v2` release line at https://github.com/actions/setup-node/releases