### PR TITLE
New feature: capitalizeWord

### DIFF
--- a/capitalizeWord.js
+++ b/capitalizeWord.js
@@ -1,0 +1,27 @@
+import capitalize from './capitalize'
+
+function asWord(word) {
+  return `\\b${word}\\b`
+}
+
+/**
+ * @category String
+ * @param {string} string input string
+ * @param {string} word word that will be capitalized
+ * @returns {string} Returns a new string with all the words that match 2nd capitalized. Partially matches are ignore (e.g.:  capitalizeWord('github', 'git') will still return 'github')
+ * @example
+ * capitalizeWord('frank talks about it frankly', 'frank');
+ * // => 'Frank talks about it frankly'
+ */
+const capitalizeWord = (string, word) => {
+  const matchWordRegex = new RegExp(asWord(word), 'ig')
+  const matchWord = string.match(matchWordRegex)
+  if (!matchWord) {
+    return string
+  }
+
+  const replaceWord = capitalize(matchWord[0])
+  return string.replace(new RegExp(matchWordRegex), replaceWord)
+}
+
+export default capitalizeWord

--- a/test/capitalizeWord.test.js
+++ b/test/capitalizeWord.test.js
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import capitalizeWord from '../capitalizeWord'
+
+describe('capitalizeWord', () => {
+  it('at start', () => {
+    assert.strictEqual(capitalizeWord('CAP lorem ipsum', 'cap'), 'Cap lorem ipsum');
+    assert.strictEqual(capitalizeWord('cap lorem ipsum', 'cap'), 'Cap lorem ipsum');
+    assert.strictEqual(capitalizeWord('Cap lorem ipsum', 'cap'), 'Cap lorem ipsum');
+    assert.strictEqual(capitalizeWord('cAp lorem ipsum', 'cap'), 'Cap lorem ipsum');
+    assert.strictEqual(capitalizeWord('caP lorem ipsum', 'cap'), 'Cap lorem ipsum');
+  });
+  it('at end', () => {
+    assert.strictEqual(capitalizeWord('lorem ipsum cap', 'cap'), 'lorem ipsum Cap');
+    assert.strictEqual(capitalizeWord('lorem ipsum Cap', 'cap'), 'lorem ipsum Cap');
+    assert.strictEqual(capitalizeWord('lorem ipsum cAp', 'cap'), 'lorem ipsum Cap');
+    assert.strictEqual(capitalizeWord('lorem ipsum caP', 'cap'), 'lorem ipsum Cap');
+    assert.strictEqual(capitalizeWord('lorem ipsum CAP', 'cap'), 'lorem ipsum Cap');
+  });
+  describe('next to punc', () => {
+    it('comma', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap,', 'cap'), 
+        'lorem ipsum Cap,'
+      );
+    });
+    it('dot', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap.', 'cap'), 
+        'lorem ipsum Cap.'
+      );
+    });
+    it('questionMark', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap?', 'cap'), 
+        'lorem ipsum Cap?'
+      );
+    });
+    it('exclamationMark', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap!', 'cap'), 
+        'lorem ipsum Cap!'
+      );
+    });
+    it('semicolon', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap;', 'cap'), 
+        'lorem ipsum Cap;'
+      );
+    });
+    it('colon', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap:', 'cap'), 
+        'lorem ipsum Cap:'
+      );
+    });
+    it('ellipsis', () => {
+      assert.strictEqual(capitalizeWord('lorem ipsum cap...', 'cap'), 
+        'lorem ipsum Cap...'
+      );
+    });
+  });
+  it('next to newline', () => {
+    assert.strictEqual(
+      capitalizeWord(
+        `lorem ipsum cap
+`,
+        'cap'
+      ),`lorem ipsum Cap
+`);
+  });
+});


### PR DESCRIPTION
Returns a new string with all the words that match 2nd capitalized. 
Partially matches are ignore (e.g.:  capitalizeWord('github', 'git') will still return 'github')

```js
capitalizeWord('frank talks about it frankly', 'frank');
// => 'Frank talks about it frankly'
capitalizeWord('Lorem ipsum...', 'ipsum')
// => 'Lorem Ipsum...'
```

Use case: Capitalize a person's name in a text 