### PR TITLE
Add 'pickArray' function

### DIFF
--- a/pickArray.js
+++ b/pickArray.js
@@ -1,0 +1,29 @@
+import map from './map.js'
+import flatten from './flatten.js'
+
+/**
+ * Creates an array containing the picked `object` properties.
+ *
+ * @since 5.0.0
+ * @category Array
+ * @param {Array} arr The source array.
+ * @param {string} key The property to pick.
+ * @returns {Array} Returns the new array.
+ * @example
+ *
+ * const arr = [
+ *   { 'a': 1, 'b': 2 },
+ *   { 'a': 1, 'b': 3 },
+ *   { 'a': 2, 'b': 4 }
+ * ]
+ *
+ * pickArray(arr, 'a')
+ * // => [1, 1, 2]
+ */
+function pickArray(arr, key) {
+  return arr == null ? [] : flatten(
+    map(arr, (object) => object[key])
+  )
+}
+
+export default pickArray

--- a/test/pickArray.test.js
+++ b/test/pickArray.test.js
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import pickArray from '../pickArray.js';
+
+describe('pickArray', function() {
+  it('should work with objects as input', function() {
+    var arr = [
+      { 'a': 1, 'b': 2 },
+      { 'a': 1, 'b': 3 },
+      { 'a': 2, 'b': 4 }
+    ]
+
+    var actual = pickArray(arr, 'a')
+    
+    assert.deepStrictEqual(actual, [1, 1, 2])
+  })
+
+  it('should work with arrays as input', function() {
+    var arr = [[1, 2], [1, 3], [2, 4]]
+
+    var actual = pickArray(arr, 0)
+    
+    assert.deepStrictEqual(actual, [1, 1, 2])
+  })
+});


### PR DESCRIPTION
Added a function which picks an object property from every object in an array.

Example:

```js
const arr = [
  { 'a': 1, 'b': 2 },
  { 'a': 1, 'b': 3 },
  { 'a': 2, 'b': 4 }
]
pickArray(arr, 'a')
// => [1, 1, 2]
```

Also works with nested arrays:

```js
const arr = [[1, 2], [1, 3], [2, 4]]
pickArray(arr, 0)
// => [1, 1, 2]
```