### PR TITLE
Remove code duplication

### DIFF
--- a/.internal/baseClone.js
+++ b/.internal/baseClone.js
@@ -102,6 +102,7 @@ function initCloneByTag(object, tag, isDeep) {
       return cloneTypedArray(object, isDeep)
 
     case mapTag:
+    case setTag:
       return new Ctor
 
     case numberTag:
@@ -110,9 +111,6 @@ function initCloneByTag(object, tag, isDeep) {
 
     case regexpTag:
       return cloneRegExp(object)
-
-    case setTag:
-      return new Ctor
 
     case symbolTag:
       return cloneSymbol(object)


### PR DESCRIPTION
The body of a case duplicates the body of another case clause. This may be caused by a copy-paste error. If this usage is intentional, consider using fall-through to remove code duplication.