### PR TITLE
perf: return first if match

### DIFF
--- a/.internal/baseSortedIndex.js
+++ b/.internal/baseSortedIndex.js
@@ -28,8 +28,10 @@ function baseSortedIndex(array, value, retHighest) {
       if (computed !== null && !isSymbol(computed) &&
           (retHighest ? (computed <= value) : (computed < value))) {
         low = mid + 1
-      } else {
+      } else if (computed > value) {
         high = mid
+      } else {
+        return high
       }
     }
     return high


### PR DESCRIPTION
In an ordered array with essentially the same values, priority return can make binary search lookups faster.

## benchmark
```
 lodash-sortedIndex-benchmark npm run bench

> lodash-sortedindex-benchmark@1.0.0 bench /Users/xiwz/xiwz/github/lodash-sortedIndex-benchmark
> node bench

oldSortedIndex x 13,666,760 ops/sec ±1.20% (86 runs sampled)
newSortedIndex x 95,870,016 ops/sec ±0.31% (90 runs sampled)
Fastest is newSortedIndex
```
see [benchmark](https://github.com/Zaynex/lodash-binary-search-benchmark)