### PR TITLE
Add Feature: isEqualCommonProps

### DIFF
--- a/isEqualCommonProps.js
+++ b/isEqualCommonProps.js
@@ -1,0 +1,69 @@
+import baseIsEqual from './.internal/baseIsEqual.js'
+import isEmpty from './isEmpty';
+import intersectionWith from './intersectionWith';
+import isObjectLike from './isObjectLike.js';
+
+/**
+ * This method is like `isEqual` except that it only compares the common properties
+ * between both objects. The method first checks equality with `isEqual`, and if it
+ * returns `false`, it then compares both objects only by the shared properties. If
+ * each one of these are equal, it will return `true`, else `false`.
+ *
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * const objectA = {
+ *  c: '3',
+ *  a: '1',
+ *  b: '2',
+ * }
+ * 
+ * const objectB = {
+ *  b: '2',
+ *  c: '3',
+ *  d: '5',
+ * }
+ * 
+ * const objectC = {
+ *  a: '4',
+ *  b: '2',
+ * }
+ * 
+ * isEqualCommonProps(objectA, objectB)
+ * // => true
+ * 
+ * isEqualCommonProps(objectA, objectC)
+ * // => false
+ */
+function isEqualCommonProps(value, other) {
+  if (baseIsEqual(value, other)) {
+    return true;
+  }
+
+  if (!isObjectLike(value) || !isObjectLike(other)) {
+    return false;
+  }
+
+  const valueProps = Object.keys(value);
+  const otherProps = Object.keys(other);
+  const commonProps = intersectionWith(valueProps, otherProps, baseIsEqual);
+
+  if (isEmpty(commonProps)) {
+    return false;
+  }
+
+  const modifiedValue = {};
+  const modifiedOther = {};
+
+  commonProps.forEach((prop) => {
+    modifiedValue[prop] = value[prop];
+    modifiedOther[prop] = other[prop];
+  });
+
+  return baseIsEqual(modifiedValue, modifiedOther);
+}
+
+export default isEqualCommonProps;

--- a/test/isEqualCommonProps.test.js
+++ b/test/isEqualCommonProps.test.js
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import isEqualCommonProps from '../isEqualCommonProps';
+
+describe('isEqualCommonProps', function() {
+  it('should return `true` for objects with equal common properties', function() {
+    const objectA = { c: 3, a: 1, b: 2 };
+    const objectB = { a: 1, d: 5, b: 2 };
+
+    assert.strictEqual(isEqualCommonProps(objectA, objectB), true);
+  });
+
+  it('should return `false` for objects with common properties with different values', function() {
+    const objectA = { c: 3, a: 1, b: 2 };
+    const objectB = { a: 8, d: 5, b: 2 };
+
+    assert.strictEqual(isEqualCommonProps(objectA, objectB), false);
+  });
+
+  it('should return `false` for objects with no common properties', function() {
+    const objectA = { c: 3, a: 1, b: 2 };
+    const objectB = { d: 3, e: 1, f: 2 };
+
+    assert.strictEqual(isEqualCommonProps(objectA, objectB), false);
+  });
+
+  it('should return `false` when one of the objects is `null`', function() {
+    const objectA = { c: 3, a: 1, b: 2 };
+
+    assert.strictEqual(isEqualCommonProps(objectA, null), false);
+  });
+
+  it('should return `false` when one of the objects is `undefined`', function() {
+    const objectA = { c: 3, a: 1, b: 2 };
+
+    assert.strictEqual(isEqualCommonProps(objectA, undefined), false);
+  });
+
+  it("should return `false` when one of the objects is `{}` but the other isn't", function() {
+    const objectA = { c: 3, a: 1, b: 2 };
+
+    assert.strictEqual(isEqualCommonProps(objectA, {}), false);
+  });
+
+  it('should return `true` when both objects are `{}`', function() {
+    assert.strictEqual(isEqualCommonProps({}, {}), true);
+  });
+});


### PR DESCRIPTION
This PR adds a new feature which compares objects only by the properties they have in common, as requested in this issue: https://github.com/lodash/lodash/issues/5186.

The solution consists in comparing both objects' list of properties, retain only the ones in common, and build new objects with only these properties. These will then be compared using the normal `isEqual`. 

Together with @mariquena we study software engineering, and we're in course about open source software at our university. We have an assignment in which we have to make a PR for a Linux Foundation project of our choice. We decided to contribute to `lodash` as it is a library we use a lot in our jobs as front-end developers.

