### PR TITLE
Add _.count

### DIFF
--- a/count.js
+++ b/count.js
@@ -16,7 +16,7 @@ import countBy from './countBy.js'
  * countBy(users, value => value.active);
  * // => { 'blue': 2, 'red': 3, 'green': 1 }
  */
-function count(collection, iteratee) {
+function count(collection) {
   return countBy(collection, value => value)
 }
 

--- a/count.js
+++ b/count.js
@@ -1,0 +1,24 @@
+import countBy from './countBy.js'
+
+/**
+ * Creates an object composed of keys generated from the values of `Collection`.
+ * The corresponding value of each key is the number of times the key was
+ * returned.
+ *
+ * @since 4.17.0
+ * @category Collection
+ * @param {Array} collection The collection to iterate over.
+ * @returns {Object} Returns the composed aggregate object.
+ * @example
+ *
+ * const colors = ['blue', 'red', 'green', 'red', 'red', 'blue']
+ *
+ * countBy(users, value => value.active);
+ * // => { 'blue': 2, 'red': 3, 'green': 1 }
+ */
+function count(collection, iteratee) {
+  return countBy(collection, value => value)
+}
+
+export default count
+

--- a/count.js
+++ b/count.js
@@ -13,7 +13,7 @@ import countBy from './countBy.js'
  *
  * const colors = ['blue', 'red', 'green', 'red', 'red', 'blue']
  *
- * countBy(users, value => value.active);
+ * countBy(colors, value => value.active);
  * // => { 'blue': 2, 'red': 3, 'green': 1 }
  */
 function count(collection) {


### PR DESCRIPTION
Lodash supports `_.countBy`. It would be great if Lodash also supported a `_.count` option in place of writing `_.countBy` with the `_.identity` iteratee. It's a common pattern for lodash to support two variants of the same function (e.g. `_.min` and `_.minBy`, or `_.sum` and `_.sumBy`). It would be great if we did the same for the `_.countBy` method.