### PR TITLE
Make `bitmask` param type a number

### DIFF
--- a/.internal/baseIsEqual.js
+++ b/.internal/baseIsEqual.js
@@ -8,7 +8,7 @@ import isObjectLike from '../isObjectLike.js'
  * @private
  * @param {*} value The value to compare.
  * @param {*} other The other value to compare.
- * @param {boolean} bitmask The bitmask flags.
+ * @param {number} bitmask The bitmask flags.
  *  1 - Unordered comparison
  *  2 - Partial comparison
  * @param {Function} [customizer] The function to customize comparisons.


### PR DESCRIPTION
The param type for `bitmask` in `baseIsEqual` doesn't align with `baseIsDeepEqual` or other similar `bitmask` usage throughout the codebase.