### PR TITLE
add extract

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -1,0 +1,41 @@
+import forEach from './forEach.js'
+import reduce from './reduce.js'
+import times from './times.js'
+
+/**
+ * Creates an array of `n` arrays of elements, each array containing
+ * the elements that return truthy for the respective predicate. The
+ * predicate is invoked with one argument: (value).
+ *
+ * @since ?
+ * @category Collection
+ * @param {Array|Object} collection The collection to iterate over.
+ * @param {...*} [predicates] The functions invoked per iteration.
+ * @returns {Array} Returns the array of arrays of grouped elements.
+ * @example
+ *
+ * const consumables = [
+ *   { 'name': 'pear',        'type': 'fruit',      'active': false },
+ *   { 'name': 'plum',        'type': 'fruit',      'active': true },
+ *   { 'name': 'lettuce',     'type': 'vegetable',  'active': false },
+ *   { 'name': 'apple juice', 'type': 'liquid',     'active': false }
+ * ]
+ *
+ * extract(
+ *  consumables,
+ *  ({ type }) => type === 'fruit',
+ *  ({ type }) => type === 'vegetable',
+ *  ({ type }) => type === 'liquid',
+ * )
+ * // => objects for [['pear', 'plum'], ['lettuce'], ['apple juice']]
+ */
+function extract(collection, ...predicates) {
+  return reduce(collection, (result, value) => {
+    forEach(predicates, (predicate, nth) => {
+      if (predicate(value)) result[nth].push(value)
+    })
+    return result
+  }, times(predicates.length, () => []))
+}
+
+export default extract

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert'
+import {identity, stubTrue, stubFalse} from './utils.js'
+import extract from '../extract.js'
+
+describe('extract', () => {
+  const array = [1, 0, 2]
+
+  it('should split elements into n groups, where n is the number of predicates', () => {
+    assert.deepStrictEqual(extract([], identity), [[]])
+    assert.deepStrictEqual(extract(array, stubTrue, stubFalse), [[1, 0, 2], []])
+    assert.deepStrictEqual(extract(array,
+      (element) => element === 0,
+      (element) => element === 1,
+      (element) => element === 2
+    ), [[0], [1], [2]])
+  })
+
+  it('should return empty array if no predicate is used', () => {
+    assert.deepStrictEqual(extract([1, 2, 3]), []);
+  })
+
+  it('should work with an object for `collection`', () => {
+    const actual = extract({'a': 1.1, 'b': 0.2, 'c': 1.3}, Math.floor, Math.ceil)
+    assert.deepStrictEqual(actual, [[1.1, 1.3], [1.1, 0.2, 1.3]])
+  })
+})


### PR DESCRIPTION
Hello 👋. Hope this PR will help many in their software development process.
## What is introduced in this PR?
This PR introduces `extract` function which helps you extract sublists from a given collection and some predicates.
## How is `extract` used?
Let's say we have this array:
```javascript
const documents = [
  { pages: 24,  type: 'ebook',   category: 'finance', ... },
  { pages: 240, type: 'book',    category: 'self development', ... },
  { pages: 41,  type: 'ebook',   category: 'finance', ... },
  { pages: 66,  type: 'ebook',   category: 'it', ... },
  { pages: 2,   type: 'article', category: 'it', ... }
]
```
and we want to extract `finance ebooks`, `self development books` and documents from `it` category.

We can do this with `extract` function I implemented:
```javascript
const [financeEbooks, selfDevelopmentBooks, itDocuments] = extract(
  documents,
  doc => doc.type === 'ebook' && doc.category === 'finance',
  doc => doc.type === 'book' && doc.category === 'self development',
  doc => doc.category === 'it'
)
```
Printing these sublists we obtain:
```javascript
console.log(financeEbooks)
// [ { pages: 24, type: 'ebook', category: 'finance', ... }, { pages: 41, type: 'ebook', category: 'finance', ... }]

console.log(selfDevelopmentBooks)
//  [{ pages: 240, type: 'book', category: 'self development', ... }]

console.log(itDocuments)
//  [{ pages: 66, type: 'ebook', category: 'it', ... }, { pages: 2, type: 'article', category: 'it', ... }]
```
## How would you do this without extract?
```javascript
const financeEbooks = documents.filter(doc => doc.type === 'ebook' && doc.category === 'finance');
const selfDevelopmentBooks = documents.filter(doc => doc.type === 'book' && doc.category === 'self development');
const itDocuments = documents.filter(doc => doc.category === 'it');
```
## Why the addition of extract?
You won't parse the `documents` array three times (or N times generally speaking). You'll only parse it once. Also, you'll declare the sublists in the same place, thus making the code easier to read.