### PR TITLE
Feature: add Array/splitAt function

### DIFF
--- a/splitAt.js
+++ b/splitAt.js
@@ -1,0 +1,29 @@
+import slice from './slice'
+import toInteger from './toInteger'
+
+/**
+ * Splits `array` into two separate arrays
+ *
+ * **Note:** This method is based on
+ * [`Slice`](https://lodash.com/docs/4.17.15#slice).
+ *
+     * @since 5.0.0
+ * @category Array
+ * @param {array} [array=[1, 2, 3]] The array to split.
+ * @param {index|number} index The index to split the array.
+ * @returns {[Array, Array]} Returns two arrays.
+ * @example
+ *
+ * splitAt([1, 2, 3, 4, 5, 6, 7], 4)
+ * // => [[1, 2, 3, 4], [5, 6, 7]]
+ */
+const splitAt = (array, index) => {
+  if (toInteger(index) <= 0) { return [[], array] }
+
+  const firstItems = slice(array, 0, index)
+  const tail = slice(array, index)
+
+  return [firstItems, tail]
+}
+
+export default splitAt

--- a/test/splitAt.test.js
+++ b/test/splitAt.test.js
@@ -1,0 +1,80 @@
+import assert from 'assert'
+import splitAt from '../splitAt'
+
+describe('splitAt', () => {
+  describe('when array has no values', () => {
+    it('should return two empty arrays', () => {
+      const arr = []
+      const index = 4
+      const [firstItems, rest] = splitAt(arr, index)
+
+      assert.deepEqual(firstItems, [])
+      assert.deepEqual(rest,  [])
+    })
+  })
+
+  describe('when array has no tail', () => {
+    it('should return the second array empty', () => {
+      const arr = [1, 2, 3, 4]
+      const index = 4
+      const [firstItems, rest] = splitAt(arr, index)
+
+      assert.deepEqual(firstItems, [1, 2, 3, 4])
+      assert.deepEqual(rest,  [])
+    })
+  })
+
+  describe('when array has tail', () => {
+    it('should return both arrays with values', () => {
+      const arr = [1, 2, 3, 4, 5, 6, 7]
+      const index = 4
+      const [firstItems, rest] = splitAt(arr, index)
+
+      assert.deepEqual(firstItems, [1, 2, 3, 4])
+      assert.deepEqual(rest,  [5, 6, 7])
+    })
+  })
+
+  describe('when index is negative', () => {
+    it('should return the first array empty', () => {
+      const arr = [1, 2, 3]
+      const index = -1
+      const [firstItems, rest] = splitAt(arr, index)
+
+      assert.deepEqual(firstItems, [])
+      assert.deepEqual(rest,  [1, 2, 3])
+    })
+  })
+
+  describe('when index is 0', () => {
+    it('should return the first array empty', () => {
+      const arr = [1, 2, 3]
+      const index = 0
+      const [firstItems, rest] = splitAt(arr, index)
+
+      assert.deepEqual(firstItems, [])
+      assert.deepEqual(rest,  [1, 2, 3])
+    })
+  })
+
+  describe('when index is undefined', () => {
+    it('should return the first array empty', () => {
+      const arr = [1, 2, 3]
+      const [firstItems, rest] = splitAt(arr)
+
+      assert.deepEqual(firstItems, [])
+      assert.deepEqual(rest,  [1, 2, 3])
+    })
+  })
+
+  describe('when index is null', () => {
+    it('should return the first array empty', () => {
+      const arr = [1, 2, 3]
+      const index = null
+      const [firstItems, rest] = splitAt(arr, index)
+
+      assert.deepEqual(firstItems, [])
+      assert.deepEqual(rest,  [1, 2, 3])
+    })
+  })
+})


### PR DESCRIPTION
## Description

Splits an Array into two parts at the given index with the first resulting array including everything up to but not including the index and the second including everything from the index till the end.

This PR closes #5288

## Usage examples

```js
const arr = [1, 2, 3, 4, 5, 6, 7]
const [firstItems, tail] = splitAt(arr, 4) // firstItems = [1, 2, 3, 4], tail = [5, 6, 7]

const arr = [1, 2, 3]
const [firstItems, tail] = splitAt(arr, 4) // firstItems = [1, 2, 3], tail =[]

const arr = []
const [firstItems, tail] = splitAt(arr, 4) // firstItems = [], tail = []
```