### PR TITLE
Add dropEndsWhile

### DIFF
--- a/dropEndsWhile.js
+++ b/dropEndsWhile.js
@@ -1,0 +1,30 @@
+import baseWhile from './.internal/baseWhile.js'
+
+/**
+ * Creates a slice of `array` excluding elements dropped from the beginning and end.
+ * Elements are dropped until `predicate` returns falsey. The predicate is
+ * invoked with three arguments: (value, index, array).
+ *
+ * @since 5.0.0
+ * @category Array
+ * @param {Array} array The array to query.
+ * @param {Function} predicate The function invoked per iteration.
+ * @returns {Array} Returns the slice of `array`.
+ * @example
+ *
+ * const users = [
+ *   { 'user': 'barney',  'active': true },
+ *   { 'user': 'pebbles', 'active': false },
+ *   { 'user': 'fred',    'active': true }
+ * ]
+ *
+ * dropEndsWhile(users, ({ active }) => active)
+ * // => objects for ['pebbles']
+ */
+function dropEndsWhile(array, predicate) {
+  return (array != null && array.length)
+    ? baseWhile(baseWhile(array, predicate, true), predicate, true, true)
+    : []
+}
+
+export default dropEndsWhile

--- a/test/Arrays-category-methods.js
+++ b/test/Arrays-category-methods.js
@@ -4,6 +4,7 @@ import difference from '../difference.js';
 import union from '../union.js';
 import compact from '../compact.js';
 import drop from '../drop.js';
+import dropEndsWhile from '../dropEndsWhile.js';
 import dropRight from '../dropRight.js';
 import dropRightWhile from '../dropRightWhile.js';
 import dropWhile from '../dropWhile.js';
@@ -48,6 +49,7 @@ describe('"Arrays" category methods', function() {
 
     assert.deepStrictEqual(compact(args), [1, [3], 5], message('compact'));
     assert.deepStrictEqual(drop(args, 3), [null, 5], message('drop'));
+    assert.deepStrictEqual(dropEndsWhile(args,identity), [1, null, [3], null], message('dropEndsWhile'));
     assert.deepStrictEqual(dropRight(args, 3), [1, null], message('dropRight'));
     assert.deepStrictEqual(dropRightWhile(args,identity), [1, null, [3], null], message('dropRightWhile'));
     assert.deepStrictEqual(dropWhile(args,identity), [null, [3], null, 5], message('dropWhile'));

--- a/test/custom-_.iteratee-methods.js
+++ b/test/custom-_.iteratee-methods.js
@@ -34,6 +34,12 @@ describe('custom `_.iteratee` methods', function() {
     iteratee = iteratee;
   });
 
+  it('`_.dropEndsWhile` should use `_.iteratee` internally', function() {
+    iteratee = getPropB;
+    assert.deepEqual(_.dropEndsWhile(objects), objects.slice(0, 2));
+    iteratee = iteratee;
+  });
+
   it('`_.dropRightWhile` should use `_.iteratee` internally', function() {
     iteratee = getPropB;
     assert.deepEqual(_.dropRightWhile(objects), objects.slice(0, 2));

--- a/test/dropEndsWhile.js
+++ b/test/dropEndsWhile.js
@@ -1,0 +1,75 @@
+import assert from "assert";
+import lodashStable from "lodash";
+import { slice, LARGE_ARRAY_SIZE } from "./utils.js";
+import dropEndsWhile from "../dropEndsWhile.js";
+
+describe("dropEndsWhile", function () {
+  var array = [1, 2, 3, 1, 3, 2, 1];
+
+  var objects = [
+    { a: 2, b: 2 },
+    { a: 1, b: 1 },
+    { a: 0, b: 0 },
+    { a: 1, b: 1 },
+    { a: 2, b: 2 },
+  ];
+
+  it("should drop elements while `predicate` returns truthy", function () {
+    var actual = dropEndsWhile(array, function (n) {
+      return n < 3;
+    });
+
+    assert.deepStrictEqual(actual, [3, 1, 3]);
+  });
+
+  it("should provide correct `predicate` arguments", function () {
+    var args;
+
+    dropEndsWhile(array, function () {
+      args = slice.call(arguments);
+    });
+
+    assert.deepStrictEqual(args, [1, 0, array]);
+  });
+
+  it("should work with `_.matches` shorthands", function () {
+    assert.deepStrictEqual(dropEndsWhile(objects, { b: 2 }), objects.slice(1));
+  });
+
+  it("should work with `_.matchesProperty` shorthands", function () {
+    assert.deepStrictEqual(dropEndsWhile(objects, ["b", 2]), objects.slice(1));
+  });
+
+  it("should work with `_.property` shorthands", function () {
+    assert.deepStrictEqual(dropEndsWhile(objects, "b"), objects.slice(2));
+  });
+
+  it("should work in a lazy sequence", function () {
+    var array = lodashStable.range(1, LARGE_ARRAY_SIZE + 3),
+      predicate = function (n) {
+        return n < 3;
+      },
+      expected = dropEndsWhile(array, predicate),
+      wrapped = _(array).dropEndsWhile(predicate);
+
+    assert.deepEqual(wrapped.value(), expected);
+    assert.deepEqual(wrapped.reverse().value(), expected.slice().reverse());
+    assert.strictEqual(wrapped.last(), _.last(expected));
+  });
+
+  it("should work in a lazy sequence with `drop`", function () {
+    var array = lodashStable.range(1, LARGE_ARRAY_SIZE + 3);
+
+    var actual = _(array)
+      .dropEndsWhile(function (n) {
+        return n == 1;
+      })
+      .drop()
+      .dropEndsWhile(function (n) {
+        return n == 3;
+      })
+      .value();
+
+    assert.deepEqual(actual, array.slice(3));
+  });
+});


### PR DESCRIPTION
Hello everyone,

This adds a `dropEndsWhile` function that drops elements from both ends of the array. I simply modeled it after the existing functions and it just calls `baseWhile` twice. I also did attempt to rewrite `baseWhile` to take an extra argument (`fromLeft`) which would change the new function so it would only need to call `baseWhile` once. However, it doesn't appear that `npm run test` actually tests these array functions, and I couldn't figure out how to actually run these tests, so I decided to stop and instead proceed to open this PR and to ask for assistance on that.

Please let me know how to run the tests so that I can finish up the PR.

Thanks!