### PR TITLE
typo fix in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In a browser:
 
 Using npm:
 ```shell
-$ npm i -g npm
+$ npm i -g lodash
 $ npm i lodash
 ```
 Note: add `--save` if you are using npm < 5.0.0


### PR DESCRIPTION
on line 39, I think npm i -g "npm" is a typo for "lodash"