### PR TITLE
pref: `err` instead of `e`

### DIFF
--- a/attempt.js
+++ b/attempt.js
@@ -22,8 +22,8 @@ import isError from './isError.js'
 function attempt(func, ...args) {
   try {
     return func(...args)
-  } catch (e) {
-    return isError(e) ? e : new Error(e)
+  } catch (err) {
+    return isError(err) ? err : new Error(err)
   }
 }
 


### PR DESCRIPTION
As `e` is often used for the `event`.  Proposed a change from `e` to `err` in order to increase the readability of code. 