### PR TITLE
fix check for array type in remove(array, predicate). Fixes #5412

### DIFF
--- a/remove.js
+++ b/remove.js
@@ -27,7 +27,7 @@ import basePullAt from './.internal/basePullAt.js'
  */
 function remove(array, predicate) {
   const result = []
-  if (!(array != null && array.length)) {
+  if (!Array.isArray(array)) {
     return result
   }
   let index = -1

--- a/test/remove.js
+++ b/test/remove.js
@@ -77,4 +77,11 @@ describe('remove', function() {
 
     assert.deepStrictEqual(array, [2]);
   });
+
+  it('should return an empty array when provided an array-like parameter, leaving the input unchanged XXXX', () => {
+    var arrayLike = { length: 9 };
+    var result = remove(arrayLike, () => true); 
+    assert.deepEqual(result, []);
+    assert.deepEqual(arrayLike, { length: 9 });
+  });
 });


### PR DESCRIPTION
Fixes [https://github.com/lodash/lodash/issues/5412](https://github.com/lodash/lodash/issues/5412)