### PR TITLE
Fix misleading update example

### DIFF
--- a/update.js
+++ b/update.js
@@ -21,7 +21,7 @@ import baseUpdate from './.internal/baseUpdate.js'
  * console.log(object.a[0].b.c)
  * // => 9
  *
- * update(object, 'x[0].y.z', n => n ? n + 1 : 0)
+ * update(object, 'x[0].y.z', n !== undefined => n ? n + 1 : 0)
  * console.log(object.x[0].y.z)
  * // => 0
  */


### PR DESCRIPTION
The current example will always set `n` to `0`.