### PR TITLE
Fix syntax error where delete cannot be used in strict mode

### DIFF
--- a/test/bind.js
+++ b/test/bind.js
@@ -82,7 +82,7 @@ describe('bind', function() {
         bound = bind(fn, object, _ph, 'b', ph);
 
     assert.deepEqual(bound('a', 'c'), [object, 'a', 'b', ph, 'c']);
-    delete placeholder;
+    placeholder = null;
   });
 
   it('should create a function with a `length` of `0`', function() {

--- a/test/curry.js
+++ b/test/curry.js
@@ -66,7 +66,7 @@ describe('curry', function() {
         ph = curried.placeholder;
 
     assert.deepEqual(curried(1)(_ph, 3)(ph, 4), [1, ph, 3, 4]);
-    delete placeholder;
+    placeholder = null;
   });
 
   it('should provide additional arguments after reaching the target arity', function() {

--- a/test/curryRight.js
+++ b/test/curryRight.js
@@ -67,7 +67,7 @@ describe('curryRight', function() {
         ph = curried.placeholder;
 
     assert.deepEqual(curried(4)(2, _ph)(1, ph), [1, 2, ph, 4]);
-    delete placeholder;
+    placeholder = null;
   });
 
   it('should provide additional arguments after reaching the target arity', function() {

--- a/test/partial-methods.js
+++ b/test/partial-methods.js
@@ -58,7 +58,7 @@ describe('partial methods', function() {
           expected = isPartial ? ['a', 'b', ph, 'c'] : ['a', 'c', 'b', ph];
 
       assert.deepEqual(par('a', 'c'), expected);
-      delete placeholder;
+      placeholder = null;
     });
 
     it('`_.' + methodName + '` creates a function with a `length` of `0`', function() {


### PR DESCRIPTION
This error occurs when attempting to delete a plain variable, it throws an error when in strict mode. So setting the variable to null will perform in the same way without the syntax error of the previous implementation.
![error](https://user-images.githubusercontent.com/76674104/162994989-6e04628f-287f-4dbe-b576-6dff008f5d67.png)
