### PR TITLE
Fix import statement for non-existent module

### DIFF
--- a/test/isType-checks.js
+++ b/test/isType-checks.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import lodashStable from 'lodash';
-import { objToString, objectTag, _, xml } from './utils.js';
+import { objToString, objectTag, _ } from './utils.js';
 
 describe('isType checks', function() {
   it('should return `false` for subclassed values', function() {


### PR DESCRIPTION
The import statement contains a module named "xml", but it doesn't exist in the "./utils.js" files. The fix was just to simply remove the "xml" import.