### PR TITLE
remove extra semicolon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,4 +122,4 @@ module.exports = {
 
     'template-curly-spacing': ['error', 'never']
   }
-};
+}


### PR DESCRIPTION
when running `npm run style`, it throws 

C:\Users\centr\OneDrive\Documents\Code\lodash\.eslintrc.js
  125:2  error  Extra semicolon  semi

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

removing the semicolon fixes it