### PR TITLE
perf: use `===` instead of `==` of all files.

### DIFF
--- a/.internal/ListCache.js
+++ b/.internal/ListCache.js
@@ -45,7 +45,7 @@ class ListCache {
       return false
     }
     const lastIndex = data.length - 1
-    if (index == lastIndex) {
+    if (index === lastIndex) {
       data.pop()
     } else {
       data.splice(index, 1)

--- a/.internal/MapCache.js
+++ b/.internal/MapCache.js
@@ -112,7 +112,7 @@ class MapCache {
     const size = data.size
 
     data.set(key, value)
-    this.size += data.size == size ? 0 : 1
+    this.size += data.size === size ? 0 : 1
     return this
   }
 }

--- a/.internal/baseAssignValue.js
+++ b/.internal/baseAssignValue.js
@@ -8,7 +8,7 @@
  * @param {*} value The value to assign.
  */
 function baseAssignValue(object, key, value) {
-  if (key == '__proto__') {
+  if (key === '__proto__') {
     Object.defineProperty(object, key, {
       'configurable': true,
       'enumerable': true,

--- a/.internal/baseClone.js
+++ b/.internal/baseClone.js
@@ -182,7 +182,7 @@ function baseClone(value, bitmask, customizer, key, object, stack) {
     if (isBuffer(value)) {
       return cloneBuffer(value, isDeep)
     }
-    if (tag == objectTag || tag == argsTag || (isFunc && !object)) {
+    if (tag === objectTag || tag === argsTag || (isFunc && !object)) {
       result = (isFlat || isFunc) ? {} : initCloneObject(value)
       if (!isDeep) {
         return isFlat
@@ -204,14 +204,14 @@ function baseClone(value, bitmask, customizer, key, object, stack) {
   }
   stack.set(value, result)
 
-  if (tag == mapTag) {
+  if (tag === mapTag) {
     value.forEach((subValue, key) => {
       result.set(key, baseClone(subValue, bitmask, customizer, key, value, stack))
     })
     return result
   }
 
-  if (tag == setTag) {
+  if (tag === setTag) {
     value.forEach((subValue) => {
       result.add(baseClone(subValue, bitmask, customizer, subValue, value, stack))
     })

--- a/.internal/baseGet.js
+++ b/.internal/baseGet.js
@@ -18,7 +18,7 @@ function baseGet(object, path) {
   while (object != null && index < length) {
     object = object[toKey(path[index++])]
   }
-  return (index && index == length) ? object : undefined
+  return (index && index === length) ? object : undefined
 }
 
 export default baseGet

--- a/.internal/baseIsEqualDeep.js
+++ b/.internal/baseIsEqualDeep.js
@@ -37,12 +37,12 @@ function baseIsEqualDeep(object, other, bitmask, customizer, equalFunc, stack) {
   let objTag = objIsArr ? arrayTag : getTag(object)
   let othTag = othIsArr ? arrayTag : getTag(other)
 
-  objTag = objTag == argsTag ? objectTag : objTag
-  othTag = othTag == argsTag ? objectTag : othTag
+  objTag = objTag === argsTag ? objectTag : objTag
+  othTag = othTag === argsTag ? objectTag : othTag
 
-  let objIsObj = objTag == objectTag
-  const othIsObj = othTag == objectTag
-  const isSameTag = objTag == othTag
+  let objIsObj = objTag === objectTag
+  const othIsObj = othTag === objectTag
+  const isSameTag = objTag === othTag
 
   if (isSameTag && isBuffer(object)) {
     if (!isBuffer(other)) {

--- a/.internal/baseSet.js
+++ b/.internal/baseSet.js
@@ -30,7 +30,7 @@ function baseSet(object, path, value, customizer) {
     const key = toKey(path[index])
     let newValue = value
 
-    if (index != lastIndex) {
+    if (index !== lastIndex) {
       const objValue = nested[key]
       newValue = customizer ? customizer(objValue, key, nested) : undefined
       if (newValue === undefined) {

--- a/.internal/baseSortedIndexBy.js
+++ b/.internal/baseSortedIndexBy.js
@@ -20,7 +20,7 @@ const MAX_ARRAY_INDEX = MAX_ARRAY_LENGTH - 1
 function baseSortedIndexBy(array, value, iteratee, retHighest) {
   let low = 0
   let high = array == null ? 0 : array.length
-  if (high == 0) {
+  if (high === 0) {
     return 0
   }
 

--- a/.internal/baseXor.js
+++ b/.internal/baseXor.js
@@ -25,7 +25,7 @@ function baseXor(arrays, iteratee, comparator) {
     let othIndex = -1
 
     while (++othIndex < length) {
-      if (othIndex != index) {
+      if (othIndex !== index) {
         result[index] = baseDifference(result[index] || array, arrays[othIndex], iteratee, comparator)
       }
     }

--- a/.internal/compareMultiple.js
+++ b/.internal/compareMultiple.js
@@ -27,7 +27,7 @@ function compareMultiple(object, other, orders) {
     const result = cmpFn(objCriteria[index], othCriteria[index])
     if (result) {
       if (order && typeof order !== 'function') {
-        return result * (order == 'desc' ? -1 : 1)
+        return result * (order === 'desc' ? -1 : 1)
       }
       return result
     }

--- a/.internal/createSet.js
+++ b/.internal/createSet.js
@@ -10,7 +10,7 @@ const INFINITY = 1 / 0
  * @param {Array} values The values to add to the set.
  * @returns {Object} Returns the new set.
  */
-const createSet = (Set && (1 / setToArray(new Set([,-0]))[1]) == INFINITY)
+const createSet = (Set && (1 / setToArray(new Set([,-0]))[1]) === INFINITY)
   ? (values) => new Set(values)
   : () => {}
 

--- a/.internal/equalArrays.js
+++ b/.internal/equalArrays.js
@@ -24,13 +24,13 @@ function equalArrays(array, other, bitmask, customizer, equalFunc, stack) {
   const arrLength = array.length
   const othLength = other.length
 
-  if (arrLength != othLength && !(isPartial && othLength > arrLength)) {
+  if (arrLength !== othLength && !(isPartial && othLength > arrLength)) {
     return false
   }
   // Assume cyclic values are equal.
   const stacked = stack.get(array)
   if (stacked && stack.get(other)) {
-    return stacked == other
+    return stacked === other
   }
   let index = -1
   let result = true

--- a/.internal/equalByTag.js
+++ b/.internal/equalByTag.js
@@ -44,15 +44,15 @@ const symbolValueOf = Symbol.prototype.valueOf
 function equalByTag(object, other, tag, bitmask, customizer, equalFunc, stack) {
   switch (tag) {
     case dataViewTag:
-      if ((object.byteLength != other.byteLength) ||
-          (object.byteOffset != other.byteOffset)) {
+      if ((object.byteLength !== other.byteLength) ||
+          (object.byteOffset !== other.byteOffset)) {
         return false
       }
       object = object.buffer
       other = other.buffer
 
     case arrayBufferTag:
-      if ((object.byteLength != other.byteLength) ||
+      if ((object.byteLength !== other.byteLength) ||
           !equalFunc(new Uint8Array(object), new Uint8Array(other))) {
         return false
       }
@@ -66,14 +66,14 @@ function equalByTag(object, other, tag, bitmask, customizer, equalFunc, stack) {
       return eq(+object, +other)
 
     case errorTag:
-      return object.name == other.name && object.message == other.message
+      return object.name === other.name && object.message === other.message
 
     case regexpTag:
     case stringTag:
       // Coerce regexes to strings and treat strings, primitives and objects,
       // as equal. See http://www.ecma-international.org/ecma-262/7.0/#sec-regexp.prototype.tostring
       // for more details.
-      return object == `${other}`
+      return object === `${other}`
 
     case mapTag:
       let convert = mapToArray
@@ -82,13 +82,13 @@ function equalByTag(object, other, tag, bitmask, customizer, equalFunc, stack) {
       const isPartial = bitmask & COMPARE_PARTIAL_FLAG
       convert || (convert = setToArray)
 
-      if (object.size != other.size && !isPartial) {
+      if (object.size !== other.size && !isPartial) {
         return false
       }
       // Assume cyclic values are equal.
       const stacked = stack.get(object)
       if (stacked) {
-        return stacked == other
+        return stacked === other
       }
       bitmask |= COMPARE_UNORDERED_FLAG
 
@@ -100,7 +100,7 @@ function equalByTag(object, other, tag, bitmask, customizer, equalFunc, stack) {
 
     case symbolTag:
       if (symbolValueOf) {
-        return symbolValueOf.call(object) == symbolValueOf.call(other)
+        return symbolValueOf.call(object) === symbolValueOf.call(other)
       }
   }
   return false

--- a/.internal/equalObjects.js
+++ b/.internal/equalObjects.js
@@ -26,7 +26,7 @@ function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
   const othProps = getAllKeys(other)
   const othLength = othProps.length
 
-  if (objLength != othLength && !isPartial) {
+  if (objLength !== othLength && !isPartial) {
     return false
   }
   let key
@@ -40,7 +40,7 @@ function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
   // Assume cyclic values are equal.
   const stacked = stack.get(object)
   if (stacked && stack.get(other)) {
-    return stacked == other
+    return stacked === other
   }
   let result = true
   stack.set(object, other)
@@ -66,14 +66,14 @@ function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
       result = false
       break
     }
-    skipCtor || (skipCtor = key == 'constructor')
+    skipCtor || (skipCtor = key === 'constructor')
   }
   if (result && !skipCtor) {
     const objCtor = object.constructor
     const othCtor = other.constructor
 
     // Non `Object` object instances with different constructors are not equal.
-    if (objCtor != othCtor &&
+    if (objCtor !== othCtor &&
         ('constructor' in object && 'constructor' in other) &&
         !(typeof objCtor === 'function' && objCtor instanceof objCtor &&
           typeof othCtor === 'function' && othCtor instanceof othCtor)) {

--- a/.internal/isIndex.js
+++ b/.internal/isIndex.js
@@ -19,7 +19,7 @@ function isIndex(value, length) {
   return !!length &&
     (type === 'number' ||
       (type !== 'symbol' && reIsUint.test(value))) &&
-        (value > -1 && value % 1 == 0 && value < length)
+        (value > -1 && value % 1 === 0 && value < length)
 }
 
 export default isIndex

--- a/.internal/root.js
+++ b/.internal/root.js
@@ -2,7 +2,7 @@
 import freeGlobal from './freeGlobal.js'
 
 /** Detect free variable `globalThis` */
-const freeGlobalThis = typeof globalThis === 'object' && globalThis !== null && globalThis.Object == Object && globalThis
+const freeGlobalThis = typeof globalThis === 'object' && globalThis !== null && globalThis.Object === Object && globalThis
 
 /** Detect free variable `self`. */
 const freeSelf = typeof self === 'object' && self !== null && self.Object === Object && self

--- a/.internal/toKey.js
+++ b/.internal/toKey.js
@@ -15,7 +15,7 @@ function toKey(value) {
     return value
   }
   const result = `${value}`
-  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result
+  return (result === '0' && (1 / value) === -INFINITY) ? '-0' : result
 }
 
 export default toKey

--- a/endsWith.js
+++ b/endsWith.js
@@ -23,7 +23,7 @@
 function endsWith(string, target, position) {
   const { length } = string
   position = position === undefined ? length : +position
-  if (position < 0 || position != position) {
+  if (position < 0 || position !== position) {
     position = 0
   }
   else if (position > length) {
@@ -31,7 +31,7 @@ function endsWith(string, target, position) {
   }
   const end = position
   position -= target.length
-  return position >= 0 && string.slice(position, end) == target
+  return position >= 0 && string.slice(position, end) === target
 }
 
 export default endsWith

--- a/hasPath.js
+++ b/hasPath.js
@@ -42,7 +42,7 @@ function hasPath(object, path) {
     }
     object = object[key]
   }
-  if (result || ++index != length) {
+  if (result || ++index !== length) {
     return result
   }
   length = object == null ? 0 : object.length

--- a/hasPathIn.js
+++ b/hasPathIn.js
@@ -39,7 +39,7 @@ function hasPathIn(object, path) {
     }
     object = object[key]
   }
-  if (result || ++index != length) {
+  if (result || ++index !== length) {
     return result
   }
   length = object == null ? 0 : object.length

--- a/isArguments.js
+++ b/isArguments.js
@@ -17,7 +17,7 @@ import isObjectLike from './isObjectLike.js'
  * // => false
  */
 function isArguments(value) {
-  return isObjectLike(value) && getTag(value) == '[object Arguments]'
+  return isObjectLike(value) && getTag(value) === '[object Arguments]'
 }
 
 export default isArguments

--- a/isArrayBuffer.js
+++ b/isArrayBuffer.js
@@ -22,6 +22,6 @@ const nodeIsArrayBuffer = nodeTypes && nodeTypes.isArrayBuffer
  */
 const isArrayBuffer = nodeIsArrayBuffer
   ? (value) => nodeIsArrayBuffer(value)
-  : (value) => isObjectLike(value) && getTag(value) == '[object ArrayBuffer]'
+  : (value) => isObjectLike(value) && getTag(value) === '[object ArrayBuffer]'
 
 export default isArrayBuffer

--- a/isBoolean.js
+++ b/isBoolean.js
@@ -18,7 +18,7 @@ import isObjectLike from './isObjectLike.js'
  */
 function isBoolean(value) {
   return value === true || value === false ||
-    (isObjectLike(value) && getTag(value) == '[object Boolean]')
+    (isObjectLike(value) && getTag(value) === '[object Boolean]')
 }
 
 export default isBoolean

--- a/isDate.js
+++ b/isDate.js
@@ -22,6 +22,6 @@ const nodeIsDate = nodeTypes && nodeTypes.isDate
  */
 const isDate = nodeIsDate
   ? (value) => nodeIsDate(value)
-  : (value) => isObjectLike(value) && getTag(value) == '[object Date]'
+  : (value) => isObjectLike(value) && getTag(value) === '[object Date]'
 
 export default isDate

--- a/isEmpty.js
+++ b/isEmpty.js
@@ -52,7 +52,7 @@ function isEmpty(value) {
     return !value.length
   }
   const tag = getTag(value)
-  if (tag == '[object Map]' || tag == '[object Set]') {
+  if (tag === '[object Map]' || tag === '[object Set]') {
     return !value.size
   }
   if (isPrototype(value)) {

--- a/isError.js
+++ b/isError.js
@@ -23,7 +23,7 @@ function isError(value) {
     return false
   }
   const tag = getTag(value)
-  return tag == '[object Error]' || tag == '[object DOMException]' ||
+  return tag === '[object Error]' || tag === '[object DOMException]' ||
     (typeof value.message === 'string' && typeof value.name === 'string' && !isPlainObject(value))
 }
 

--- a/isLength.js
+++ b/isLength.js
@@ -27,7 +27,7 @@ const MAX_SAFE_INTEGER = 9007199254740991
  */
 function isLength(value) {
   return typeof value === 'number' &&
-    value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER
+    value > -1 && value % 1 === 0 && value <= MAX_SAFE_INTEGER
 }
 
 export default isLength

--- a/isMap.js
+++ b/isMap.js
@@ -22,6 +22,6 @@ const nodeIsMap = nodeTypes && nodeTypes.isMap
  */
 const isMap = nodeIsMap
   ? (value) => nodeIsMap(value)
-  : (value) => isObjectLike(value) && getTag(value) == '[object Map]'
+  : (value) => isObjectLike(value) && getTag(value) === '[object Map]'
 
 export default isMap

--- a/isNumber.js
+++ b/isNumber.js
@@ -28,7 +28,7 @@ import isObjectLike from './isObjectLike.js'
  */
 function isNumber(value) {
   return typeof value === 'number' ||
-    (isObjectLike(value) && getTag(value) == '[object Number]')
+    (isObjectLike(value) && getTag(value) === '[object Number]')
 }
 
 export default isNumber

--- a/isPlainObject.js
+++ b/isPlainObject.js
@@ -28,7 +28,7 @@ import isObjectLike from './isObjectLike.js'
  * // => true
  */
 function isPlainObject(value) {
-  if (!isObjectLike(value) || getTag(value) != '[object Object]') {
+  if (!isObjectLike(value) || getTag(value) !== '[object Object]') {
     return false
   }
   if (Object.getPrototypeOf(value) === null) {

--- a/isRegExp.js
+++ b/isRegExp.js
@@ -22,6 +22,6 @@ const nodeIsRegExp = nodeTypes && nodeTypes.isRegExp
  */
 const isRegExp = nodeIsRegExp
   ? (value) => nodeIsRegExp(value)
-  : (value) => isObjectLike(value) && getTag(value) == '[object RegExp]'
+  : (value) => isObjectLike(value) && getTag(value) === '[object RegExp]'
 
 export default isRegExp

--- a/isSet.js
+++ b/isSet.js
@@ -22,6 +22,6 @@ const nodeIsSet = nodeTypes && nodeTypes.isSet
  */
 const isSet = nodeIsSet
   ? (value) => nodeIsSet(value)
-  : (value) => isObjectLike(value) && getTag(value) == '[object Set]'
+  : (value) => isObjectLike(value) && getTag(value) === '[object Set]'
 
 export default isSet

--- a/isString.js
+++ b/isString.js
@@ -17,7 +17,7 @@ import getTag from './.internal/getTag.js'
  */
 function isString(value) {
   const type = typeof value
-  return type === 'string' || (type === 'object' && value != null && !Array.isArray(value) && getTag(value) == '[object String]')
+  return type === 'string' || (type === 'object' && value != null && !Array.isArray(value) && getTag(value) === '[object String]')
 }
 
 export default isString

--- a/isSymbol.js
+++ b/isSymbol.js
@@ -17,7 +17,7 @@ import getTag from './.internal/getTag.js'
  */
 function isSymbol(value) {
   const type = typeof value
-  return type == 'symbol' || (type === 'object' && value != null && getTag(value) == '[object Symbol]')
+  return type === 'symbol' || (type === 'object' && value != null && getTag(value) === '[object Symbol]')
 }
 
 export default isSymbol

--- a/isWeakMap.js
+++ b/isWeakMap.js
@@ -17,7 +17,7 @@ import isObjectLike from './isObjectLike.js'
  * // => false
  */
 function isWeakMap(value) {
-  return isObjectLike(value) && getTag(value) == '[object WeakMap]'
+  return isObjectLike(value) && getTag(value) === '[object WeakMap]'
 }
 
 export default isWeakMap

--- a/isWeakSet.js
+++ b/isWeakSet.js
@@ -17,7 +17,7 @@ import isObjectLike from './isObjectLike.js'
  * // => false
  */
 function isWeakSet(value) {
-  return isObjectLike(value) && getTag(value) == '[object WeakSet]'
+  return isObjectLike(value) && getTag(value) === '[object WeakSet]'
 }
 
 export default isWeakSet

--- a/remove.js
+++ b/remove.js
@@ -17,7 +17,7 @@ import basePullAt from './.internal/basePullAt.js'
  * @example
  *
  * const array = [1, 2, 3, 4]
- * const evens = remove(array, n => n % 2 == 0)
+ * const evens = remove(array, n => n % 2 === 0)
  *
  * console.log(array)
  * // => [1, 3]

--- a/size.js
+++ b/size.js
@@ -34,7 +34,7 @@ function size(collection) {
     return isString(collection) ? stringSize(collection) : collection.length
   }
   const tag = getTag(collection)
-  if (tag == mapTag || tag == setTag) {
+  if (tag === mapTag || tag === setTag) {
     return collection.size
   }
   return Object.keys(collection).length

--- a/startsWith.js
+++ b/startsWith.js
@@ -30,7 +30,7 @@ function startsWith(string, target, position) {
     position = length
   }
   target = `${target}`
-  return string.slice(position, position + target.length) == target
+  return string.slice(position, position + target.length) === target
 }
 
 export default startsWith

--- a/test/at.test.js
+++ b/test/at.test.js
@@ -106,7 +106,7 @@ describe('at', function() {
 
       assert.strictEqual(count, expected);
 
-      expected = index == 3 ? [] : [index == 2 ? undefined : square(lastIndex)];
+      expected = index === 3 ? [] : [index === 2 ? undefined : square(lastIndex)];
       assert.deepEqual(actual, expected);
     });
   });

--- a/test/case-methods.test.js
+++ b/test/case-methods.test.js
@@ -40,7 +40,7 @@ describe('case methods', function() {
 
     it('`_.' + methodName + '` should convert `string` to ' + caseName + ' case', function() {
       var actual = lodashStable.map(strings, function(string) {
-        var expected = (caseName == 'start' && string == 'FOO BAR') ? string : converted;
+        var expected = (caseName === 'start' && string === 'FOO BAR') ? string : converted;
         return func(string) === expected;
       });
 
@@ -49,7 +49,7 @@ describe('case methods', function() {
 
     it('`_.' + methodName + '` should handle double-converting strings', function() {
       var actual = lodashStable.map(strings, function(string) {
-        var expected = (caseName == 'start' && string == 'FOO BAR') ? string : converted;
+        var expected = (caseName === 'start' && string === 'FOO BAR') ? string : converted;
         return func(func(string)) === expected;
       });
 

--- a/test/chain.js
+++ b/test/chain.js
@@ -51,8 +51,8 @@ describe('chain', function() {
       wrapped = index ? _(array).chain() : chain(array);
       actual = wrapped
         .chain()
-        .filter(function(n) { return n % 2 != 0; })
-        .reject(function(n) { return n % 3 == 0; })
+        .filter(function(n) { return n % 2 !== 0; })
+        .reject(function(n) { return n % 3 === 0; })
         .sortBy(function(n) { return -n; })
         .value();
 

--- a/test/clone-methods.js
+++ b/test/clone-methods.js
@@ -124,14 +124,14 @@ describe('clone methods', function() {
     });
 
     assert.ok(isNpm
-      ? actual.constructor.name == 'Stack'
+      ? actual.constructor.name === 'Stack'
       : actual instanceof mapCaches.Stack
     );
   });
 
   lodashStable.each(['clone', 'cloneDeep'], function(methodName) {
     var func = _[methodName],
-        isDeep = methodName == 'cloneDeep';
+        isDeep = methodName === 'cloneDeep';
 
     lodashStable.forOwn(objects, function(object, kind) {
       it('`_.' + methodName + '` should clone ' + kind, function() {
@@ -388,7 +388,7 @@ describe('clone methods', function() {
 
   lodashStable.each(['cloneWith', 'cloneDeepWith'], function(methodName) {
     var func = _[methodName],
-        isDeep = methodName == 'cloneDeepWith';
+        isDeep = methodName === 'cloneDeepWith';
 
     it('`_.' + methodName + '` should provide correct `customizer` arguments', function() {
       var argsList = [],

--- a/test/conforms-methods.js
+++ b/test/conforms-methods.js
@@ -5,7 +5,7 @@ import conformsTo from '../conformsTo.js';
 
 describe('conforms methods', function() {
   lodashStable.each(['conforms', 'conformsTo'], function(methodName) {
-    var isConforms = methodName == 'conforms';
+    var isConforms = methodName === 'conforms';
 
     function conforms(source) {
       return isConforms ? _.conforms(source) : function(object) {

--- a/test/curry-methods.js
+++ b/test/curry-methods.js
@@ -7,7 +7,7 @@ describe('curry methods', function() {
   lodashStable.each(['curry', 'curryRight'], function(methodName) {
     var func = _[methodName],
         fn = function(a, b) { return slice.call(arguments); },
-        isCurry = methodName == 'curry';
+        isCurry = methodName === 'curry';
 
     it('`_.' + methodName + '` should not error on functions with the same name as lodash methods', function() {
       function run(a, b) {

--- a/test/debounce-and-throttle.js
+++ b/test/debounce-and-throttle.js
@@ -6,7 +6,7 @@ import runInContext from '../runInContext.js';
 describe('debounce and throttle', function() {
   lodashStable.each(['debounce', 'throttle'], function(methodName) {
     var func = _[methodName],
-        isDebounce = methodName == 'debounce';
+        isDebounce = methodName === 'debounce';
 
     it('`_.' + methodName + '` should not error for non-object `options` values', function() {
       func(noop, 32, 1);
@@ -76,7 +76,7 @@ describe('debounce and throttle', function() {
         var lodash = runInContext({
           'Date': {
             'now': function() {
-              return ++dateCount == 4
+              return ++dateCount === 4
                 ? +new Date(2012, 3, 23, 23, 27, 18)
                 : +new Date;
             }

--- a/test/debounce.test.js
+++ b/test/debounce.test.js
@@ -233,7 +233,7 @@ describe('debounce', function() {
     var debounced = debounce(function(value) {
       actual = [this];
       push.apply(actual, arguments);
-      return ++callCount != 2;
+      return ++callCount !== 2;
     }, 32, { 'leading': true, 'maxWait': 64 });
 
     while (true) {

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -57,9 +57,9 @@ describe('dropWhile', function() {
     var array = lodashStable.range(1, LARGE_ARRAY_SIZE + 3);
 
     var actual = _(array)
-      .dropWhile(function(n) { return n == 1; })
+      .dropWhile(function(n) { return n === 1; })
       .drop()
-      .dropWhile(function(n) { return n == 3; })
+      .dropWhile(function(n) { return n === 3; })
       .value();
 
     assert.deepEqual(actual, array.slice(3));

--- a/test/extremum-methods.js
+++ b/test/extremum-methods.js
@@ -28,7 +28,7 @@ describe('extremum methods', function() {
   lodashStable.each(['maxBy', 'minBy'], function(methodName) {
     var array = [1, 2, 3],
         func = _[methodName],
-        isMax = methodName == 'maxBy';
+        isMax = methodName === 'maxBy';
 
     it('`_.' + methodName + '` should work with an `iteratee`', function() {
       var actual = func(array, function(n) {

--- a/test/filter-methods.js
+++ b/test/filter-methods.js
@@ -6,7 +6,7 @@ describe('filter methods', function() {
   lodashStable.each(['filter', 'reject'], function(methodName) {
     var array = [1, 2, 3, 4],
         func = _[methodName],
-        isFilter = methodName == 'filter',
+        isFilter = methodName === 'filter',
         objects = [{ 'a': 0 }, { 'a': 1 }];
 
     it('`_.' + methodName + '` should not modify the resulting value from within `predicate`', function() {

--- a/test/find-and-findLast.js
+++ b/test/find-and-findLast.js
@@ -4,7 +4,7 @@ import { LARGE_ARRAY_SIZE, square, isEven } from './utils.js';
 
 describe('find and findLast', function() {
   lodashStable.each(['find', 'findLast'], function(methodName) {
-    var isFind = methodName == 'find';
+    var isFind = methodName === 'find';
 
     it('`_.' + methodName + '` should support shortcut fusion', function() {
       var findCount = 0,

--- a/test/find-and-includes.js
+++ b/test/find-and-includes.js
@@ -5,8 +5,8 @@ import { _, identity, args, falsey } from './utils.js';
 describe('find and includes', function() {
   lodashStable.each(['includes', 'find'], function(methodName) {
     var func = _[methodName],
-        isIncludes = methodName == 'includes',
-        resolve = methodName == 'find' ? lodashStable.curry(lodashStable.eq) : identity;
+        isIncludes = methodName === 'includes',
+        resolve = methodName === 'find' ? lodashStable.curry(lodashStable.eq) : identity;
 
     lodashStable.each({
       'an `arguments` object': args,

--- a/test/findLastIndex-and-lastIndexOf.test.js
+++ b/test/findLastIndex-and-lastIndexOf.test.js
@@ -13,7 +13,7 @@ describe('findLastIndex and lastIndexOf', function() {
   lodashStable.each(['findLastIndex', 'lastIndexOf'], function(methodName) {
     var array = [1, 2, 3, 1, 2, 3],
         func = methods[methodName],
-        resolve = methodName == 'findLastIndex' ? lodashStable.curry(lodashStable.eq) : identity;
+        resolve = methodName === 'findLastIndex' ? lodashStable.curry(lodashStable.eq) : identity;
 
     it('`_.' + methodName + '` should return the index of the last matched value', function() {
       assert.strictEqual(func(array, resolve(3)), 5);

--- a/test/flatten-methods.js
+++ b/test/flatten-methods.js
@@ -51,9 +51,9 @@ describe('flatten methods', function() {
       var expected = Array(5e5);
       try {
         var func = flatten;
-        if (index == 1) {
+        if (index === 1) {
           func = flattenDeep;
-        } else if (index == 2) {
+        } else if (index === 2) {
           func = flattenDepth;
         }
         assert.deepStrictEqual(func([expected]), expected);

--- a/test/flow-methods.test.js
+++ b/test/flow-methods.test.js
@@ -15,7 +15,7 @@ const methods = {
 describe('flow methods', function() {
   lodashStable.each(['flow', 'flowRight'], function(methodName) {
     var func = methods[methodName],
-        isFlow = methodName == 'flow';
+        isFlow = methodName === 'flow';
 
     it('`_.' + methodName + '` should supply each function with the return value of the previous', function() {
       var fixed = function(n) { return n.toFixed(1); },

--- a/test/has-methods.js
+++ b/test/has-methods.js
@@ -5,7 +5,7 @@ import { _, toArgs, stubTrue, args, symbol, defineProperty, stubFalse } from './
 describe('has methods', function() {
   lodashStable.each(['has', 'hasIn'], function(methodName) {
     var func = _[methodName],
-        isHas = methodName == 'has',
+        isHas = methodName === 'has',
         sparseArgs = toArgs([1]),
         sparseArray = Array(1),
         sparseString = Object('a');

--- a/test/includes.js
+++ b/test/includes.js
@@ -62,7 +62,7 @@ describe('includes', function() {
           indexes = [4, 6, Math.pow(2, 32), Infinity];
 
       var expected = lodashStable.map(indexes, function(index) {
-        return [false, false, index == length];
+        return [false, false, index === length];
       });
 
       var actual = lodashStable.map(indexes, function(fromIndex) {

--- a/test/isFunction.js
+++ b/test/isFunction.js
@@ -40,7 +40,7 @@ describe('isFunction', function() {
 
   it('should return `true` for array view constructors', function() {
     var expected = lodashStable.map(arrayViews, function(type) {
-      return objToString.call(root[type]) == funcTag;
+      return objToString.call(root[type]) === funcTag;
     });
 
     var actual = lodashStable.map(arrayViews, function(type) {

--- a/test/isInteger-methods.js
+++ b/test/isInteger-methods.js
@@ -5,7 +5,7 @@ import { _, stubTrue, MAX_INTEGER, stubFalse, falsey, args, symbol } from './uti
 describe('isInteger methods', function() {
   lodashStable.each(['isInteger', 'isSafeInteger'], function(methodName) {
     var func = _[methodName],
-        isSafe = methodName == 'isSafeInteger';
+        isSafe = methodName === 'isSafeInteger';
 
     it('`_.' + methodName + '` should return `true` for integer values', function() {
       var values = [-1, 0, 1],

--- a/test/isMatchWith.js
+++ b/test/isMatchWith.js
@@ -79,7 +79,7 @@ describe('isMatchWith', function() {
     });
 
     assert.ok(isNpm
-      ? actual.constructor.name == 'Stack'
+      ? actual.constructor.name === 'Stack'
       : actual instanceof mapCaches.Stack
     );
   });

--- a/test/isType-checks.js
+++ b/test/isType-checks.js
@@ -14,7 +14,7 @@ describe('isType checks', function() {
       Foo.prototype = root[methodName.slice(2)].prototype;
 
       var object = new Foo;
-      if (objToString.call(object) == objectTag) {
+      if (objToString.call(object) === objectTag) {
         assert.strictEqual(_[methodName](object), false, '`_.' + methodName + '` returns `false`');
       }
     });

--- a/test/iteration-methods.js
+++ b/test/iteration-methods.js
@@ -128,7 +128,7 @@ describe('iteration methods', function() {
         isBy = /(^partition|By)$/.test(methodName),
         isFind = /^find/.test(methodName),
         isOmitPick = /^(?:omit|pick)By$/.test(methodName),
-        isSome = methodName == 'some';
+        isSome = methodName === 'some';
 
     it('`_.' + methodName + '` should provide correct iteratee arguments', function() {
       if (func) {
@@ -190,7 +190,7 @@ describe('iteration methods', function() {
   lodashStable.each(lodashStable.difference(methods, objectMethods), function(methodName) {
     var array = [1, 2, 3],
         func = _[methodName],
-        isEvery = methodName == 'every';
+        isEvery = methodName === 'every';
 
     array.a = 1;
 
@@ -209,7 +209,7 @@ describe('iteration methods', function() {
 
   lodashStable.each(lodashStable.difference(methods, unwrappedMethods), function(methodName) {
     var array = [1, 2, 3],
-        isBaseEach = methodName == '_baseEach';
+        isBaseEach = methodName === '_baseEach';
 
     it('`_.' + methodName + '` should return a wrapped value when implicitly chaining', function() {
       if (!(isBaseEach || isNpm)) {
@@ -295,7 +295,7 @@ describe('iteration methods', function() {
   lodashStable.each(methods, function(methodName) {
     var func = _[methodName],
         isFind = /^find/.test(methodName),
-        isSome = methodName == 'some',
+        isSome = methodName === 'some',
         isReduce = /^reduce/.test(methodName);
 
     it('`_.' + methodName + '` should ignore changes to `length`', function() {
@@ -304,7 +304,7 @@ describe('iteration methods', function() {
             array = [1];
 
         func(array, function() {
-          if (++count == 1) {
+          if (++count === 1) {
             array.push(2);
           }
           return !(isFind || isSome);
@@ -318,7 +318,7 @@ describe('iteration methods', function() {
   lodashStable.each(lodashStable.difference(lodashStable.union(methods, collectionMethods), arrayMethods), function(methodName) {
     var func = _[methodName],
         isFind = /^find/.test(methodName),
-        isSome = methodName == 'some',
+        isSome = methodName === 'some',
         isReduce = /^reduce/.test(methodName);
 
     it('`_.' + methodName + '` should ignore added `object` properties', function() {
@@ -327,7 +327,7 @@ describe('iteration methods', function() {
             object = { 'a': 1 };
 
         func(object, function() {
-          if (++count == 1) {
+          if (++count === 1) {
             object.b = 2;
           }
           return !(isFind || isSome);

--- a/test/keys-methods.js
+++ b/test/keys-methods.js
@@ -16,7 +16,7 @@ import {
 describe('keys methods', function() {
   lodashStable.each(['keys', 'keysIn'], function(methodName) {
     var func = _[methodName],
-        isKeys = methodName == 'keys';
+        isKeys = methodName === 'keys';
 
     it('`_.' + methodName + '` should return the string keyed property names of `object`', function() {
       var actual = func({ 'a': 1, 'b': 1 }).sort();

--- a/test/lodash(...)-methods-that-return-new-wrapped-values.js
+++ b/test/lodash(...)-methods-that-return-new-wrapped-values.js
@@ -34,7 +34,7 @@ describe('lodash(...) methods that return new wrapped values', function() {
 
   lodashStable.each(funcs, function(methodName) {
     it('`_(...).' + methodName + '` should return a new wrapped value', function() {
-      var value = methodName == 'split' ? 'abc' : [1, 2, 3],
+      var value = methodName === 'split' ? 'abc' : [1, 2, 3],
           wrapped = _(value),
           actual = wrapped[methodName]();
 

--- a/test/lodash-methods.js
+++ b/test/lodash-methods.js
@@ -103,13 +103,13 @@ describe('lodash methods', function() {
         return index ? func(value) : func();
       });
 
-      if (methodName == 'noConflict') {
+      if (methodName === 'noConflict') {
         root._ = oldDash;
       }
-      else if (methodName == 'pull' || methodName == 'pullAll') {
+      else if (methodName === 'pull' || methodName === 'pullAll') {
         expected = falsey;
       }
-      if (lodashStable.includes(returnArrays, methodName) && methodName != 'sample') {
+      if (lodashStable.includes(returnArrays, methodName) && methodName !== 'sample') {
         assert.deepStrictEqual(actual, expected, '_.' + methodName + ' returns an array');
       }
       assert.ok(true, '`_.' + methodName + '` accepts falsey arguments');
@@ -140,7 +140,7 @@ describe('lodash methods', function() {
       }
       assert.ok(lodashStable.isArray(actual), '_.' + methodName + ' returns an array');
 
-      var isPull = methodName == 'pull' || methodName == 'pullAll';
+      var isPull = methodName === 'pull' || methodName === 'pullAll';
       assert.strictEqual(actual === array, isPull, '_.' + methodName + ' should ' + (isPull ? '' : 'not ') + 'return the given array');
     });
   });
@@ -157,7 +157,7 @@ describe('lodash methods', function() {
           index ? func(value) : func();
         } catch (e) {
           pass = !pass && (e instanceof TypeError) &&
-            (!lodashStable.includes(checkFuncs, methodName) || (e.message == FUNC_ERROR_TEXT));
+            (!lodashStable.includes(checkFuncs, methodName) || (e.message === FUNC_ERROR_TEXT));
         }
         return pass;
       });
@@ -170,7 +170,7 @@ describe('lodash methods', function() {
     lodashStable.each(noBinding, function(methodName) {
       var fn = function() { return this.a; },
           func = _[methodName],
-          isNegate = methodName == 'negate',
+          isNegate = methodName === 'negate',
           object = { 'a': 1 },
           expected = isNegate ? false : 1;
 

--- a/test/matches-methods.js
+++ b/test/matches-methods.js
@@ -5,7 +5,7 @@ import isMatch from '../isMatch.js';
 
 describe('matches methods', function() {
   lodashStable.each(['matches', 'isMatch'], function(methodName) {
-    var isMatches = methodName == 'matches';
+    var isMatches = methodName === 'matches';
 
     function matches(source) {
       return isMatches ? _.matches(source) : function(object) {

--- a/test/math-operator-methods.js
+++ b/test/math-operator-methods.js
@@ -5,7 +5,7 @@ import { _, symbol } from './utils.js';
 describe('math operator methods', function() {
   lodashStable.each(['add', 'divide', 'multiply', 'subtract'], function(methodName) {
     var func = _[methodName],
-        isAddSub = methodName == 'add' || methodName == 'subtract';
+        isAddSub = methodName === 'add' || methodName === 'subtract';
 
     it('`_.' + methodName + '` should return `' + (isAddSub ? 0 : 1) + '` when no arguments are given', function() {
       assert.strictEqual(func(), isAddSub ? 0 : 1);

--- a/test/mergeWith.js
+++ b/test/mergeWith.js
@@ -37,7 +37,7 @@ describe('mergeWith', function() {
     });
 
     assert.ok(isNpm
-      ? actual.constructor.name == 'Stack'
+      ? actual.constructor.name === 'Stack'
       : actual instanceof mapCaches.Stack
     );
   });

--- a/test/negate.js
+++ b/test/negate.js
@@ -31,7 +31,7 @@ describe('negate', function() {
         case 3: negate(1, 2, 3); break;
         case 4: negate(1, 2, 3, 4);
       }
-      return argCount == index;
+      return argCount === index;
     });
 
     assert.deepStrictEqual(actual, expected);

--- a/test/number-coercion-methods.js
+++ b/test/number-coercion-methods.js
@@ -35,10 +35,10 @@ describe('number coercion methods', function() {
 
   lodashStable.each(['toFinite', 'toInteger', 'toLength', 'toNumber', 'toSafeInteger'], function(methodName) {
     var func = _[methodName],
-        isToFinite = methodName == 'toFinite',
-        isToLength = methodName == 'toLength',
-        isToNumber = methodName == 'toNumber',
-        isToSafeInteger = methodName == 'toSafeInteger';
+        isToFinite = methodName === 'toFinite',
+        isToLength = methodName === 'toLength',
+        isToNumber = methodName === 'toNumber',
+        isToSafeInteger = methodName === 'toSafeInteger';
 
     function negative(string) {
       return '-' + string;
@@ -69,10 +69,10 @@ describe('number coercion methods', function() {
 
       var expected = lodashStable.map(values, function(value) {
         if (!isToNumber) {
-          if (!isToFinite && value == 1.2) {
+          if (!isToFinite && value === 1.2) {
             value = 1;
           }
-          else if (value == Infinity) {
+          else if (value === Infinity) {
             value = MAX_INTEGER;
           }
           else if (value !== value) {
@@ -106,13 +106,13 @@ describe('number coercion methods', function() {
       var expected = lodashStable.map(values, function(value) {
         var n = +value;
         if (!isToNumber) {
-          if (!isToFinite && n == 1.234567890) {
+          if (!isToFinite && n === 1.234567890) {
             n = 1;
           }
-          else if (n == Infinity) {
+          else if (n === Infinity) {
             n = MAX_INTEGER;
           }
-          else if ((!isToFinite && n == Number.MIN_VALUE) || n !== n) {
+          else if ((!isToFinite && n === Number.MIN_VALUE) || n !== n) {
             n = 0;
           }
           if (isToLength || isToSafeInteger) {

--- a/test/object-assignments.js
+++ b/test/object-assignments.js
@@ -6,7 +6,7 @@ import has from '../has.js';
 describe('object assignments', function() {
   lodashStable.each(['assign', 'assignIn', 'defaults', 'defaultsDeep', 'merge'], function(methodName) {
     var func = _[methodName],
-        isAssign = methodName == 'assign',
+        isAssign = methodName === 'assign',
         isDefaults = /^defaults/.test(methodName);
 
     it('`_.' + methodName + '` should coerce primitives to objects', function() {
@@ -123,7 +123,7 @@ describe('object assignments', function() {
 
   lodashStable.each(['assignWith', 'assignInWith', 'mergeWith'], function(methodName) {
     var func = _[methodName],
-        isMergeWith = methodName == 'mergeWith';
+        isMergeWith = methodName === 'mergeWith';
 
     it('`_.' + methodName + '` should provide correct `customizer` arguments', function() {
       var args,

--- a/test/omit-methods.js
+++ b/test/omit-methods.js
@@ -9,7 +9,7 @@ describe('omit methods', function() {
         object = { 'a': 1, 'b': 2, 'c': 3, 'd': 4 },
         resolve = lodashStable.nthArg(1);
 
-    if (methodName == 'omitBy') {
+    if (methodName === 'omitBy') {
       resolve = function(object, props) {
         props = lodashStable.castArray(props);
         return function(value) {

--- a/test/omitBy.js
+++ b/test/omitBy.js
@@ -6,7 +6,7 @@ describe('omitBy', function() {
     var object = { 'a': 1, 'b': 2, 'c': 3, 'd': 4 };
 
     var actual = omitBy(object, function(n) {
-      return n != 2 && n != 4;
+      return n !== 2 && n !== 4;
     });
 
     assert.deepStrictEqual(actual, { 'b': 2, 'd': 4 });

--- a/test/pad-methods.js
+++ b/test/pad-methods.js
@@ -6,8 +6,8 @@ import pad from '../pad.js';
 describe('pad methods', function() {
   lodashStable.each(['pad', 'padStart', 'padEnd'], function(methodName) {
     var func = _[methodName],
-        isPad = methodName == 'pad',
-        isStart = methodName == 'padStart',
+        isPad = methodName === 'pad',
+        isStart = methodName === 'padStart',
         string = 'abc';
 
     it('`_.' + methodName + '` should not pad if string is >= `length`', function() {

--- a/test/partial-methods.js
+++ b/test/partial-methods.js
@@ -7,7 +7,7 @@ import curry from '../curry.js';
 describe('partial methods', function() {
   lodashStable.each(['partial', 'partialRight'], function(methodName) {
     var func = _[methodName],
-        isPartial = methodName == 'partial',
+        isPartial = methodName === 'partial',
         ph = func.placeholder;
 
     it('`_.' + methodName + '` partially applies arguments', function() {

--- a/test/pick-methods.js
+++ b/test/pick-methods.js
@@ -6,11 +6,11 @@ describe('pick methods', function() {
   lodashStable.each(['pick', 'pickBy'], function(methodName) {
     var expected = { 'a': 1, 'c': 3 },
         func = _[methodName],
-        isPick = methodName == 'pick',
+        isPick = methodName === 'pick',
         object = { 'a': 1, 'b': 2, 'c': 3, 'd': 4 },
         resolve = lodashStable.nthArg(1);
 
-    if (methodName == 'pickBy') {
+    if (methodName === 'pickBy') {
       resolve = function(object, props) {
         props = lodashStable.castArray(props);
         return function(value) {

--- a/test/pickBy.test.js
+++ b/test/pickBy.test.js
@@ -7,7 +7,7 @@ describe('pickBy', function() {
     var object = { 'a': 1, 'b': 2, 'c': 3, 'd': 4 };
 
     var actual = pickBy(object, function(n) {
-      return n == 1 || n == 3;
+      return n === 1 || n === 3;
     });
 
     assert.deepStrictEqual(actual, { 'a': 1, 'c': 3 });

--- a/test/pull-methods.js
+++ b/test/pull-methods.js
@@ -5,7 +5,7 @@ import { _ } from './utils.js';
 describe('pull methods', function() {
   lodashStable.each(['pull', 'pullAll', 'pullAllWith'], function(methodName) {
     var func = _[methodName],
-        isPull = methodName == 'pull';
+        isPull = methodName === 'pull';
 
     function pull(array, values) {
       return isPull

--- a/test/random.js
+++ b/test/random.js
@@ -96,7 +96,7 @@ describe('random', function() {
         randoms = lodashStable.map(array, random);
 
     var actual = lodashStable.map(randoms, function(result, index) {
-      return result >= 0 && result <= array[index] && (result % 1) == 0;
+      return result >= 0 && result <= array[index] && (result % 1) === 0;
     });
 
     assert.deepStrictEqual(actual, expected);

--- a/test/range-methods.js
+++ b/test/range-methods.js
@@ -5,7 +5,7 @@ import { _, falsey } from './utils.js';
 describe('range methods', function() {
   lodashStable.each(['range', 'rangeRight'], function(methodName) {
     var func = _[methodName],
-        isRange = methodName == 'range';
+        isRange = methodName === 'range';
 
     function resolve(range) {
       return isRange ? range : range.reverse();

--- a/test/reduce-methods.js
+++ b/test/reduce-methods.js
@@ -6,7 +6,7 @@ describe('reduce methods', function() {
   lodashStable.each(['reduce', 'reduceRight'], function(methodName) {
     var func = _[methodName],
         array = [1, 2, 3],
-        isReduce = methodName == 'reduce';
+        isReduce = methodName === 'reduce';
 
     it('`_.' + methodName + '` should reduce a collection to a single value', function() {
       var actual = func(['a', 'b', 'c'], function(accumulator, value) {

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -33,7 +33,7 @@ describe('reduce', function() {
         object = { 'a': 1, 'b': 2 },
         firstKey = head(keys(object));
 
-    var expected = firstKey == 'a'
+    var expected = firstKey === 'a'
       ? [0, 1, 'a', object]
       : [0, 2, 'b', object];
 
@@ -44,7 +44,7 @@ describe('reduce', function() {
     assert.deepStrictEqual(args, expected);
 
     args = undefined;
-    expected = firstKey == 'a'
+    expected = firstKey === 'a'
       ? [1, 2, 'b', object]
       : [2, 1, 'a', object];
 

--- a/test/reduceRight.js
+++ b/test/reduceRight.js
@@ -30,7 +30,7 @@ describe('reduceRight', function() {
   it('should provide correct `iteratee` arguments when iterating an object', function() {
     var args,
         object = { 'a': 1, 'b': 2 },
-        isFIFO = lodashStable.keys(object)[0] == 'a';
+        isFIFO = lodashStable.keys(object)[0] === 'a';
 
     var expected = isFIFO
       ? [0, 2, 'b', object]

--- a/test/round-methods.js
+++ b/test/round-methods.js
@@ -6,8 +6,8 @@ import round from '../round.js';
 describe('round methods', function() {
   lodashStable.each(['ceil', 'floor', 'round'], function(methodName) {
     var func = _[methodName],
-        isCeil = methodName == 'ceil',
-        isFloor = methodName == 'floor';
+        isCeil = methodName === 'ceil',
+        isFloor = methodName === 'floor';
 
     it('`_.' + methodName + '` should return a rounded number without a precision', function() {
       var actual = func(4.006);

--- a/test/sortedIndex-methods.js
+++ b/test/sortedIndex-methods.js
@@ -6,7 +6,7 @@ import sortBy from '../sortBy.js';
 describe('sortedIndex methods', function() {
   lodashStable.each(['sortedIndex', 'sortedLastIndex'], function(methodName) {
     var func = _[methodName],
-        isSortedIndex = methodName == 'sortedIndex';
+        isSortedIndex = methodName === 'sortedIndex';
 
     it('`_.' + methodName + '` should return the insert index', function() {
       var array = [30, 50],

--- a/test/sortedIndexBy-methods.js
+++ b/test/sortedIndexBy-methods.js
@@ -5,7 +5,7 @@ import { _, slice, MAX_ARRAY_LENGTH, MAX_ARRAY_INDEX } from './utils.js';
 describe('sortedIndexBy methods', function() {
   lodashStable.each(['sortedIndexBy', 'sortedLastIndexBy'], function(methodName) {
     var func = _[methodName],
-        isSortedIndexBy = methodName == 'sortedIndexBy';
+        isSortedIndexBy = methodName === 'sortedIndexBy';
 
     it('`_.' + methodName + '` should provide correct `iteratee` arguments', function() {
       var args;
@@ -50,7 +50,7 @@ describe('sortedIndexBy methods', function() {
             ? 0
             : Math.min(length, MAX_ARRAY_INDEX);
 
-          assert.ok(steps == 32 || steps == 33);
+          assert.ok(steps === 32 || steps === 33);
           assert.strictEqual(actual, expected);
         });
       });

--- a/test/sortedIndexOf-methods.js
+++ b/test/sortedIndexOf-methods.js
@@ -5,7 +5,7 @@ import { _ } from './utils.js';
 describe('sortedIndexOf methods', function() {
   lodashStable.each(['sortedIndexOf', 'sortedLastIndexOf'], function(methodName) {
     var func = _[methodName],
-        isSortedIndexOf = methodName == 'sortedIndexOf';
+        isSortedIndexOf = methodName === 'sortedIndexOf';
 
     it('`_.' + methodName + '` should perform a binary search', function() {
       var sorted = [4, 4, 5, 5, 6, 6];

--- a/test/startsWith-and-endsWith.js
+++ b/test/startsWith-and-endsWith.js
@@ -5,7 +5,7 @@ import { _, MAX_SAFE_INTEGER } from './utils.js';
 describe('startsWith and endsWith', function() {
   lodashStable.each(['startsWith', 'endsWith'], function(methodName) {
     var func = _[methodName],
-        isStartsWith = methodName == 'startsWith';
+        isStartsWith = methodName === 'startsWith';
 
     var string = 'abc',
         chr = isStartsWith ? 'a' : 'c';

--- a/test/strict-mode-checks.js
+++ b/test/strict-mode-checks.js
@@ -5,7 +5,7 @@ import { _, isStrict, freeze } from './utils.js';
 describe('strict mode checks', function() {
   lodashStable.each(['assign', 'assignIn', 'bindAll', 'defaults', 'defaultsDeep', 'merge'], function(methodName) {
     var func = _[methodName],
-        isBindAll = methodName == 'bindAll';
+        isBindAll = methodName === 'bindAll';
 
     it('`_.' + methodName + '` should ' + (isStrict ? '' : 'not ') + 'throw strict mode errors', function() {
       var object = freeze({ 'a': undefined, 'b': function() {} }),

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -58,7 +58,7 @@ describe('takeWhile', function() {
     var actual = _(array)
       .takeWhile(function(n) { return n < 4; })
       .take(2)
-      .takeWhile(function(n) { return n == 0; })
+      .takeWhile(function(n) { return n === 0; })
       .value();
 
     assert.deepEqual(actual, [0]);

--- a/test/template.js
+++ b/test/template.js
@@ -284,7 +284,7 @@ describe('template', function() {
 
   it('should work with statements containing quotes', function() {
     var compiled = template("<%\
-      if (a == 'A' || a == \"a\") {\
+      if (a === 'A' || a === \"a\") {\
         %>'a',\"A\"<%\
       } %>"
     );

--- a/test/throttle.js
+++ b/test/throttle.js
@@ -47,7 +47,7 @@ describe('throttle', function() {
       var lodash = runInContext({
         'Date': {
           'now': function() {
-            return ++dateCount == 5 ? Infinity : +new Date;
+            return ++dateCount === 5 ? Infinity : +new Date;
           }
         }
       });

--- a/test/toInteger-methods.js
+++ b/test/toInteger-methods.js
@@ -5,7 +5,7 @@ import { _, MAX_SAFE_INTEGER, MAX_INTEGER } from './utils.js';
 describe('toInteger methods', function() {
   lodashStable.each(['toInteger', 'toSafeInteger'], function(methodName) {
     var func = _[methodName],
-        isSafe = methodName == 'toSafeInteger';
+        isSafe = methodName === 'toSafeInteger';
 
     it('`_.' + methodName + '` should convert values to integers', function() {
       assert.strictEqual(func(-5.6), -5);

--- a/test/toPairs-methods.js
+++ b/test/toPairs-methods.js
@@ -5,7 +5,7 @@ import { _ } from './utils.js';
 describe('toPairs methods', function() {
   lodashStable.each(['toPairs', 'toPairsIn'], function(methodName) {
     var func = _[methodName],
-        isToPairs = methodName == 'toPairs';
+        isToPairs = methodName === 'toPairs';
 
     it('`_.' + methodName + '` should create an array of string keyed-value pairs', function() {
       var object = { 'a': 1, 'b': 2 },

--- a/test/transform.js
+++ b/test/transform.js
@@ -170,7 +170,7 @@ describe('transform', function() {
       });
 
       var first = args[0];
-      if (key == 'array') {
+      if (key === 'array') {
         assert.ok(first !== object && lodashStable.isArray(first));
         assert.deepStrictEqual(args, [first, 1, 0, object]);
       } else {

--- a/test/trim-methods.js
+++ b/test/trim-methods.js
@@ -7,31 +7,31 @@ describe('trim methods', function() {
     var func = _[methodName],
         parts = [];
 
-    if (index != 2) {
+    if (index !== 2) {
       parts.push('leading');
     }
-    if (index != 1) {
+    if (index !== 1) {
       parts.push('trailing');
     }
     parts = parts.join(' and ');
 
     it('`_.' + methodName + '` should remove ' + parts + ' whitespace', function() {
       var string = whitespace + 'a b c' + whitespace,
-          expected = (index == 2 ? whitespace : '') + 'a b c' + (index == 1 ? whitespace : '');
+          expected = (index === 2 ? whitespace : '') + 'a b c' + (index === 1 ? whitespace : '');
 
       assert.strictEqual(func(string), expected);
     });
 
     it('`_.' + methodName + '` should coerce `string` to a string', function() {
       var object = { 'toString': lodashStable.constant(whitespace + 'a b c' + whitespace) },
-          expected = (index == 2 ? whitespace : '') + 'a b c' + (index == 1 ? whitespace : '');
+          expected = (index === 2 ? whitespace : '') + 'a b c' + (index === 1 ? whitespace : '');
 
       assert.strictEqual(func(object), expected);
     });
 
     it('`_.' + methodName + '` should remove ' + parts + ' `chars`', function() {
       var string = '-_-a-b-c-_-',
-          expected = (index == 2 ? '-_-' : '') + 'a-b-c' + (index == 1 ? '-_-' : '');
+          expected = (index === 2 ? '-_-' : '') + 'a-b-c' + (index === 1 ? '-_-' : '');
 
       assert.strictEqual(func(string, '_-'), expected);
     });
@@ -39,7 +39,7 @@ describe('trim methods', function() {
     it('`_.' + methodName + '` should coerce `chars` to a string', function() {
       var object = { 'toString': lodashStable.constant('_-') },
           string = '-_-a-b-c-_-',
-          expected = (index == 2 ? '-_-' : '') + 'a-b-c' + (index == 1 ? '-_-' : '');
+          expected = (index === 2 ? '-_-' : '') + 'a-b-c' + (index === 1 ? '-_-' : '');
 
       assert.strictEqual(func(string, object), expected);
     });
@@ -54,7 +54,7 @@ describe('trim methods', function() {
 
     it('`_.' + methodName + '` should work with `undefined` or empty string values for `chars`', function() {
       var string = whitespace + 'a b c' + whitespace,
-          expected = (index == 2 ? whitespace : '') + 'a b c' + (index == 1 ? whitespace : '');
+          expected = (index === 2 ? whitespace : '') + 'a b c' + (index === 1 ? whitespace : '');
 
       assert.strictEqual(func(string, undefined), expected);
       assert.strictEqual(func(string, ''), string);
@@ -62,7 +62,7 @@ describe('trim methods', function() {
 
     it('`_.' + methodName + '` should work as an iteratee for methods like `_.map`', function() {
       var string = Object(whitespace + 'a b c' + whitespace),
-          trimmed = (index == 2 ? whitespace : '') + 'a b c' + (index == 1 ? whitespace : ''),
+          trimmed = (index === 2 ? whitespace : '') + 'a b c' + (index === 1 ? whitespace : ''),
           actual = lodashStable.map([string, string, string], func);
 
       assert.deepStrictEqual(actual, [trimmed, trimmed, trimmed]);
@@ -70,7 +70,7 @@ describe('trim methods', function() {
 
     it('`_.' + methodName + '` should return an unwrapped value when implicitly chaining', function() {
       var string = whitespace + 'a b c' + whitespace,
-          expected = (index == 2 ? whitespace : '') + 'a b c' + (index == 1 ? whitespace : '');
+          expected = (index === 2 ? whitespace : '') + 'a b c' + (index === 1 ? whitespace : '');
 
       assert.strictEqual(_(string)[methodName](), expected);
     });

--- a/test/unionWith.test.js
+++ b/test/unionWith.test.js
@@ -16,7 +16,7 @@ describe('unionWith', function() {
         others = [{ 'x': 1, 'y': 2 }];
 
     var actual = unionWith(objects, others, function(a, b) {
-      return a.x == b.x;
+      return a.x === b.x;
     });
 
     assert.deepStrictEqual(actual, [{ 'x': 1, 'y': 1 }]);

--- a/test/uniqBy-methods.js
+++ b/test/uniqBy-methods.js
@@ -6,7 +6,7 @@ import sortBy from '../sortBy.js';
 describe('uniqBy methods', function() {
   lodashStable.each(['uniqBy', 'sortedUniqBy'], function(methodName) {
     var func = _[methodName],
-        isSorted = methodName == 'sortedUniqBy',
+        isSorted = methodName === 'sortedUniqBy',
         objects = [{ 'a': 2 }, { 'a': 3 }, { 'a': 1 }, { 'a': 2 }, { 'a': 3 }, { 'a': 1 }];
 
     if (isSorted) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -80,7 +80,7 @@ var arrayBuffer = ArrayBuffer ? new ArrayBuffer(2) : undefined,
 /** Math helpers. */
 var add = function(x, y) { return x + y; },
     doubled = function(n) { return n * 2; },
-    isEven = function(n) { return n % 2 == 0; },
+    isEven = function(n) { return n % 2 === 0; },
     square = function(n) { return n * n; };
 
 /** Stub functions. */
@@ -263,7 +263,7 @@ setProperty(root, 'setTimeout', setTimeout);
 
 /** Used to test Web Workers. */
 var Worker = !(ui.isForeign || ui.isSauceLabs || isModularize) &&
-  (document && document.origin != 'null') && root.Worker;
+  (document && document.origin !== 'null') && root.Worker;
 
 /** Poison the free variable `root` in Node.js */
 try {
@@ -486,7 +486,7 @@ function toArgs(array) {
 
   var _propertyIsEnumerable = objectProto.propertyIsEnumerable;
   setProperty(objectProto, 'propertyIsEnumerable', function(key) {
-    return !(key == 'valueOf' && this && this.valueOf === 1) && _propertyIsEnumerable.call(this, key);
+    return !(key === 'valueOf' && this && this.valueOf === 1) && _propertyIsEnumerable.call(this, key);
   });
 
   if (Buffer) {
@@ -497,7 +497,7 @@ function toArgs(array) {
         var caller = get.caller,
             name = caller ? caller.name : '';
 
-        if (!(name == 'runInContext' || name.length == 1 || /\b_\.isBuffer\b/.test(caller))) {
+        if (!(name === 'runInContext' || name.length === 1 || /\b_\.isBuffer\b/.test(caller))) {
           return Buffer;
         }
       }

--- a/test/values-methods.js
+++ b/test/values-methods.js
@@ -5,7 +5,7 @@ import { _, args, strictArgs } from './utils.js';
 describe('values methods', function() {
   lodashStable.each(['values', 'valuesIn'], function(methodName) {
     var func = _[methodName],
-        isValues = methodName == 'values';
+        isValues = methodName === 'values';
 
     it('`_.' + methodName + '` should get string keyed values of `object`', function() {
       var object = { 'a': 1, 'b': 2 },

--- a/test/zipObject-methods.js
+++ b/test/zipObject-methods.js
@@ -6,7 +6,7 @@ describe('zipObject methods', function() {
   lodashStable.each(['zipObject', 'zipObjectDeep'], function(methodName) {
     var func = _[methodName],
         object = { 'barney': 36, 'fred': 40 },
-        isDeep = methodName == 'zipObjectDeep';
+        isDeep = methodName === 'zipObjectDeep';
 
     it('`_.' + methodName + '` should zip together key/value arrays into an object', function() {
       var actual = func(['barney', 'fred'], [36, 40]);

--- a/toArray.js
+++ b/toArray.js
@@ -47,7 +47,7 @@ function toArray(value) {
     return iteratorToArray(value[symIterator]())
   }
   const tag = getTag(value)
-  const func = tag == mapTag ? mapToArray : (tag == setTag ? setToArray : values)
+  const func = tag === mapTag ? mapToArray : (tag === setTag ? setToArray : values)
 
   return func(value)
 }

--- a/toString.js
+++ b/toString.js
@@ -38,7 +38,7 @@ function toString(value) {
     return value.toString()
   }
   const result = `${value}`
-  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result
+  return (result === '0' && (1 / value) === -INFINITY) ? '-0' : result
 }
 
 export default toString

--- a/transform.js
+++ b/transform.js
@@ -24,7 +24,7 @@ import isTypedArray from './isTypedArray.js'
  *
  * transform([2, 3, 4], (result, n) => {
  *   result.push(n *= n)
- *   return n % 2 == 0
+ *   return n % 2 === 0
  * }, [])
  * // => [4, 9]
  *

--- a/truncate.js
+++ b/truncate.js
@@ -101,7 +101,7 @@ function truncate(string, options) {
       }
       result = result.slice(0, newEnd === undefined ? end : newEnd)
     }
-  } else if (string.indexOf(baseToString(separator), end) != end) {
+  } else if (string.indexOf(baseToString(separator), end) !== end) {
     const index = result.lastIndexOf(separator)
     if (index > -1) {
       result = result.slice(0, index)


### PR DESCRIPTION
I've noticed that there are already some PRs that do something similar to me, but they've only committed a few files.

I checked all the files in the project and replaced all `==` with `===` and `!=` with `!==` as much as possible.

The only thing that is not modified is about the `null` value, because the value being compared may be `null`, it may be `undefined`, in general, when we use `== null` or `!= null`, We may want to check if it is `null` or `undefined`.