### PR TITLE
Lodash's GroupBy Iterations Controlled By a Parameter and when its 1 , it Returns an Object of Objects .

### DIFF
--- a/groupBy.js
+++ b/groupBy.js
@@ -21,13 +21,15 @@ const hasOwnProperty = Object.prototype.hasOwnProperty
  * groupBy([6.1, 4.2, 6.3], Math.floor)
  * // => { '4': [4.2], '6': [6.1, 6.3] }
  */
-function groupBy(collection, iteratee) {
+ function groupBy(collection, iteratee, iteration) {
+  !iteration && (iteration = collection.length)
   return reduce(collection, (result, value, key) => {
     key = iteratee(value)
     if (hasOwnProperty.call(result, key)) {
-      result[key].push(value)
+      Array.isArray(result[key]) && !(result[key].length > iteration) && result[key].push(value)
     } else {
       baseAssignValue(result, key, [value])
+      iteration == 1 && (result[key] = value)
     }
     return result
   }, {})


### PR DESCRIPTION
Lodash's GroupBy Works in a way that it will always return an Object that each Key has its own array , but if you want to slice it to have no longer than a specific number of elements , You cannot do that with the same performance and you ave to  Loop through an Object Keys and Loop through each key value to slice it to a number.

I have added some modefications to Groupby.js that 

**1 -** now its accepting another parameter which is "Iterations" that by default its undefined and it works as GroupBy worked before if you dont pass anything ( Tests Success )

**2-** if you pass a number , it will make sure to not push any longer than that to the Array and it's same complexity for performance

**3-** If you pass 1 as iterations , it won't return you an Object of An Array per Key  ... instead it will return you an Object that each key is also an object ( rather than an array ) .. it will be easier in UI to Access that instead of accessing the key then Point to the First element of the Array to find the value.


:))