### PR TITLE
pref: use `===` instead of `==`

### DIFF
--- a/.internal/Hash.js
+++ b/.internal/Hash.js
@@ -12,7 +12,7 @@ class Hash {
    */
   constructor(entries) {
     let index = -1
-    const length = entries == null ? 0 : entries.length
+    const length = entries === null ? 0 : entries.length
 
     this.clear()
     while (++index < length) {


### PR DESCRIPTION
I saw there's already a PR [#5428](https://github.com/lodash/lodash/pull/5428) exist for migrating from `==` to `===`. However `.internals/Hash.js` file was missed by them.

Also noticeable that in most condition, `null` is being used which will be false when conditioning with `===`, that means when doing a condition with three equals `null` and `undefined` will be false.