### PR TITLE
fixing backlash display under "escapeRegExp"

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14324,7 +14324,7 @@
     }
 
     /**
-     * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+     * Escapes the `RegExp` special characters "^", "$", "\\", ".", "*", "+",
      * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
      *
      * @static


### PR DESCRIPTION
currently under escapeRegExp in the Lodash Documentation backlash display as empty string, since it is an escape character so adding two will display it correctly