### PR TITLE
fix(toString): handle plain objects (#5454)

### DIFF
--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -36,6 +36,20 @@ describe('toString', function() {
     assert.strictEqual(toString([symbol]), 'Symbol(a)');
   });
 
+  it('should handle objects', function() {
+    var values = [
+        Object.create(null),
+        Object('foo'),
+        Object(46),
+        String('bar'),
+        new Set([1, 2, 3])
+      ],
+        expected = ['[object Object]', 'foo', '46', 'bar', '[object Set]'],
+        actual = lodashStable.map(values, toString);
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
   it('should return the `toString` result of the wrapped value', function() {
     var wrapped = _([1, 2, 3]);
     assert.strictEqual(wrapped.toString(), '1,2,3');

--- a/toString.js
+++ b/toString.js
@@ -1,4 +1,5 @@
 import isSymbol from './isSymbol.js'
+import getTag from './.internal/getTag'
 
 /** Used as references for various `Number` constants. */
 const INFINITY = 1 / 0
@@ -36,6 +37,9 @@ function toString(value) {
   }
   if (isSymbol(value)) {
     return value.toString()
+  }
+  if (typeof value.toString !== 'function') {
+    return getTag(value)
   }
   const result = `${value}`
   return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result


### PR DESCRIPTION
The `toString` method can't handle the objects that doesn't have `toString` method

Refs: #5454 