### PR TITLE
fix: fix duplicate uniqueId generation (#5457)

### DIFF
--- a/test/uniqueId.test.js
+++ b/test/uniqueId.test.js
@@ -17,6 +17,22 @@ describe('uniqueId', function() {
 
   it('should coerce the prefix argument to a string', function() {
     var actual = [uniqueId(3), uniqueId(2), uniqueId(1)];
-    assert.ok(/3\d+,2\d+,1\d+/.test(actual));
+    assert.ok(/3_\d+,2_\d+,1_\d+/.test(actual));
+  });
+
+  it('should handle numeric prefixes properly', function() {
+    var firstId = uniqueId('1')
+    var moreIds = lodashStable.times(15, function() {
+      return uniqueId()
+    });
+    assert.ok(!moreIds.includes(firstId))
+  });
+
+  it('should properly handle prefixes that end with digits', function() {
+    var firstFooId = uniqueId('foo1')
+    var moreFooIds = lodashStable.times(15, function() {
+      return uniqueId('foo')
+    });
+    assert.ok(!moreFooIds.includes(firstFooId))
   });
 });

--- a/uniqueId.js
+++ b/uniqueId.js
@@ -17,17 +17,11 @@ const idCounter = {}
  * uniqueId()
  * // => '105'
  */
-function uniqueId(prefix='$lodash$') {
-  if (!idCounter[prefix]) {
-    idCounter[prefix] = 0
-  }
-
-  const id =++idCounter[prefix]
-  if (prefix === '$lodash$') {
-    return `${id}`
-  }
-
-  return `${prefix}${id}`
+function uniqueId(prefix='') {
+  prefix = String(prefix)
+  prefix += /\d$/.test(prefix) ? '_' : ''
+  idCounter[prefix] = (idCounter[prefix] || 0) + 1
+  return `${prefix}${idCounter[prefix]}`
 }
 
 export default uniqueId


### PR DESCRIPTION
Please see #5457: The _.uniqueId function could generate duplicates.

### Summary
When the `prefix` param ends with a numeric digit, `_.uniqueId` function could previously generate duplicate IDs. This PR introduces a fix, and two new test cases. The fixed `_.uniqueId` function passes all tests (new and old). Prior to the fix, the function didn't pass the newly added tests.

### Approach
If the prefix ends with a number, we append the `'_'` character to the prefix. That is, calling `_.uniqueId('foo1')` is equivalent to calling `_.uniqueId('foo1_')`. This way, `'foo1_1'`, `'foo1_2'` ... `'foo1_11'`, `'foo1_21'` ... `'foo1_{N}'` will all be unique. Without the appended underscore, `'foo111'` could arise as `'foo1' + '11'` or `'foo11' + '1'`. Similar, `foo121` could arise as `'foo1' + '21'` or `'foo12' + '1'`

Note that `'_'` is appended only if the supplied prefix ends with a number. So, if the prefix is `'contact_'`, like in the docs, it will remain `'contact_'`; an extra underscore won't be appended. (It won't become `'contact__'`). Similarly, if the prefix is just `contact`, no underscore will be appended. But if it is `'contact5'`, an underscore will be appended, making it equivalent to the prefix `'contact5_'`. 

This approach ensures that no matter the `prefix` supplied, the generated id is always unique. At it's core, it's pretty much unchanged. We're just handling numeber-ending prefixes a bit differently.

### Aside
Instead of relying on `'$lodash$'` as a reserved (default) prefix, this PR switches the default value to `''`. This is done in a backward compatible way, i.e. when `_.uniqueId()` is called with no argument, we continue to return a numeric string (with no prefix). And while this PR is not really related to #4357, it does address the concern therein too.