### PR TITLE
Fix baseFlatten's bug

### DIFF
--- a/.internal/baseFlatten.js
+++ b/.internal/baseFlatten.js
@@ -27,7 +27,7 @@ function baseFlatten(array, depth, predicate, isStrict, result) {
       } else {
         result.push(...value)
       }
-    } else if (!isStrict) {
+    } else if (!isStrict && value !== undefined) {
       result[result.length] = value
     }
   }


### PR DESCRIPTION
When using flatten to flatten an array, the following bugs occur, which is not the same as Array.prototype.flat.

```js
const arr = [1,,2,3,4]
console.log(arr.flat()) // [1,2,3,4]
console.log(_.flatten(arr)) [1, undefined, 2,3,4]
```
