### PR TITLE
⚡️reduction of lodash size at import

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "5.0.0",
   "license": "MIT",
   "private": true,
-  "main": "lodash.js",
+  "files": ["lodash.min.js"],
+  "main": "lodash.min.js",
   "engines": {
     "node": ">=4.0.0"
   },


### PR DESCRIPTION
Fix #5376 

Replacing main entry inside `package.json` by the minified file instead of  `lodash.js` and including the minified file through "files" package.json entry