### PR TITLE
docs: words is chainable by default

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -1631,7 +1631,7 @@
      * `toPairs`, `toPairsIn`, `toPath`, `toPlainObject`, `transform`, `unary`,
      * `union`, `unionBy`, `unionWith`, `uniq`, `uniqBy`, `uniqWith`, `unset`,
      * `unshift`, `unzip`, `unzipWith`, `update`, `updateWith`, `values`,
-     * `valuesIn`, `without`, `wrap`, `xor`, `xorBy`, `xorWith`, `zip`,
+     * `valuesIn`, `without`, `words`, `wrap`, `xor`, `xorBy`, `xorWith`, `zip`,
      * `zipObject`, `zipObjectDeep`, and `zipWith`
      *
      * The wrapper methods that are **not** chainable by default are:
@@ -1659,7 +1659,7 @@
      * `template`, `times`, `toFinite`, `toInteger`, `toJSON`, `toLength`,
      * `toLower`, `toNumber`, `toSafeInteger`, `toString`, `toUpper`, `trim`,
      * `trimEnd`, `trimStart`, `truncate`, `unescape`, `uniqueId`, `upperCase`,
-     * `upperFirst`, `value`, and `words`
+     * `upperFirst`, and `value`
      *
      * @name _
      * @constructor

--- a/doc/README.md
+++ b/doc/README.md
@@ -8609,7 +8609,7 @@ The chainable wrapper methods are:<br>
 `toPairs`, `toPairsIn`, `toPath`, `toPlainObject`, `transform`, `unary`,
 `union`, `unionBy`, `unionWith`, `uniq`, `uniqBy`, `uniqWith`, `unset`,
 `unshift`, `unzip`, `unzipWith`, `update`, `updateWith`, `values`,
-`valuesIn`, `without`, `wrap`, `xor`, `xorBy`, `xorWith`, `zip`,
+`valuesIn`, `without`, `words`, `wrap`, `xor`, `xorBy`, `xorWith`, `zip`,
 `zipObject`, `zipObjectDeep`, and `zipWith`
 <br>
 <br>
@@ -8638,7 +8638,7 @@ The wrapper methods that are **not** chainable by default are:<br>
 `template`, `times`, `toFinite`, `toInteger`, `toJSON`, `toLength`,
 `toLower`, `toNumber`, `toSafeInteger`, `toString`, `toUpper`, `trim`,
 `trimEnd`, `trimStart`, `truncate`, `unescape`, `uniqueId`, `upperCase`,
-`upperFirst`, `value`, and `words`
+`upperFirst`, and `value`
 
 #### Arguments
 1. `value` *(&#42;)*: The value to wrap in a `lodash` instance.

--- a/lodash.js
+++ b/lodash.js
@@ -1631,7 +1631,7 @@
      * `toPairs`, `toPairsIn`, `toPath`, `toPlainObject`, `transform`, `unary`,
      * `union`, `unionBy`, `unionWith`, `uniq`, `uniqBy`, `uniqWith`, `unset`,
      * `unshift`, `unzip`, `unzipWith`, `update`, `updateWith`, `values`,
-     * `valuesIn`, `without`, `wrap`, `xor`, `xorBy`, `xorWith`, `zip`,
+     * `valuesIn`, `without`, `words`, `wrap`, `xor`, `xorBy`, `xorWith`, `zip`,
      * `zipObject`, `zipObjectDeep`, and `zipWith`
      *
      * The wrapper methods that are **not** chainable by default are:
@@ -1659,7 +1659,7 @@
      * `template`, `times`, `toFinite`, `toInteger`, `toJSON`, `toLength`,
      * `toLower`, `toNumber`, `toSafeInteger`, `toString`, `toUpper`, `trim`,
      * `trimEnd`, `trimStart`, `truncate`, `unescape`, `uniqueId`, `upperCase`,
-     * `upperFirst`, `value`, and `words`
+     * `upperFirst`, and `value`
      *
      * @name _
      * @constructor


### PR DESCRIPTION
Discovered via the definitelytyped definition - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61001 :

https://github.com/lodash/lodash/wiki/Changelog#v400
  > Made `_.words` chainable by default

Changed in https://github.com/lodash/lodash/commit/2cb4829536fa31fadfa577aa5115e724b91224cc