### PR TITLE
fix(README): remove the old way to make the build from the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The [Lodash](https://lodash.com/) library exported as a [UMD](https://github.com
 
 Generated using [lodash-cli](https://www.npmjs.com/package/lodash-cli):
 ```shell
-$ npm run build
 $ lodash -o ./dist/lodash.js
 $ lodash core -o ./dist/lodash.core.js
 ```


### PR DESCRIPTION
Hey, the command `npm run build` is still present in the README file even though the script does not exist in `package.json`. This PR fixes this.