### PR TITLE
feat(Function): add method sync

### DIFF
--- a/.internal/nodeTypes.js
+++ b/.internal/nodeTypes.js
@@ -20,9 +20,9 @@ const nodeTypes = ((() => {
     const typesHelper = freeModule && freeModule.require && freeModule.require('util').types
     return typesHelper
       ? typesHelper
-      /* Legacy process.binding('util') for Node.js earlier than v10. */
+    /* Legacy process.binding('util') for Node.js earlier than v10. */
       : freeProcess && freeProcess.binding && freeProcess.binding('util')
-  } catch (e) {}
+  } catch (e) { }
 })())
 
 export default nodeTypes

--- a/.internal/noop.js
+++ b/.internal/noop.js
@@ -1,0 +1,2 @@
+/** Used as a black function */
+export default function() { }

--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,61 @@
+import noop from './.internal/noop'
+/**
+ * Creates a function that will run `func` only after previous one was finished
+ * and return results in a promise.
+ *
+ * @since 5.1.0
+ * @category Function
+ * @param {Function} func The function to sync.
+ * @examples
+ *  1) It will run call function only after previous calls are finilized(succeed or failed)
+ *		const sendRequest = (delay) => {
+ *			console.log('Triggered:', delay);
+ *			return new Promise((resolve) => setTimeout(() => {
+ *				console.log('Finished:', delay)
+ *				resolve(delay)
+ *			}, delay))
+ *		}
+ *		sendRequest(1000);
+ *		sendRequest(100);
+ *		sendRequest(500);
+ *		const sendRequestSynced = sync(sendRequest);
+ *		sendRequestSynced(1000);
+ *		sendRequestSynced(100);
+ *		sendRequestSynced(500);
+ *
+ *    sendRequestSynced   sendRequest
+ *    Triggered: 1000     Triggered: 1000
+ *    Triggered: 100      Triggered: 100
+ *    Triggered: 500      Triggered: 500
+
+ *    Finished: 1000      Finished: 100
+ *    Finished: 100       Finished: 500
+ *    Finished: 500       Finished: 1000
+ * 2) If you pass not async function it will wrap results in the promise anyway
+ *    const func = () => 1;
+ *    sync(func)().then((res) => console.log(res))
+ *    // => 1
+ */
+function sync(func) {
+  let lastCallPromise = null
+
+  function caller(...args) {
+    const callPromise = new Promise((resolve, reject) => {
+      const callFunc = function() {
+        Promise.resolve(func(...args)).then(resolve).catch(reject)
+      }
+      if (lastCallPromise) {
+        lastCallPromise.finally(callFunc).catch(noop)
+      } else {
+        callFunc()
+      }
+    })
+
+    lastCallPromise = callPromise
+    return callPromise
+  }
+
+  return caller
+}
+
+export default sync

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -1,0 +1,139 @@
+import assert from 'assert'
+import sync from '../sync.js'
+import { noop } from './utils.js'
+
+describe('sync', () => {
+  it('should sync an async function', (done) => {
+    function func(delay) {
+      return new Promise((resolve) => setTimeout(() => resolve(delay)), delay)
+    }
+    const delayArg = 1000
+    const sendRequestSynced = sync(func)
+    const funcPromise = sendRequestSynced(delayArg)
+    setTimeout(() => {
+      funcPromise.then((res) => {
+        assert.strictEqual(res, delayArg)
+        done()
+      }, delayArg)
+    })
+  })
+
+  it('should sync not async function and wrap result in promise as well', (done) => {
+    function func(...args) {
+      return args
+    }
+    const args = [1, {}, '']
+    const funcSynced = sync(func)
+
+    const funcPromise = funcSynced(...args)
+
+    funcPromise.then((res) => {
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(args))
+      done()
+    })
+  })
+
+  it('should run func only when previous one was succeed', (done) => {
+    const delayArg1 = 1000
+    const delayArg2 = 100
+    const delayArg3 = 500
+
+    const funcResolveMap = {
+      [delayArg1]: false,
+      [delayArg2]: false,
+      [delayArg3]: false
+    }
+
+    function func(delay) {
+      return new Promise((resolve) => setTimeout(() => { funcResolveMap[delay] = true; resolve(delay) }, delay))
+    }
+
+    const sendRequestSynced = sync(func)
+    sendRequestSynced(delayArg1)
+    sendRequestSynced(delayArg2)
+    sendRequestSynced(delayArg3)
+
+    setTimeout(() => {
+      assert.strictEqual(funcResolveMap[delayArg1], true)
+      assert.strictEqual(funcResolveMap[delayArg2], false)
+      assert.strictEqual(funcResolveMap[delayArg3], false)
+      setTimeout(() => {
+        assert.strictEqual(funcResolveMap[delayArg1], true)
+        assert.strictEqual(funcResolveMap[delayArg2], true)
+        assert.strictEqual(funcResolveMap[delayArg3], false)
+        setTimeout(() => {
+          assert.strictEqual(funcResolveMap[delayArg1], true)
+          assert.strictEqual(funcResolveMap[delayArg2], true)
+          assert.strictEqual(funcResolveMap[delayArg3], true)
+          done()
+        }, delayArg3)
+      }, delayArg2)
+    }, delayArg1)
+  })
+
+  it('should run func when previous failed', (done) => {
+    const delayArg1 = 1000
+    const delayArg2 = 100
+    const delayArg3 = 500
+
+    const funcFailMap = {
+      [delayArg1]: false,
+      [delayArg2]: false,
+      [delayArg3]: false
+    }
+
+    function funcError(delay) {
+      return new Promise((_resolve, reject) => setTimeout(() => { funcFailMap[delay] = true; reject(delay) }, delay))
+    }
+
+    const funcErrorSynced = sync(funcError)
+
+    funcErrorSynced(delayArg1).catch(noop)
+    funcErrorSynced(delayArg2).catch(noop)
+    funcErrorSynced(delayArg3).catch(noop)
+
+    setTimeout(() => {
+      assert.strictEqual(funcFailMap[delayArg1], true)
+      assert.strictEqual(funcFailMap[delayArg2], false)
+      assert.strictEqual(funcFailMap[delayArg3], false)
+      setTimeout(() => {
+        assert.strictEqual(funcFailMap[delayArg1], true)
+        assert.strictEqual(funcFailMap[delayArg2], true)
+        assert.strictEqual(funcFailMap[delayArg3], false)
+        setTimeout(() => {
+          assert.strictEqual(funcFailMap[delayArg1], true)
+          assert.strictEqual(funcFailMap[delayArg2], true)
+          assert.strictEqual(funcFailMap[delayArg3], true)
+          done()
+        }, delayArg3)
+      }, delayArg2)
+    }, delayArg1)
+  })
+
+  it('should behave the same as func on success', (done) => {
+    function funcSuccess(...args) {
+      return new Promise((resolve) => resolve(args))
+    }
+    const funcSuccessSynced = sync(funcSuccess)
+    const args = [1, {}, []]
+
+    funcSuccessSynced(...args).then((res) => {
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(args))
+      done()
+    })
+  })
+
+  it('should behave the same as func on failute', (done) => {
+    function funcError(...args) {
+      return new Promise((_resolve, reject) => reject(args))
+    }
+
+    const funcErrorSynced = sync(funcError)
+    const args = [1, {}, []]
+
+    funcErrorSynced(...args).catch((res) => {
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(args))
+      done()
+    })
+  })
+})


### PR DESCRIPTION
**Problem:**
Let's say we have an async method `applySettings`
```
const async applySettings(delay) {
  return Promise((resolve) => {
    // do some stuff
    setTimeout(resolve, delay);
  })
}
```
When we call it multiple times from multiple places it comes with race conditions which leads to unpredictable behavior. 
```
applySettings(1000)
applySettings(100)
applySettings(500)

100
500
1000
```
- all 3 will run at the same time independently
- the order changed randomly

**Solution**

```
const applySettingsSynced = sync(applySettings);
applySettings(1000)
applySettings(100)
applySettings(500)

1000
100
500
```
- here they are all finished in the correct order one after one

Hello! @jdalton I checked existing functionality and did not find anything similar. Please have a look. Thanks.
