### PR TITLE
Nth returns 'undefined' if n is not of type 'number'

### DIFF
--- a/nth.js
+++ b/nth.js
@@ -21,7 +21,7 @@ import isIndex from './.internal/isIndex.js'
  */
 function nth(array, n) {
   const length = array == null ? 0 : array.length
-  if (!length) {
+  if (!length || typeof n !== 'number') {
     return
   }
   n += n < 0 ? length : 0

--- a/test/nth.test.js
+++ b/test/nth.test.js
@@ -22,20 +22,11 @@ describe('nth', function() {
     assert.deepStrictEqual(actual, ['d', 'c', 'b', 'a']);
   });
 
-  it('should coerce `n` to an integer', function() {
-    var values = falsey,
-        expected = lodashStable.map(values, stubA);
+  it('should return `undefined` for non-number `n`', function () {
+    var values = ['1', 'x'],
+        expected = lodashStable.map(values, noop);
 
-    var actual = lodashStable.map(values, function(n) {
-      return n ? nth(array, n) : nth(array);
-    });
-
-    assert.deepStrictEqual(actual, expected);
-
-    values = ['1', 1.6];
-    expected = lodashStable.map(values, stubB);
-
-    actual = lodashStable.map(values, function(n) {
+    var actual = lodashStable.map(values, function (n) {
       return nth(array, n);
     });
 


### PR DESCRIPTION
Closes #5517
# Changes
- Activate unit testing for nth
- Remove coercion unit test
- Return `undefined` if n param is not of type `number`