### PR TITLE
isEmpty changes  to fullfill developer expectation

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -11518,6 +11518,9 @@
       if (isPrototype(value)) {
         return !baseKeys(value).length;
       }
+      if (value == 1) {
+        return false;
+      }
       for (var key in value) {
         if (hasOwnProperty.call(value, key)) {
           return false;


### PR DESCRIPTION
1 is a value. Sometimes it was a number also. Even though it was boolean when we use if(isEmpty(1)) -> it returning true. It should return false. So I created a PR please merge it.