### PR TITLE
Added support for locales for string-modifying functions

### DIFF
--- a/.internal/createCaseFirst.js
+++ b/.internal/createCaseFirst.js
@@ -10,7 +10,7 @@ import stringToArray from './stringToArray.js'
  * @returns {Function} Returns the new case function.
  */
 function createCaseFirst(methodName) {
-  return (string) => {
+  return (string, locales = []) => {
     if (!string) {
       return ''
     }
@@ -27,7 +27,7 @@ function createCaseFirst(methodName) {
       ? castSlice(strSymbols, 1).join('')
       : string.slice(1)
 
-    return chr[methodName]() + trailing
+    return chr[methodName](locales) + trailing
   }
 }
 

--- a/camelCase.js
+++ b/camelCase.js
@@ -8,6 +8,7 @@ import toString from './toString.js'
  * @since 3.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the camel cased string.
  * @see lowerCase, kebabCase, snakeCase, startCase, upperCase, upperFirst
  * @example
@@ -21,10 +22,10 @@ import toString from './toString.js'
  * camelCase('__FOO_BAR__')
  * // => 'fooBar'
  */
-const camelCase = (string) => (
+const camelCase = (string, locales = []) => (
   words(toString(string).replace(/['\u2019]/g, '')).reduce((result, word, index) => {
-    word = word.toLowerCase()
-    return result + (index ? upperFirst(word) : word)
+    word = word.toLocaleLowerCase(locales)
+    return result + (index ? upperFirst(word, locales) : word)
   }, '')
 )
 

--- a/capitalize.js
+++ b/capitalize.js
@@ -8,13 +8,14 @@ import toString from './toString.js'
  * @since 3.0.0
  * @category String
  * @param {string} [string=''] The string to capitalize.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the capitalized string.
  * @example
  *
  * capitalize('FRED')
  * // => 'Fred'
  */
-const capitalize = (string) => upperFirst(toString(string).toLowerCase())
+const capitalize = (string, locales = []) => upperFirst(toString(string).toLocaleLowerCase(locales), locales)
 
 
 export default capitalize

--- a/kebabCase.js
+++ b/kebabCase.js
@@ -8,6 +8,7 @@ import toString from './toString.js'
  * @since 3.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the kebab cased string.
  * @see camelCase, lowerCase, snakeCase, startCase, upperCase, upperFirst
  * @example
@@ -21,9 +22,9 @@ import toString from './toString.js'
  * kebabCase('__FOO_BAR__')
  * // => 'foo-bar'
  */
-const kebabCase = (string) => (
+const kebabCase = (string, locales = []) => (
   words(toString(string).replace(/['\u2019]/g, '')).reduce((result, word, index) => (
-    result + (index ? '-' : '') + word.toLowerCase()
+    result + (index ? '-' : '') + word.toLocaleLowerCase(locales)
   ), '')
 )
 

--- a/lowerCase.js
+++ b/lowerCase.js
@@ -9,6 +9,7 @@ const reQuotes = /['\u2019]/g
  * @since 4.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the lower cased string.
  * @see camelCase, kebabCase, snakeCase, startCase, upperCase, upperFirst
  * @example
@@ -22,9 +23,9 @@ const reQuotes = /['\u2019]/g
  * lowerCase('__FOO_BAR__')
  * // => 'foo bar'
  */
-const lowerCase = (string) => (
+const lowerCase = (string, locales = []) => (
   words(toString(string).replace(reQuotes, '')).reduce((result, word, index) => (
-    result + (index ? ' ' : '') + word.toLowerCase()
+    result + (index ? ' ' : '') + word.toLocaleLowerCase(locales)
   ), '')
 )
 

--- a/lowerFirst.js
+++ b/lowerFirst.js
@@ -6,6 +6,7 @@ import createCaseFirst from './.internal/createCaseFirst.js'
  * @since 4.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the converted string.
  * @example
  *
@@ -15,6 +16,6 @@ import createCaseFirst from './.internal/createCaseFirst.js'
  * lowerFirst('FRED')
  * // => 'fRED'
  */
-const lowerFirst = createCaseFirst('toLowerCase')
+const lowerFirst = createCaseFirst('toLocaleLowerCase')
 
 export default lowerFirst

--- a/snakeCase.js
+++ b/snakeCase.js
@@ -8,6 +8,7 @@ import toString from './toString.js'
  * @since 3.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the snake cased string.
  * @see camelCase, lowerCase, kebabCase, startCase, upperCase, upperFirst
  * @example
@@ -24,9 +25,9 @@ import toString from './toString.js'
  * snakeCase('foo2bar')
  * // => 'foo_2_bar'
  */
-const snakeCase = (string) => (
+const snakeCase = (string, locales=[]) => (
   words(toString(string).replace(/['\u2019]/g, '')).reduce((result, word, index) => (
-    result + (index ? '_' : '') + word.toLowerCase()
+    result + (index ? '_' : '') + word.toLocaleLowerCase(locales)
   ), '')
 )
 

--- a/test/camelCase.test.js
+++ b/test/camelCase.test.js
@@ -25,4 +25,9 @@ describe('camelCase', function() {
       assert.strictEqual(camelCase(string), 'xmlHttpRequest');
     });
   });
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(camelCase('dinç muhteşem iyi'), 'dinçMuhteşemIyi'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(camelCase('dinç muhteşem iyi', 'tr-TR'), 'dinçMuhteşemİyi');
+    assert.strictEqual(camelCase('dinç muhteşem iyi', ['tr-TR']), 'dinçMuhteşemİyi');
+  });
 });

--- a/test/capitalize.test.js
+++ b/test/capitalize.test.js
@@ -6,5 +6,11 @@ describe('capitalize', function() {
     assert.strictEqual(capitalize('fred'), 'Fred');
     assert.strictEqual(capitalize('Fred'), 'Fred');
     assert.strictEqual(capitalize(' fred'), ' fred');
+    assert.strictEqual(capitalize('fRED'), 'Fred');
+  });
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(capitalize('iyi'), 'Iyi'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(capitalize('iyi', 'tr-TR'), 'İyi');
+    assert.strictEqual(capitalize('iyi', ['tr-TR']), 'İyi');
   });
 });

--- a/test/kebabCase.test.js
+++ b/test/kebabCase.test.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import lodashStable from 'lodash';
+import kebabCase from '../kebabCase.js';
+
+describe('kebabCase', function() {
+  it('should work with numbers', function() {
+    assert.strictEqual(kebabCase('12 feet'), '12-feet');
+    assert.strictEqual(kebabCase('enable 6h format'), 'enable-6-h-format');
+    assert.strictEqual(kebabCase('enable 24H format'), 'enable-24-h-format');
+    assert.strictEqual(kebabCase('too legit 2 quit'), 'too-legit-2-quit');
+    assert.strictEqual(kebabCase('walk 500 miles'), 'walk-500-miles');
+    assert.strictEqual(kebabCase('xhr2 request'), 'xhr-2-request');
+  });
+
+  it('should handle acronyms', function() {
+    lodashStable.each(['safe HTML', 'safeHTML'], function(string) {
+      assert.strictEqual(kebabCase(string), 'safe-html');
+    });
+
+    lodashStable.each(['escape HTML entities', 'escapeHTMLEntities'], function(string) {
+      assert.strictEqual(kebabCase(string), 'escape-html-entities');
+    });
+
+    lodashStable.each(['XMLHttpRequest', 'XmlHTTPRequest'], function(string) {
+      assert.strictEqual(kebabCase(string), 'xml-http-request');
+    });
+  });
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(kebabCase('dinç muhteşem İyi'), 'dinç-muhteşem-i̇yi');
+    assert.strictEqual(kebabCase('dinç muhteşem İyi', 'tr-TR'), 'dinç-muhteşem-iyi');
+    assert.strictEqual(kebabCase('dinç muhteşem İyi', ['tr-TR']), 'dinç-muhteşem-iyi');
+  });
+});

--- a/test/lowerCase.test.js
+++ b/test/lowerCase.test.js
@@ -7,4 +7,9 @@ describe('lowerCase', function() {
     assert.strictEqual(lowerCase('fooBar'), 'foo bar');
     assert.strictEqual(lowerCase('__FOO_BAR__'), 'foo bar');
   });
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(lowerCase('DINÇ MUHTEŞEM İYI'), 'dinç muhteşem i̇yi'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(lowerCase('DINÇ MUHTEŞEM İYI', 'tr-TR'), 'dınç muhteşem iyı');
+    assert.strictEqual(lowerCase('DINÇ MUHTEŞEM İYI', ['tr-TR']), 'dınç muhteşem iyı');
+  });
 });

--- a/test/lowerFirst.test.js
+++ b/test/lowerFirst.test.js
@@ -7,4 +7,9 @@ describe('lowerFirst', function() {
     assert.strictEqual(lowerFirst('Fred'), 'fred');
     assert.strictEqual(lowerFirst('FRED'), 'fRED');
   });
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(lowerFirst('İYİ'), 'i̇Yİ'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(lowerFirst('İYİ', 'tr-TR'), 'iYİ');
+    assert.strictEqual(lowerFirst('İYİ', ['tr-TR']), 'iYİ');
+  });
 });

--- a/test/snakeCase.test.js
+++ b/test/snakeCase.test.js
@@ -1,0 +1,41 @@
+import assert from 'assert';
+import lodashStable from 'lodash';
+import snakeCase from '../snakeCase';
+
+describe('snakeCase', function() {
+  it('should convert given examples to snake_case', function() {
+    assert.strictEqual(snakeCase('Foo Bar'), 'foo_bar');
+    assert.strictEqual(snakeCase('fooBar'), 'foo_bar');
+    assert.strictEqual(snakeCase('--FOO-BAR--'), 'foo_bar');
+    assert.strictEqual(snakeCase('foo2bar'), 'foo_2_bar');
+  });
+
+  it('should work with numbers', function() {
+    assert.strictEqual(snakeCase('12 feet'), '12_feet');
+    assert.strictEqual(snakeCase('enable 6h format'), 'enable_6_h_format');
+    assert.strictEqual(snakeCase('enable 24H format'), 'enable_24_h_format');
+    assert.strictEqual(snakeCase('too legit 2 quit'), 'too_legit_2_quit');
+    assert.strictEqual(snakeCase('walk 500 miles'), 'walk_500_miles');
+    assert.strictEqual(snakeCase('xhr2 request'), 'xhr_2_request');
+  });
+
+  it('should handle acronyms', function() {
+    lodashStable.each(['safe HTML', 'safeHTML'], function(string) {
+      assert.strictEqual(snakeCase(string), 'safe_html');
+    });
+
+    lodashStable.each(['escape HTML entities', 'escapeHTMLEntities'], function(string) {
+      assert.strictEqual(snakeCase(string), 'escape_html_entities');
+    });
+
+    lodashStable.each(['XMLHttpRequest', 'XmlHTTPRequest'], function(string) {
+      assert.strictEqual(snakeCase(string), 'xml_http_request');
+    });
+  });
+  
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(snakeCase('DINÇ MUHTEŞEM İYI'), 'dinç_muhteşem_i̇yi'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(snakeCase('DINÇ MUHTEŞEM İYI', 'tr-TR'), 'dınç_muhteşem_iyı');
+    assert.strictEqual(snakeCase('DINÇ MUHTEŞEM İYI', ['tr-TR']), 'dınç_muhteşem_iyı');
+  });
+});

--- a/test/upperCase.test.js
+++ b/test/upperCase.test.js
@@ -7,4 +7,9 @@ describe('upperCase', function() {
     assert.strictEqual(upperCase('fooBar'), 'FOO BAR');
     assert.strictEqual(upperCase('__foo_bar__'), 'FOO BAR');
   });
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(upperCase('iyi'), 'IYI'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(upperCase('iyi', 'tr-TR'), 'İYİ');
+    assert.strictEqual(upperCase('iyi', ['tr-TR']), 'İYİ');
+  });
 });

--- a/test/upperFirst.test.js
+++ b/test/upperFirst.test.js
@@ -6,5 +6,10 @@ describe('upperFirst', function() {
     assert.strictEqual(upperFirst('fred'), 'Fred');
     assert.strictEqual(upperFirst('Fred'), 'Fred');
     assert.strictEqual(upperFirst('FRED'), 'FRED');
+  });;
+  it('should handle locale information correctly', function() {
+    assert.strictEqual(upperFirst('iyi'), 'Iyi'); // Without specifying the locale, this is the correct behaviour
+    assert.strictEqual(upperFirst('iyi', 'tr-TR'), 'İyi');
+    assert.strictEqual(upperFirst('iyi', ['tr-TR']), 'İyi');
   });
 });

--- a/upperCase.js
+++ b/upperCase.js
@@ -7,6 +7,7 @@ import toString from './toString.js'
  * @since 4.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the upper cased string.
  * @see camelCase, kebabCase, lowerCase, snakeCase, startCase, upperFirst
  * @example
@@ -20,9 +21,9 @@ import toString from './toString.js'
  * upperCase('__foo_bar__')
  * // => 'FOO BAR'
  */
-const upperCase = (string) => (
+const upperCase = (string, locales = []) => (
   words(toString(string).replace(/['\u2019]/g, '')).reduce((result, word, index) => (
-    result + (index ? ' ' : '') + word.toUpperCase()
+    result + (index ? ' ' : '') + word.toLocaleUpperCase(locales)
   ), '')
 )
 

--- a/upperFirst.js
+++ b/upperFirst.js
@@ -6,6 +6,7 @@ import createCaseFirst from './.internal/createCaseFirst.js'
  * @since 4.0.0
  * @category String
  * @param {string} [string=''] The string to convert.
+ * @param {string|string[]} [locales=[]] Optional locale information to use.
  * @returns {string} Returns the converted string.
  * @see camelCase, kebabCase, lowerCase, snakeCase, startCase, upperCase
  * @example
@@ -16,6 +17,6 @@ import createCaseFirst from './.internal/createCaseFirst.js'
  * upperFirst('FRED')
  * // => 'FRED'
  */
-const upperFirst = createCaseFirst('toUpperCase')
+const upperFirst = createCaseFirst('toLocaleUpperCase')
 
 export default upperFirst


### PR DESCRIPTION
Fixes #4603
Improves #5237 

This pull request aims to add the locales option as an optional parameter to any function modifying a string. I have found the following usages of "toLowerCase" and "toUpperCase" in the actual code:
* capitalize
* upperFirst
* upperCase
* camelCase
* kebabCase
* lowerCase
* lowerFirst
* snakeCase

No usages of "toLowerCase" or "toUpperCase" were modified. However testcases were added for the methods mentioned above. If no test file was found, a new one was created. For these testcases not only the testcases for the locales parameter but also basic testcases for the function of the corresponding function were added, too.

Please signal me, if I need to alter anything.