### PR TITLE
Fix _.round error with negative numbers

### DIFF
--- a/.internal/createRound.js
+++ b/.internal/createRound.js
@@ -8,12 +8,12 @@
 function createRound(methodName) {
   const func = Math[methodName]
   return (number, precision) => {
-    let isNegative = number < 0;
+    let isNegative = number < 0, isRound = methodName == 'round';
     precision = precision == null ? 0 : (precision >= 0 ? Math.min(precision, 292) : Math.max(precision, -292))
     // Shift with exponential notation to avoid floating-point issues.
     // See [MDN](https://mdn.io/round#Examples) for more details.
     if (precision) {
-      if (isNegative) {
+      if (isRound && isNegative) {
         let t = -number;
         let pair = `${t}e`.split('e')
         const value = func(`${pair[0]}e${+pair[1] + precision}`)
@@ -29,7 +29,7 @@ function createRound(methodName) {
       }
     }
     else {
-      if (isNegative) return -func(-number)
+      if (isRound && isNegative) return -func(-number)
       else return func(number)
     }
   }

--- a/.internal/createRound.js
+++ b/.internal/createRound.js
@@ -8,17 +8,30 @@
 function createRound(methodName) {
   const func = Math[methodName]
   return (number, precision) => {
+    let isNegative = number < 0;
     precision = precision == null ? 0 : (precision >= 0 ? Math.min(precision, 292) : Math.max(precision, -292))
+    // Shift with exponential notation to avoid floating-point issues.
+    // See [MDN](https://mdn.io/round#Examples) for more details.
     if (precision) {
-      // Shift with exponential notation to avoid floating-point issues.
-      // See [MDN](https://mdn.io/round#Examples) for more details.
-      let pair = `${number}e`.split('e')
-      const value = func(`${pair[0]}e${+pair[1] + precision}`)
+      if (isNegative) {
+        let t = -number;
+        let pair = `${t}e`.split('e')
+        const value = func(`${pair[0]}e${+pair[1] + precision}`)
 
-      pair = `${value}e`.split('e')
-      return +`${pair[0]}e${+pair[1] - precision}`
+        pair = `${value}e`.split('e')
+        return -`${pair[0]}e${+pair[1] - precision}`
+      } else {
+        let pair = `${number}e`.split('e')
+        const value = func(`${pair[0]}e${+pair[1] + precision}`)
+
+        pair = `${value}e`.split('e')
+        return +`${pair[0]}e${+pair[1] - precision}`
+      }
     }
-    return func(number)
+    else {
+      if (isNegative) return -func(-number)
+      else return func(number)
+    }
   }
 }
 

--- a/test/round-methods.js
+++ b/test/round-methods.js
@@ -19,6 +19,11 @@ describe('round methods', function() {
       assert.strictEqual(actual, isCeil ? 5 : 4);
     });
 
+    it('`_.' + methodName + '` should work with a negative number', function() {
+      var actual = func(-4.016, 2);
+      assert.strictEqual(actual, isFloor ? -4.01 : -4.02);
+    });
+
     it('`_.' + methodName + '` should work with a positive precision', function() {
       var actual = func(4.016, 2);
       assert.strictEqual(actual, isFloor ? 4.01 : 4.02);

--- a/test/round-methods.js
+++ b/test/round-methods.js
@@ -21,7 +21,7 @@ describe('round methods', function() {
 
     it('`_.' + methodName + '` should work with a negative number', function() {
       var actual = func(-4.016, 2);
-      assert.strictEqual(actual, isFloor ? -4.01 : -4.02);
+      assert.strictEqual(actual, isCeil ? -4.01 : -4.02);
     });
 
     it('`_.' + methodName + '` should work with a positive precision', function() {


### PR DESCRIPTION
_.round works error with negative numbers?

example: 
_.round(-3007577.4950, 2)   // should be -3007577.5，but not -3007577.49