### PR TITLE
Adding compact object method

### DIFF
--- a/compactObject.js
+++ b/compactObject.js
@@ -1,0 +1,29 @@
+/**
+ * Creates an object with all falsey values removed from the original object. The values `false`, `null`,
+ * `0`, `""`, `undefined`, and `NaN` are falsey.
+ *
+ * @since 4.17.21
+ * @category Object
+ * @param {Object} object The object to compact.
+ * @returns {Object} Returns the new object of filtered values.
+ * @example
+ *
+ * compact({a: 1, b: 'foo', c: null, e: 0, '': 1, false: NaN})
+ * // => { a: 1, b: 'foo' }
+ */
+function compactObject(object) {
+  if (object == null) {
+    return {}
+  }
+  const result = {}
+  const entries = Object.entries(object)
+
+  for (const [key, value] of entries) {
+    if (value && key) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+export default compactObject

--- a/test/compactObject.test.js
+++ b/test/compactObject.test.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import compactObject from '../compactObject.js';
+import { falseyObject } from './utils.js';
+
+describe('compact', function () {
+
+  it('should filter falsey values', function () {
+    var object = {
+      'a': 'aa',
+      'b': 1,
+      'c': true
+    };
+    assert.deepStrictEqual(compactObject(Object.assign({}, object, falseyObject)), object);
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -158,6 +158,26 @@ var deburredLetters = [
 /** Used to provide falsey values to methods. */
 var falsey = [, null, undefined, false, 0, NaN, ''];
 
+/** Used to provide falsey key-value pairs to methods */
+var falseyObject = {
+  0: '',
+  '': 0,
+  null: '',
+  '': null,
+  undefined: '',
+  '': undefined,
+  false: '',
+  '': false,
+  NaN: '',
+  '': NaN,
+  '': '',
+  0: 0,
+  null: null,
+  undefined: undefined,
+  false: false,
+  NaN: NaN
+}
+
 /** Used to specify the emoji style glyph variant of characters. */
 var emojiVar = '\ufe0f';
 
@@ -766,6 +786,7 @@ export {
   comboMarks,
   deburredLetters,
   falsey,
+  falseyObject,
   emojiVar,
   empties,
   errors,


### PR DESCRIPTION
I was working with one of my backend projects so I was feeling this feature is needed for objects that are received from req.body either in frontend or backend.

This method works very well with objects and safeties are also checked to prevent the app from crashing.

I should note that this method gets inspired by the compact method which is used for arrays and works very similarly but it will validate both Keys and Value pairs in the object, and lastly, I was thinking about a flag that can be passed as a second arg to the method (which is optional btw!) to check if a developer wants to check Keys or Values or Both of them in the object.