### PR TITLE
Changed `baseFlatten` implementation to use `Array.prototype.concat` to avoid stack limits

### DIFF
--- a/.internal/baseFlatten.js
+++ b/.internal/baseFlatten.js
@@ -25,7 +25,7 @@ function baseFlatten(array, depth, predicate, isStrict, result) {
         // Recursively flatten arrays (susceptible to call stack limits).
         baseFlatten(value, depth - 1, predicate, isStrict, result)
       } else {
-        result.push(...value)
+        result = result.concat(value)
       }
     } else if (!isStrict) {
       result[result.length] = value


### PR DESCRIPTION
Changed `baseFlatten` implementation to use `Array.prototype.concat` in order to avoid stack limits for large arrays