### PR TITLE
Update isArrayLike docs to exclude document.all

### DIFF
--- a/isArrayLike.js
+++ b/isArrayLike.js
@@ -2,8 +2,8 @@ import isLength from './isLength.js'
 
 /**
  * Checks if `value` is array-like. A value is considered array-like if it's
- * not a function and has a `value.length` that's an integer greater than or
- * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
+ * not a function, it's not falsey and has a `value.length` that's an integer
+ * greater than or equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
  *
  * @since 4.0.0
  * @category Lang
@@ -21,6 +21,9 @@ import isLength from './isLength.js'
  * // => true
  *
  * isArrayLike(Function)
+ * // => false
+ * 
+ * isArrayLike(document.all)
  * // => false
  */
 function isArrayLike(value) {


### PR DESCRIPTION
Without this addition to docs, `isArrayLike(document.all)` should return `true` instead of `false`, since it is not a function, with `value.length >= 0`