### PR TITLE
Add isBlank and isFilled functions

### DIFF
--- a/isBlank.js
+++ b/isBlank.js
@@ -1,0 +1,56 @@
+import isNil from './isNil.js'
+import isString from './isString.js'
+import trim from './trim.js'
+import isNumber from './isNumber.js'
+import isBoolean from './isBoolean.js'
+import isArrayLike from './isArrayLike.js'
+import isObjectLike from './isObjectLike.js'
+import every from './every.js'
+import values from './values.js'
+import isEmpty from './isEmpty.js'
+
+/**
+ * Checks if `value` is bland.
+ *
+ * @since 4.17.1
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `false` if `value` is a blank, else `true`.
+ * @example
+ *
+ * isBlank([])
+ * // => true
+ *
+ * isBlank([[]])
+ * // => true
+ *
+ * isBlank(0)
+ * // => false
+ *
+ * isBlank(false)
+ * // => false
+ *
+ * isBlank(null)
+ * // => true
+ */
+function isBlank(value) {
+  if (isNil(value)) {
+    return true
+  }
+  if (isString(value)) {
+    return trim(value) === ''
+  }
+  if (isNumber(value)) {
+    return false
+  }
+  if (isBoolean(value)) {
+    return false
+  }
+  if (isArrayLike(value) || isObjectLike(value)) {
+    return every(values(value), isBlank)
+  }
+
+  return isEmpty(value)
+}
+
+export default isBlank

--- a/isFilled.js
+++ b/isFilled.js
@@ -1,0 +1,28 @@
+import isBlank from './isBlank.js'
+
+/**
+ * Checks if `value` is filled.It is opposite of isBlank()
+ *
+ * @since 4.17.1
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a filled, else `false`.
+ * @example
+ *
+ * isFilled([])
+ * // => false
+ *
+ * isFilled(0)
+ * // => true
+ *
+ * isFilled(false)
+ * // => true
+ *
+ * isFilled(null)
+ * // => false
+ */
+function isFilled(value) {
+  return !isBlank(value)
+}
+
+export default isFilled

--- a/test/isBlank.test.js
+++ b/test/isBlank.test.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { realm } from './utils.js';
+import isBlank from '../isBlank.js';
+
+describe('isBlank', function() {
+  it('should return `true` for `null` and `undefined` values', function() {
+    assert.strictEqual(isBlank(null), true);
+    assert.strictEqual(isBlank(undefined), true);
+  });
+
+  it('should return `true` for empty string values', function() {
+    assert.strictEqual(isBlank(''), true);
+  });
+
+  it('should return `true` for numbers values', function() {
+    assert.strictEqual(isBlank(0), false);
+    assert.strictEqual(isBlank(10), false);
+  });
+
+  it('should return `false` for boolean values', function() {
+    assert.strictEqual(isBlank(true), false);
+    assert.strictEqual(isBlank(false), false);
+  });
+
+  it('should return `true` for empty array values', function() {
+    assert.strictEqual(isBlank([[], [[]], [[[null]]], [[[null, undefined]]]]), true);
+  });
+
+  it('should return `false` for filled array values', function() {
+    assert.strictEqual(isBlank([0, false]), false);
+    assert.strictEqual(isBlank(realm.array), false);
+  });
+
+  it('should return `true` for empty object values', function() {
+    assert.strictEqual(isBlank({}), true);
+    assert.strictEqual(isBlank({0: null, 1: undefined, 2: {0: {  }, 1: null, 2: undefined}}), true);
+  });
+
+  it('should return `false` for filld object values', function() {
+    assert.strictEqual(isBlank(realm.object), false);
+    assert.strictEqual(isBlank({0: 0}), false);
+
+  });
+});

--- a/test/isFilled.test.js
+++ b/test/isFilled.test.js
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import { realm } from './utils.js';
+import isFilled from '../isFilled.js';
+
+describe('isFilled', function() {
+  it('should return `false` for `null` and `undefined` values', function() {
+    assert.strictEqual(isFilled(null), false);
+    assert.strictEqual(isFilled(undefined), false);
+  });
+
+  it('should return `false` for empty string values', function() {
+    assert.strictEqual(isFilled(''), false);
+  });
+
+  it('should return `true` for numbers values', function() {
+    assert.strictEqual(isFilled(0), true);
+    assert.strictEqual(isFilled(10), true);
+  });
+
+  it('should return `true` for boolean values', function() {
+    assert.strictEqual(isFilled(true), true);
+    assert.strictEqual(isFilled(false), true);
+  });
+
+  it('should return `false` for empty array values', function() {
+    assert.strictEqual(isFilled([[], [[]], [[[null]]], [[[null, undefined]]]]), false);
+  });
+
+  it('should return `true` for filled array values', function() {
+    assert.strictEqual(isFilled([0, false]), true);
+    assert.strictEqual(isFilled(realm.array), true);
+  });
+
+  it('should return `false` for empty object values', function() {
+    assert.strictEqual(isFilled({}), false);
+    assert.strictEqual(isFilled({0: null, 1: undefined, 2: {0: {  }, 1: null, 2: undefined}}), false);
+  });
+
+  it('should return `true` for filld object values', function() {
+    assert.strictEqual(isFilled(realm.object), true);
+    assert.strictEqual(isFilled({0: 0}), true);
+  });
+});


### PR DESCRIPTION
_.isEmpty function only is suitable for `arrays`, `objects`, `null`, and `undefined` types. For example:
```
_.isEmpty(0)
_.isEmpty(false)
// true
```
And It has no support for nested empty arrays and objects:
```
_.isEmpty([null])
_.isEmpty([undefined])
//false
```
This thing can sometimes be problematic and cause bugs.
_.isBlank function will resolve this issue and give some features:
```
_.isBlank('')
_.isBlank('   ')
_.isBlank(null)
_.isBlank([null, []])
_.isBlank({{}})
// true

_.isBlank(0)
_.isBlank(true)
_.isBlank(false)
 // false

```

On the other hand, `_.isFilled` function does the opposite of the `_.isBlank`

There are the same functions named [blank](https://laravel.com/docs/10.x/helpers#method-blank) and [filled](https://laravel.com/docs/10.x/helpers#method-filled) in [Laravel Framework](https://laravel.com) which is very used.