### PR TITLE
feat: Add array `move` method

### DIFF
--- a/move.js
+++ b/move.js
@@ -1,0 +1,37 @@
+/**
+ * Modifies the array in place by moving one of its items to a new position.
+ * The function will return the array unchanged if the `oldIndex` is out of
+ * bounds or there is no action to perform. The function will cap the `newIndex`
+ * between `0` and `array.length - 1`.
+ *
+ * @since 4.17.15
+ * @category Array
+ * @param {Array} array The array to modify.
+ * @param {number} oldIndex The index of the item to move.
+ * @param {number} newIndex The index to move the item to.
+ * @returns {Array} Always returns the same array reference, with the applied move when possible.
+ */
+function move(array, oldIndex, newIndex) {
+  const length = array.length
+
+  if (
+    length === 0 ||
+    oldIndex === newIndex ||
+    oldIndex < 0 ||
+    oldIndex >= length
+  ) {
+    return array
+  }
+
+  if (newIndex >= length) {
+    newIndex = length - 1
+  } else if (newIndex < 0) {
+    newIndex = 0
+  }
+
+  array.splice(newIndex, 0, array.splice(oldIndex, 1)[0])
+
+  return array
+}
+
+export default move

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -1,0 +1,43 @@
+import move from '../move.js'
+import assert from 'assert'
+
+describe('move', () => {
+  it('should move first item to the end of the array', () => {
+    const array = [1, 2, 3]
+    assert.deepStrictEqual(move(array, 0, 2), [2, 3, 1])
+  })
+  it('should move last item to the beginning of the array', () => {
+    const array = [1, 2, 3]
+    assert.deepStrictEqual(move(array, 2, 0), [3, 1, 2])
+  })
+  it('should move an item to various positions', () => {
+    const array = [1, 2, 3, 4, 5]
+    assert.deepStrictEqual(move(array.slice(), 0, 2), [2, 3, 1, 4, 5])
+    assert.deepStrictEqual(move(array.slice(), 1, 3), [1, 3, 4, 2, 5])
+    assert.deepStrictEqual(move(array.slice(), 2, 4), [1, 2, 4, 5, 3])
+    assert.deepStrictEqual(move(array.slice(), 3, 1), [1, 4, 2, 3, 5])
+  })
+  it('should not modify the array if the `oldIndex` is out of bounds', () => {
+    const array = [1, 2, 3]
+    assert.deepStrictEqual(move(array, 4, 1), [1, 2, 3])
+  })
+  it('should not modify the array if the `oldIndex` is the same as `newIndex`', () => {
+    const array = [1, 2, 3]
+    assert.deepStrictEqual(move(array, 1, 1), [1, 2, 3])
+  })
+  it('should cap the `newIndex` to `array.length - 1` when higher', () => {
+    const array = [1, 2, 3]
+    assert.deepStrictEqual(move(array, 0, 9), [2, 3, 1])
+  })
+  it('should cap the `newIndex` to `0` when lower', () => {
+    const array = [1, 2, 3]
+    assert.deepStrictEqual(move(array, 2, -1), [3, 1, 2])
+  })
+  it('should work with empty arrays', () => {
+    assert.deepStrictEqual(move([], 0, 1), [])
+  })
+  it('should return the same array reference', () => {
+    const array = [1, 2, 3]
+    assert.strictEqual(move(array, 0, 1), array)
+  })
+})


### PR DESCRIPTION
This method modifies the array in place by moving one of its items to a new position.

Example:
```js
const array = [1,2,3]
move(array, 0, 2)
console.log(array) // [2,3,1]
```

This function has been highly requested since 2016[^1]. While alternative packages[^2] have been created to fill the gap, including this function directly in Lodash would be beneficial.

[^1]: https://github.com/lodash/lodash/issues/1701
[^2]: https://www.npmjs.com/package/lodash-move