### PR TITLE
fix bug: getTag(document.all) returns '[object Null]' 

### DIFF
--- a/.internal/getTag.js
+++ b/.internal/getTag.js
@@ -10,8 +10,8 @@ const toString = Object.prototype.toString
 function getTag(value) {
   if (value == null) {
     return value === undefined
-    ? '[object Undefined]'
-    : (value === null ? '[object Null]' : '[object HTMLAllCollection]')
+      ? '[object Undefined]'
+      : (value === null ? '[object Null]' : '[object HTMLAllCollection]')
   }
   return toString.call(value)
 }

--- a/.internal/getTag.js
+++ b/.internal/getTag.js
@@ -9,7 +9,9 @@ const toString = Object.prototype.toString
  */
 function getTag(value) {
   if (value == null) {
-    return value === undefined ? '[object Undefined]' : '[object Null]'
+    return value === undefined
+    ? '[object Undefined]'
+    : (value === null ? '[object Null]' : '[object HTMLAllCollection]')
   }
   return toString.call(value)
 }


### PR DESCRIPTION
getTag(document.all) returns '[object Null]' when i invoke it.
while Object.prototype.toString.call(document.all)  returns '[object HTMLAllCollection]';
So, I think this is a bug.