### PR TITLE
Fix baseClone bug when cloning sparse array

### DIFF
--- a/.internal/baseClone.js
+++ b/.internal/baseClone.js
@@ -232,6 +232,16 @@ function baseClone(value, bitmask, customizer, key, object, stack) {
       key = subValue
       subValue = value[key]
     }
+
+    /**
+     * Check for empty elements
+     * For example:
+     * const arr = [];
+     * arr.length = 1;
+     * console.log(arr) => [empty];
+     */
+    if (!(key in value)) return;
+
     // Recursively populate clone (susceptible to call stack limits).
     assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack))
   })


### PR DESCRIPTION
Cloning a sparse array with cloneDeep will convert empty to undefined.
![image](https://github.com/lodash/lodash/assets/44627712/f0a84772-20de-49fa-a328-60312fd981d7)

We can use the `in` operator to check for empty elements
![image](https://github.com/lodash/lodash/assets/44627712/3b49bd89-f3cc-4b46-819d-42a60ae4aa80)

If `key in value` is false, we can return it early to avoid converting the empty element to undefined