### PR TITLE
removed semicolon that was blocking npm validate

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,4 +122,4 @@ module.exports = {
 
     'template-curly-spacing': ['error', 'never']
   }
-};
+}


### PR DESCRIPTION
I have removed a semicolon that was giving me errors when I was trying to run "npm validate" / "validate": "npm run style && npm run test"