### PR TITLE
chore: update get() docs

### DIFF
--- a/get.js
+++ b/get.js
@@ -13,7 +13,7 @@ import baseGet from './.internal/baseGet.js'
  * @see has, hasIn, set, unset
  * @example
  *
- * const object = { 'a': [{ 'b': { 'c': 3 } }] }
+ * const object = { 'a': [{ 'b': { 'c': 3 }, 'b.c': 4 }] }
  *
  * get(object, 'a[0].b.c')
  * // => 3
@@ -21,6 +21,9 @@ import baseGet from './.internal/baseGet.js'
  * get(object, ['a', '0', 'b', 'c'])
  * // => 3
  *
+ * get(object, ['a', '0', 'b.c'])
+ * // => 4
+ * 
  * get(object, 'a.b.c', 'default')
  * // => 'default'
  */


### PR DESCRIPTION
Add additional documentation for the `_.get()` method to illustrate behavior when the object's key is an exact match of the path argument. This is in response to open issue #4701.