### PR TITLE
Add `deepKeyPrune` Function

### DIFF
--- a/deepKeyPrune.js
+++ b/deepKeyPrune.js
@@ -1,0 +1,71 @@
+import isObject from './isObject.js'
+import isFunction from './isFunction.js'
+
+// Define the deepKeyPrune function
+// Overall Time Complexity: O(n), where n is the total number of keys in all nested objects
+// Overall Space Complexity: O(n), for storing the filtered objects
+const deepKeyPrune = (obj, predicates, globalPredicate = null) => {
+  // Early exit: If the input 'obj' is not an object, return it as-is
+  // Time Complexity: O(1)
+  // Space Complexity: O(1)
+  if (!isObject(obj)) {
+    return obj
+  }
+
+  // Handle arrays: If the input 'obj' is an array, map over it and apply deepKeyPrune recursively
+  // Time Complexity: O(n), where n is the number of items in the array
+  // Space Complexity: O(n), for storing the mapped array
+  if (Array.isArray(obj)) {
+    return obj.map((item) => deepKeyPrune(item, predicates, globalPredicate))
+  }
+
+  // Initialize an empty object to store the filtered properties
+  // Space Complexity: O(1) (initialization)
+  const filteredObj = {}
+
+  // Loop through each key in the object 'obj'
+  // Time Complexity: O(n), where n is the number of keys in the object
+  for (const key in obj) {
+    // Make sure the key is not from the object's prototype chain
+    // Time Complexity: O(1)
+    if (obj.hasOwnProperty(key)) {
+      // Get the value for the current key
+      // Time Complexity: O(1)
+      // Space Complexity: O(1)
+      const value = obj[key]
+      // Get the local predicate function for the current key, if it exists
+      // Time Complexity: O(1)
+      // Space Complexity: O(1)
+      const localPredicate = predicates[key]
+
+      // Initialize a flag to indicate if the current key-value pair should be included in the filtered object
+      // Space Complexity: O(1)
+      let shouldInclude = true
+
+      // Apply the local predicate function if it exists and is a function
+      // Time Complexity: O(1) (assuming predicate function has constant time)
+      if (isFunction(localPredicate) && !localPredicate(value)) {
+        shouldInclude = false
+      }
+
+      // Apply the global predicate function if it exists and is a function
+      // This is only done if 'shouldInclude' is still true after applying the local predicate
+      // Time Complexity: O(1) (assuming predicate function has constant time)
+      if (shouldInclude && isFunction(globalPredicate) && !globalPredicate(key, value)) {
+        shouldInclude = false
+      }
+
+      // If the key-value pair passed both the local and global predicates, add it to the filtered object
+      // Time Complexity: O(1) for adding to object, but recursive call can take O(n) for nested objects
+      // Space Complexity: O(1) for storing a single key-value pair, but O(n) for nested objects
+      if (shouldInclude) {
+        filteredObj[key] = deepKeyPrune(value, predicates, globalPredicate)
+      }
+    }
+  }
+
+  // Space Complexity: O(n) for the filtered object
+  return filteredObj
+}
+
+export default deepKeyPrune

--- a/test/deepKeyPrunetest.test.js
+++ b/test/deepKeyPrunetest.test.js
@@ -1,0 +1,233 @@
+/* eslint-disable no-undef */
+import assert from 'assert'
+import deepKeyPrune from '../deepKeyPrune.js'
+
+
+describe('deepKeyPrune', () => {
+  it('should filter properties based on provided predicates', () => {
+    const data = {
+      name: 'John',
+      age: 30,
+      address: {
+        city: 'New York',
+        country: 'USA'
+      },
+      hobbies: ['reading', 'swimming']
+    }
+
+    const filters = {
+      name: (value) => value !== 'John',
+      city: (value) => value !== 'New York',
+      country: (value) => value !== 'USA'
+    }
+
+    const filteredData = deepKeyPrune(data, filters)
+
+    assert.deepStrictEqual(filteredData, {
+      age: 30,
+      address: {},
+      hobbies: ['reading', 'swimming']
+    })
+  })
+
+  it('should handle filtering in nested arrays', () => {
+    const data = {
+      items: [
+        { name: 'item1', active: true },
+        { name: 'item2', active: false }
+      ]
+    }
+
+    const filters = {
+      active: (value) => value === true
+    }
+
+    const filteredData = deepKeyPrune(data, filters)
+
+    assert.deepStrictEqual(filteredData, {
+      items: [{ name: 'item1', active: true }, { name: 'item2' }]
+    })
+  })
+
+  it('should handle filtering of deeply nested objects', () => {
+    const data = {
+      level1: {
+        level2: {
+          level3: {
+            value1: 'keep',
+            value2: 'remove'
+          }
+        }
+      }
+    }
+
+    const filters = {
+      value2: (value) => value !== 'remove'
+    }
+
+    const filteredData = deepKeyPrune(data, filters)
+
+    assert.deepStrictEqual(filteredData, {
+      level1: {
+        level2: {
+          level3: {
+            value1: 'keep'
+          }
+        }
+      }
+    })
+  })
+
+  it('should not modify the original object', () => {
+    const data = {
+      name: 'John',
+      age: 30
+    }
+
+    const filters = {
+      age: (value) => value > 25
+    }
+
+    deepKeyPrune(data, filters)
+
+    assert.deepStrictEqual(data, {
+      name: 'John',
+      age: 30
+    })
+  })
+
+  it('should handle deep filtering with nested objects', () => {
+    const data = {
+      person: {
+        name: 'Alice',
+        age: 25,
+        address: {
+          street: '456 Elm St',
+          city: 'Townsville'
+        }
+      }
+    }
+
+    const predicates = {
+      person: (value) => typeof value === 'object',
+      age: (value) => value <= 18,
+      street: (value) => typeof value === 'string'
+    }
+
+    const expectedFilteredData = {
+      person: {
+        name: 'Alice',
+        address: {
+          street: '456 Elm St',
+          city: 'Townsville'
+        }
+      }
+    }
+
+    const filteredData = deepKeyPrune(data, predicates)
+    assert.deepEqual(filteredData, expectedFilteredData)
+  })
+
+  it('should handle empty object and array filtering', () => {
+    const data = {
+      prop1: {},
+      prop2: [],
+      prop3: {
+        nested: {},
+        nestedArray: []
+      }
+    }
+
+    const predicates = {
+      prop1: (value) => typeof value === 'object',
+      prop2: (value) => Array.isArray(value),
+      nested: (value) => typeof value === 'object',
+      nestedArray: (value) => Array.isArray(value)
+    }
+
+    const expectedFilteredData = {
+      prop1: {},
+      prop2: [],
+      prop3: {
+        nested: {},
+        nestedArray: []
+      }
+    }
+
+    const filteredData = deepKeyPrune(data, predicates)
+    assert.deepEqual(filteredData, expectedFilteredData)
+  })
+
+  it('should filter based on both local and global predicates', () => {
+    const originalObject = { a: 1, b: 2, c: { d: 3, e: 4 } }
+
+    const predicates = {
+      a: (v) => v > 2
+    }
+
+    const globalPredicate = (k, v) => v !== 4
+
+    assert.deepStrictEqual(deepKeyPrune(originalObject, predicates, globalPredicate), {
+      b: 2,
+      c: {
+        d: 3
+      }
+    })
+  })
+
+  it('should filter based on both local and global predicates', () => {
+    const originalObject = { a: 1, b: 2, c: { d: 3, e: 4 } }
+
+    const predicates = {
+      a: (v) => v > 2
+    }
+
+    const globalPredicate = (k, v) => v !== 4
+
+    assert.deepStrictEqual(deepKeyPrune(originalObject, predicates, globalPredicate), {
+      b: 2,
+      c: {
+        d: 3
+      }
+    })
+  })
+
+  it('should filter based on both local and global predicates key', () => {
+    const originalObject = { a: 1, b: 2, c: { d: 3, e: 4 } }
+
+    const predicates = {
+      a: (v) => v > 2
+    }
+
+    const globalPredicate = (k, v) => k !== 'e'
+
+    assert.deepStrictEqual(deepKeyPrune(originalObject, predicates, globalPredicate), {
+      b: 2,
+      c: {
+        d: 3
+      }
+    })
+  })
+
+
+})
+
+
+describe('deepKeyPrune Function Tests', () => {
+
+  it('should filter out employees based on a global predicate that checks age', () => {
+    const employees = [
+      { name: 'Alice', age: 30, role: 'developer' },
+      { name: 'Bob', age: 25, role: 'designer' },
+      { name: 'Charlie', age: 35, role: 'manager' }
+    ]
+    const globalPredicate = (key, value) => !(key === 'age' && value < 30)
+    assert.deepStrictEqual(deepKeyPrune(employees, {}, globalPredicate), [
+      { name: 'Alice', age: 30, role: 'developer' },
+      { name: 'Bob', role: 'designer' },
+      { name: 'Charlie',age: 35, role: 'manager' }
+    ])
+  })
+
+})
+


### PR DESCRIPTION
## Description

This PR adds a new utility function `deepKeyPrune` that recursively prunes keys from an object based on provided predicates.

## New Function Documentation


# `deepKeyPrune` Documentation

## `_.deepKeyPrune(object, predicates, [globalPredicate])`

Recursively prunes keys from an object based on provided predicates.

### Arguments

- `object` (Object|Array): The object or array to process.
- `predicates` (Object): An object containing key-specific predicate functions.
- `globalPredicate` (Function, Optional): A function applied globally to all key-value pairs; defaults to `null`.

### Returns

(Object|Array): Returns the new object or array with pruned keys.

### Example

\`\`\`javascript
const obj = {
  a: 1,
  b: {
    c: 2,
    d: 3
  },
  e: [4, 5, { f: 6 }]
};

const predicates = {
  a: (val) => val > 0,
  c: (val) => val < 3
};

const globalPredicate = (key, val) => key !== 'e';

const result = _.deepKeyPrune(obj, predicates, globalPredicate);
// Output: { a: 1, b: { c: 2 } }
\`\`\`

### Time Complexity

- Overall Time Complexity: \(O(n)\), where \(n\) is the total number of keys in all nested objects.

### Space Complexity

- Overall Space Complexity: \(O(n)\), where \(n\) is the total number of keys that pass the predicates in all nested objects.

### Note

This function does not mutate the original object; it returns a new object or array.


## Checklist

- [x] Added unit tests
- [x] Updated documentation
