### PR TITLE
Fixes #5751

### DIFF
--- a/src/size.ts
+++ b/src/size.ts
@@ -30,7 +30,7 @@ function size(collection) {
     if (collection == null) {
         return 0;
     }
-    if (isArrayLike(collection)) {
+    if (isArrayLike(collection) && collection.constructor.name !== 'Object') {
         return isString(collection) ? stringSize(collection) : collection.length;
     }
     const tag = getTag(collection);


### PR DESCRIPTION
According to the issue [#5751](https://github.com/lodash/lodash/issues/5751), the size is not calculating the length properly when we give it a native object with 'length' key, like this: `_.size({ 'a': 1, 'b': 2, 'length': 5 })`

I excluded native JS objects in size function by `"collection.constructor.name !== 'Object'"`. Other verification was not needed since the **isArrayLike** method checked before that we have an array like object.
