### PR TITLE
feat: init is primitive funciton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lodash",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "private": true,
   "main": "dist/lodash.js",

--- a/src/isPrimitive.ts
+++ b/src/isPrimitive.ts
@@ -1,0 +1,24 @@
+/**
+ * Checks if `value` is classified as a `String` primitive or object.
+ *
+ * @since 4.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a primitive, else `false`.
+ * @link https://developer.mozilla.org/en-US/docs/Glossary/Primitive
+ * @example
+ *
+ * isPrimitive('abc')
+ * // => true
+ *
+ * isPrimitive(null)
+ * // => true
+ *
+ * isPrimitive({})
+ * // => false
+ */
+function isPrimitive(value?: unknown): boolean {
+    return value !== Object(value);
+}
+
+export default isPrimitive;

--- a/test/isPrimitive.spec.js
+++ b/test/isPrimitive.spec.js
@@ -1,0 +1,25 @@
+// @ts-check
+import isPrimitive from '../src/isPrimitive';
+
+describe('isPrimitive', () => {
+    it('should return `true` for primitive', () => {
+        expect(isPrimitive()).toBeTruthy();
+        expect(isPrimitive('a')).toBeTruthy();
+        expect(isPrimitive(13)).toBeTruthy();
+        expect(isPrimitive(0)).toBeTruthy();
+        expect(isPrimitive(true)).toBeTruthy();
+        expect(isPrimitive(false)).toBeTruthy();
+        expect(isPrimitive(null)).toBeTruthy();
+        expect(isPrimitive(10n)).toBeTruthy();
+    });
+
+    it('should return `false` for non-primitive', () => {
+        expect(isPrimitive(Object('args'))).toBe(false);
+        expect(isPrimitive({ title: 'lodash' })).toBe(false);
+        expect(isPrimitive([1, 2, 3])).toBe(false);
+        expect(isPrimitive(new Date())).toBe(false);
+        expect(isPrimitive(new Error())).toBe(false);
+        expect(isPrimitive(/lodash/)).toBe(false);
+        expect(isPrimitive({ 0: 1, length: 1 })).toBe(false);
+    });
+});


### PR DESCRIPTION
It seems, make sense to extend the `lodash` functionality with the function which checks is the value is [primitive ](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) or not.