### PR TITLE
feat(last): add optional n elements parameter

### DIFF
--- a/src/last.ts
+++ b/src/last.ts
@@ -1,18 +1,22 @@
 /**
- * Gets the last element of `array`.
+ * Gets the last [n] element(s) of `array`.
  *
  * @since 0.1.0
  * @category Array
  * @param {Array} array The array to query.
- * @returns {*} Returns the last element of `array`.
+ * @param {Number} n The number of elements.
+ * @returns {*} Returns the last [n] element(s) of `array`.
  * @example
  *
  * last([1, 2, 3])
  * // => 3
+ *
+ * last([1, 2, 3], 2)
+ * // => [2, 3]
  */
-function last(array) {
-    const length = array == null ? 0 : array.length;
-    return length ? array[length - 1] : undefined;
+function last(array = [], n = 1) {
+    const results = array.slice(-n)
+    return results.length > 1 ? results : results[0]
 }
 
 export default last;

--- a/src/last.ts
+++ b/src/last.ts
@@ -4,19 +4,20 @@
  * @since 0.1.0
  * @category Array
  * @param {Array} array The array to query.
- * @param {Number} n The number of elements.
+ * @param {Object} n The number of elements.
  * @returns {*} Returns the last [n] element(s) of `array`.
  * @example
  *
  * last([1, 2, 3])
  * // => 3
  *
- * last([1, 2, 3], 2)
+ * last([1, 2, 3], { n: 2 })
  * // => [2, 3]
  */
-function last(array = [], n = 1) {
-    const results = array.slice(-n)
-    return results.length > 1 ? results : results[0]
+function last(array = [], options = {}) {
+    const { n = 1 } = options;
+    const results = array.slice(-n);
+    return results.length > 1 ? results : results[0];
 }
 
 export default last;

--- a/test/last.spec.js
+++ b/test/last.spec.js
@@ -8,6 +8,10 @@ describe('last', () => {
         expect(last(array)).toBe(4);
     });
 
+    it('should return the last n elements', () => {
+        expect(last(array, 2)).toEqual([3, 4]);
+    });
+
     it('should return `undefined` when querying empty arrays', () => {
         const array = [];
         array['-1'] = 1;

--- a/test/last.spec.js
+++ b/test/last.spec.js
@@ -9,7 +9,7 @@ describe('last', () => {
     });
 
     it('should return the last n elements', () => {
-        expect(last(array, 2)).toEqual([3, 4]);
+        expect(last(array, { n: 2 })).toEqual([3, 4]);
     });
 
     it('should return `undefined` when querying empty arrays', () => {


### PR DESCRIPTION
For example:
~~~ js
const array = [1,2,3,4]

_.last(array, { n: 2 }) // [3, 4]

_.last(array) // 4

[array].map(_.last) // [4]
~~~
