### PR TITLE
Docs: Fix inconsistent terminology between reject and unescape functions

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -15200,7 +15200,7 @@
     }
 
     /**
-     * The inverse of `_.escape`; this method converts the HTML entities
+     * The opposite of `_.escape`; this method converts the HTML entities
      * `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;` in `string` to
      * their corresponding characters.
      *


### PR DESCRIPTION
Fixes https://github.com/lodash/lodash/issues/5940

This PR addresses the inconsistent terminology in the documentation:

reject was described as "The opposite of _.filter"
unescape was described as "The inverse of _.escape"
I've standardized the terminology to use "opposite" consistently across both functions to improve documentation clarity.

The issue also mentioned cross-referencing, but both functions already correctly reference each other with @see tags.