### PR TITLE
test: add test for chunk with empty array

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2590,6 +2590,13 @@
       var actual = lodashStable.map([[1, 2], [3, 4]], _.chunk);
       assert.deepEqual(actual, [[[1], [2]], [[3], [4]]]);
     });
+
+    QUnit.test('should return an empty array when input is empty', function(assert) {
+      assert.expect(1);
+
+      var actual = _.chunk([], 3);
+      assert.deepEqual(actual, []);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Adds a missing test case for _.chunk([], 0) to ensure it returns an empty array as expected.

Although [issue #5293](https://github.com/lodash/lodash/issues/5293) was closed, the discussion clarified that chunking an empty array should result in an empty array, not [[]]. This PR adds a test to explicitly document and guard this behavior.