### PR TITLE
test: add test for size with string input

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2590,6 +2590,13 @@
       var actual = lodashStable.map([[1, 2], [3, 4]], _.chunk);
       assert.deepEqual(actual, [[[1], [2]], [[3], [4]]]);
     });
+
+    QUnit.test('should return an empty array when input is empty', function(assert) {
+      assert.expect(1);
+
+      var actual = _.chunk([], 3);
+      assert.deepEqual(actual, []);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/

--- a/test/test.js
+++ b/test/test.js
@@ -20467,6 +20467,12 @@
 
       assert.strictEqual(_.size({ 'length': '0' }), 1);
     });
+
+    QUnit.test('should return string length for string values', function(assert) {
+      assert.expect(1);
+
+      assert.strictEqual(_.size('hi'), 2);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Adds a test to verify that `_.size` correctly returns the length of string values.

This ensures that string inputs like `'hi'` return the expected length (2), aligning with Lodash documentation and behavior for string primitives.