### PR TITLE
fix: exclude NaN from isNumber

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -3766,7 +3766,7 @@
           if (isArray(iteratee)) {
             return function(value) {
               return baseGet(value, iteratee.length === 1 ? iteratee[0] : iteratee);
-            }
+            };
           }
           return iteratee;
         });
@@ -11961,7 +11961,8 @@
       // An `NaN` primitive is the only value that is not equal to itself.
       // Perform the `toStringTag` check first to avoid errors with some
       // ActiveX objects in IE.
-      return isNumber(value) && value != +value;
+      return (typeof value == 'number' ||
+        (isObjectLike(value) && baseGetTag(value) == numberTag)) && value != +value;
     }
 
     /**
@@ -12069,8 +12070,9 @@
      * // => false
      */
     function isNumber(value) {
-      return typeof value == 'number' ||
-        (isObjectLike(value) && baseGetTag(value) == numberTag);
+      return typeof value == 'number'
+        ? value === value
+        : (isObjectLike(value) && baseGetTag(value) == numberTag && value.valueOf() === value.valueOf());
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -11293,18 +11293,24 @@
 
   (function() {
     QUnit.test('should return `true` for numbers', function(assert) {
-      assert.expect(3);
+      assert.expect(2);
 
       assert.strictEqual(_.isNumber(0), true);
       assert.strictEqual(_.isNumber(Object(0)), true);
-      assert.strictEqual(_.isNumber(NaN), true);
+    });
+
+    QUnit.test('should return `false` for NaNs', function(assert) {
+      assert.expect(2);
+
+      assert.strictEqual(_.isNumber(NaN), false);
+      assert.strictEqual(_.isNumber(Object(NaN)), false);
     });
 
     QUnit.test('should return `false` for non-numbers', function(assert) {
       assert.expect(12);
 
       var expected = lodashStable.map(falsey, function(value) {
-        return typeof value == 'number';
+        return typeof value == 'number' && value === value;
       });
 
       var actual = lodashStable.map(falsey, function(value, index) {
@@ -25846,7 +25852,7 @@
 
       _.zipObjectDeep([keyToTest + '.a'], ['newValue']);
       // Can't access plain `a` as it's not defined and test fails
-      assert.notEqual(root['a'], 'newValue');
+      assert.notEqual(root.a, 'newValue');
     });
 
     QUnit.test('zipObjectDeep is not overwriting ' + keyToTest + ' on vars', function (assert) {
@@ -25855,20 +25861,20 @@
       const b = 'oldValue'
       _.zipObjectDeep([keyToTest + '.b'], ['newValue']);
       assert.equal(b, 'oldValue');
-      assert.notEqual(root['b'], 'newValue');
+      assert.notEqual(root.b, 'newValue');
 
       // ensure nothing was created
-      assert.notOk(root['b']);
+      assert.notOk(root.b);
     });
 
     QUnit.test('zipObjectDeep is not overwriting global.' + keyToTest, function (assert) {
       assert.expect(2);
 
       _.zipObjectDeep([root + '.' + keyToTest + '.c'], ['newValue']);
-      assert.notEqual(root['c'], 'newValue');
+      assert.notEqual(root.c, 'newValue');
 
       // ensure nothing was created
-      assert.notOk(root['c']);
+      assert.notOk(root.c);
     });
   });
 


### PR DESCRIPTION
- Updated isNumber so it now returns false for NaN values—including boxed numbers—by explicitly checking that the numeric value equals itself

- Revised isNaN to perform its own number check instead of calling isNumber, preserving correct behavior for NaN primitives and objects

- Added unit tests covering the new NaN behavior and adjusted existing expectations to reflect the change

- Tidied prototype-pollution tests by replacing bracket notation with dot notation to satisfy style guidelines