### PR TITLE
Add CI pipeline for documentation

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,32 @@
+name: CI Docs
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # Run on every PR, regardless of branch
+    branches: [ '*' ]
+
+jobs:
+  test-docs:
+    name: Docs Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (latest)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'node' # Use 'node' for the latest version
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test documentation
+        run: |
+          npm run doc:fp
+          npm run doc:site
+          npm run doc


### PR DESCRIPTION
### Main Changes
This PR introduces a new pipeline to run the documentation scripts (`npm run doc:fp`, `npm run doc:site` and `npm run doc`) in isolated mode to save some time while running large matrix on Node (#6022) and Bun (#6023)

### Assumptions

- We don't care about the node version, so latest available is used
- We run it on every PR and when something has landed to `main` branch.

### Context
- Related https://github.com/lodash/lodash/issues/6019