### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 7
+      default-days: 14
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
### Main Changes

Adds a simple Dependabot configuration that runs monthly for GitHub Actions and npm dependencies, while avoiding semver-major updates for npm.

### Assumptions

All our dependencies are dev only, so probably we can con with a longer time (quarterly?)

### Context

Related to https://github.com/lodash/lodash/issues/6027 

