### PR TITLE
Account for governance and maturity stage transition

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,7 +18,7 @@ The current Technical Steering Committee (TSC) members are:
 
 The Security Triage Team is responsible for assessing and managing vulnerability and incident reports. Security triaging is currently handled by the [TSC](#technical-steering-committee-members).
 
-### Release Team
+## Release Team
 
 The Release Team is solely responsible for publishing new versions of Lodash to npm. Its current member is:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,17 +16,10 @@ The current Technical Steering Committee (TSC) members are:
 
 ## Security Triage Team
 
-The Security Triage Team is responsible for assessing and managing vulnerability and incident reports. Its current members are:
-
-- John-David Dalton ([@jdalton](https://github.com/jdalton))
-- Jon Church ([@jonchurch](https://github.com/jonchurch))
-- Jordan Harband ([@ljharb](https://github.com/ljharb))
-- Ulises Gascón ([@UlisesGascon](https://github.com/UlisesGascon))
+The Security Triage Team is responsible for assessing and managing vulnerability and incident reports. Security triaging is currently handled by the [TSC](#technical-steering-committee-members).
 
 ### Release Team
 
 The Release Team is solely responsible for publishing new versions of Lodash to npm. Its current member is:
 
 - John-David Dalton ([@jdalton](https://github.com/jdalton))
-
-

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,10 +1,32 @@
+> [!IMPORTANT]
+> As announced on the [OpenJS Foundation blog](https://openjsf.org/blog/sta-supports-lodash), Lodash has received support from the Sovereign Tech Agency and will transition to the Feature-Complete maturity stage so that it remains stable, secure, and sustainable long-term. As part of this effort, Lodash is rebooting its governance. A draft charter will be published shortly. The upcoming Technical Steering Committee (TSC) is already at work. For transparency, its members are listed below.
+
 # Lodash Governance
 
-We're establishing a formal governance structure and Technical Steering Committee. For more details, please see the [following blog post](https://openjsf.org/blog/sta-supports-lodash). In the interim, the following folks are participating:
+## Technical Steering Committee Members
 
-- [@jonchurch](https://github.com/jonchurch)- Jon Church
-- [@jdalton](https://github.com/jdalton)- John-David Dalton
-- [@ulisesgascon](https://github.com/ulisesgascon)- Ulises Gascón
-- [@tobie](https://github.com/tobie) - Tobie Langel
-- [@falsyvalues](https://github.com/falsyvalues) - Michał Lipiński
-- [@bensternthal](https://github.com/bensternthal) - Benjamin Sternthal
+The current Technical Steering Committee (TSC) members are:
+
+- John-David Dalton ([@jdalton](https://github.com/jdalton)), _(Lodash creator)_
+- Jon Church ([@jonchurch](https://github.com/jonchurch))
+- Jordan Harband ([@ljharb](https://github.com/ljharb))
+- Michał Lipiński ([@falsyvalues](https://github.com/falsyvalues))
+- Tobie Langel ([@tobie](https://github.com/tobie))
+- Ulises Gascón ([@ulisesgascon](https://github.com/UlisesGascon))
+
+## Security Triage Team
+
+The Security Triage Team is responsible for assessing and managing vulnerability and incident reports. Its current members are:
+
+- John-David Dalton ([@jdalton](https://github.com/jdalton))
+- Jon Church ([@jonchurch](https://github.com/jonchurch))
+- Jordan Harband ([@ljharb](https://github.com/ljharb))
+- Ulises Gascón ([@UlisesGascon](https://github.com/UlisesGascon))
+
+### Release Team
+
+The Release Team is sole responsible for publishing new versions of Lodash to npm. Its current member is:
+
+- John-David Dalton ([@jdalton](https://github.com/jdalton))
+
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,7 +25,7 @@ The Security Triage Team is responsible for assessing and managing vulnerability
 
 ### Release Team
 
-The Release Team is sole responsible for publishing new versions of Lodash to npm. Its current member is:
+The Release Team is solely responsible for publishing new versions of Lodash to npm. Its current member is:
 
 - John-David Dalton ([@jdalton](https://github.com/jdalton))
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lodah v4.17.21
+# lodash v4.17.21
 
 [Site](https://lodash.com/) |
 [Docs](https://lodash.com/docs) |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# lodash v4.17.21
-
-> [!NOTE]
-> As announced on the [OpenJS Foundation blog](https://openjsf.org/blog/sta-supports-lodash), Lodash has received support from the Sovereign Tech Agency to transition into a Feature-Complete maturity stage project, ensuring its long-term stability, security, and sustainability. As part of this effort, Lodash is rebooting its governance. A draft charter will be published shortly. The interim Technical Steering Committee is already at work. For transparency, its members are listed in [GOVERNANCE.md](GOVERNANCE.md).
+# lodah v4.17.21
 
 [Site](https://lodash.com/) |
 [Docs](https://lodash.com/docs) |
@@ -9,8 +6,12 @@
 [Contributing](https://github.com/lodash/lodash/blob/master/.github/CONTRIBUTING.md) |
 [Wiki](https://github.com/lodash/lodash/wiki "Changelog, Roadmap, etc.") |
 [Code of Conduct](https://js.foundation/conduct/) |
+[Governance](https://github.com/lodash/lodash/blob/HEAD/GOVERNANCE.md) |
 [Twitter](https://twitter.com/bestiejs) |
 [Chat](https://gitter.im/lodash/lodash)
+
+> [!IMPORTANT]
+> As announced on the [OpenJS Foundation blog](https://openjsf.org/blog/sta-supports-lodash), Lodash has received support from the Sovereign Tech Agency and will transition to the Feature-Complete maturity stage so that it remains stable, secure, and sustainable long-term. As part of this effort, Lodash is rebooting its governance. A draft charter will be published shortly. The upcoming Technical Steering Committee (TSC) is already at work. For transparency, its members are listed in [GOVERNANCE.md](https://github.com/lodash/lodash/blob/HEAD/GOVERNANCE.md).
 
 The [Lodash](https://lodash.com/) library exported as a [UMD](https://github.com/umdjs/umd) module.
 

--- a/incident_response_plan.md
+++ b/incident_response_plan.md
@@ -5,7 +5,7 @@ Security is a top priority for Lodash team. This document outlines the **formal 
 
 ## Scope
 
-The Security Triage Team will use this document as a process guide when a security vulnerability is reported, from triage to resolution. This process must align with the project's [SECURITY policy](SECURITY.md) and cannot diverge significantly.
+The [Security Triage Team][] will use this document as a process guide when a security vulnerability is reported, from triage to resolution. This process must align with the project's [SECURITY policy](SECURITY.md) and cannot diverge significantly.
 
 
 ## Security Report Handling Flowchart
@@ -76,7 +76,7 @@ This person submits a security report to the Security Triage Team and provides d
 **Expectations**
 - Provide detailed information about the suspected vulnerability.
 - Follow responsible disclosure guidelines (report privately before public disclosure).
-- Cooperate with the security team by providing additional details when needed.
+- Cooperate with the Security Triage Team by providing additional details when needed.
 - Test and verify patches (when applicable).
 - Respect security timelines and avoid premature public disclosure.
 
@@ -120,7 +120,7 @@ This person acts as the focal point for a specific security report and ensures t
 
 ## Runbook
 
-The following sections outline the **step-by-step process**, explaining each decision, scenario, and possible actions. In this guide we also include links that are private (limited to the security triage team), a general overview of the process in flowchart format can be found [here](#security-report-handling-flowchart).
+The following sections outline the **step-by-step process**, explaining each decision, scenario, and possible actions. In this guide we also include links that are private (limited to the Security Triage Team), a general overview of the process in flowchart format can be found [here](#security-report-handling-flowchart).
 
 ### Step 0: Security Report Received
 
@@ -135,9 +135,9 @@ Ideally, the report must contain **clear and detailed information** like (Affect
 > [!Note]
 > While this document refers to a single SRC for simplicity, in practice, having two coordinators is acceptable and often beneficial. A second coordinator can assist with tasks such as reviewing the advisory content before it is published, ensuring accuracy and completeness.
 
-1.2 If the report was created accidentally or intentionally in a public channel (e.g. GitHub issues), it is important to share this information ASAP in the private slack channel `#lodash-security-triage` so the Security triage team is aware of it. At this stage, our priority is to remove the report from public view as soon as possible and let the reporter know what happened next.
+1.2 If the report was created accidentally or intentionally in a public channel (e.g. GitHub issues), it is important to share this information ASAP in the private slack channel `#lodash-security-triage` so the Security Triage Team is aware of it. At this stage, our priority is to remove the report from public view as soon as possible and let the reporter know what happened next.
 
-1.2.1 In the case of a report made public in a Pull request or issue under the Lodash organization the following process will be followed (by a Lodash TC member):
+1.2.1 In the case of a report made public in a Pull request or issue under the Lodash organization the following process will be followed (by a Lodash TSC Member):
 
     * Move the issue to the private repository called [lodash/security-triage](https://github.com/lodash/security-triage).
     * For any related pull requests, create an associated issue in [lodash/security-triage](https://github.com/lodash/security-triage) repository. Add a copy of the patch for the pull request to the issue. Add screenshots of discussion from the pull request to the issue.
@@ -180,3 +180,5 @@ Ideally, the report must contain **clear and detailed information** like (Affect
 4.1 At this stage the Security Report Coordinator (SRC) will make the advisory public and close the coordination issue (opened in step 1).
 
 4.2 The Security Report Coordinator (SRC) can ask the TC team to coordinate blog post or social media announcements using the OpenJS Foundation channels.
+
+[Security Triage Team]: GOVERNANCE.md#security-triage-team

--- a/incident_response_plan.md
+++ b/incident_response_plan.md
@@ -1,7 +1,7 @@
 # Incident Response Plan
 
 ## Introduction
-Security is a top priority for Lodash team. This document outlines the **formal process** for handling **security reports**, including how to **triage**, **assess**, and **disclose** vulnerabilities responsibly.
+Security is a top priority for Lodash. This document outlines the **formal process** for handling **security reports**, including how to **triage**, **assess**, and **disclose** vulnerabilities responsibly.
 
 ## Scope
 
@@ -137,7 +137,7 @@ Ideally, the report must contain **clear and detailed information** like (Affect
 
 1.2 If the report was created accidentally or intentionally in a public channel (e.g. GitHub issues), it is important to share this information ASAP in the private slack channel `#lodash-security-triage` so the Security Triage Team is aware of it. At this stage, our priority is to remove the report from public view as soon as possible and let the reporter know what happened next.
 
-1.2.1 In the case of a report made public in a Pull request or issue under the Lodash organization the following process will be followed (by a Lodash TSC Member):
+1.2.1 In the case of a report made public in a Pull request or issue under the Lodash GitHub organization the following process will be followed (by a Lodash TSC Member):
 
     * Move the issue to the private repository called [lodash/security-triage](https://github.com/lodash/security-triage).
     * For any related pull requests, create an associated issue in [lodash/security-triage](https://github.com/lodash/security-triage) repository. Add a copy of the patch for the pull request to the issue. Add screenshots of discussion from the pull request to the issue.
@@ -149,7 +149,7 @@ Ideally, the report must contain **clear and detailed information** like (Affect
         > FYI @xxxx we asked GitHub to delete your pull request while we work on releases in private.
     * Update the team in the slack channel #lodash-security-triage`.
 
-1.2.2 In the case that the report is made public in a different channel that we don't own/control, the TC team will attempt to mitigate this by trying to remove the report from public view (reporting to support, asking the reporter to remove the report, etc...).
+1.2.2 In the case that the report is made public in a different channel that we don't own/control, the Lodash TSC will attempt to mitigate this by trying to remove the report from public view (reporting to support, asking the reporter to remove the report, etc...).
 
 
 1.3 At this stage the Security Report Coordinator (SRC) will create a (private) issue in [lodash/security-triage](https://github.com/lodash/security-triage) repository with the existing information from the security report unless it already exists (step 1.2.1). This issue will serve as the central discussion point for this particular report. At this stage is expected from the Security Report Coordinator (SRC) to acknowledge receipt of the security report to the reporter.
@@ -171,14 +171,14 @@ Ideally, the report must contain **clear and detailed information** like (Affect
 
 3.2 The mitigation team (remediation developer(s), analyst(s), reporter(s)) will work on the patch(es), re-evaluate the report once the patch is ready and include regression tests (when possible).
 
-3.3 The Lodash TC will announce publicly on a public issue that there is security patch available and the plan to do a release with an specific date (ideally) and the versions affected without providing additional information to prevent early disclosure.
+3.3 The Lodash TSC will announce publicly on a public issue that there is security patch available and the plan to do a release with an specific date (ideally) and the versions affected without providing additional information to prevent early disclosure.
 
-3.4 The TC team will create the releases and publish them to npm.
+3.4 The Lodash TSC will create the releases and publish them to npm.
 
 ### Step 4: Public disclosure
 
 4.1 At this stage the Security Report Coordinator (SRC) will make the advisory public and close the coordination issue (opened in step 1).
 
-4.2 The Security Report Coordinator (SRC) can ask the TC team to coordinate blog post or social media announcements using the OpenJS Foundation channels.
+4.2 The Security Report Coordinator (SRC) can ask the Lodash TSC to coordinate blog post or social media announcements using the OpenJS Foundation channels.
 
 [Security Triage Team]: GOVERNANCE.md#security-triage-team


### PR DESCRIPTION
- Add GOVERNANCE.MD which lists TSC members
- Add link from README to GOVERNANCE.md
- Add callout on README about governance and maturity stage transition