### PR TITLE
Document that `meanBy` can return `NaN` if array is empty.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -6591,7 +6591,7 @@ The iteratee is invoked with one argument: *(value)*.
 2. `[iteratee=_.identity]` *(Function)*: The iteratee invoked per element.
 
 #### Returns
-*(number)*: Returns the mean.
+*(number)*: Returns the mean. If array is empty, then will return `NaN`.
 
 #### Example
 ```js

--- a/lodash.js
+++ b/lodash.js
@@ -16437,7 +16437,7 @@
      * @category Math
      * @param {Array} array The array to iterate over.
      * @param {Function} [iteratee=_.identity] The iteratee invoked per element.
-     * @returns {number} Returns the mean.
+     * @returns {number} Returns the mean. If array is empty, then will return `NaN`
      * @example
      *
      * var objects = [{ 'n': 4 }, { 'n': 2 }, { 'n': 8 }, { 'n': 6 }];
@@ -16448,6 +16448,10 @@
      * // The `_.property` iteratee shorthand.
      * _.meanBy(objects, 'n');
      * // => 5
+     *
+     * // If array is empty, then will return NaN
+     * _.meanBy([], 'foo')
+     * // => NaN
      */
     function meanBy(array, iteratee) {
       return baseMean(array, getIteratee(iteratee, 2));


### PR DESCRIPTION
Merging this fixes #5901 by documenting this behavior.