### PR TITLE
doc: fix autoLink function, dont autolink from headers

### DIFF
--- a/lib/main/build-site.js
+++ b/lib/main/build-site.js
@@ -184,9 +184,16 @@ function build() {
     .readFileSync(readmePath, 'utf8')
     // Uncomment docdown HTML hints.
     .replace(/(<)!--\s*|\s*--(>)/g, '$1$2')
-    // Convert source and npm package links to anchors.
-    .replace(/\[source\]\(([^)]+)\) \[npm package\]\(([^)]+)\)/g, (match, href1, href2) =>
-      `<p><a href="${ href1 }">source</a> <a href="${ href2 }">npm package</a></p>`
+    // Convert docdown-generated [source] and [npm package] links to HTML.
+    // These appear as markdown immediately after h3 tags, which marky-markdown
+    // doesn't process (it treats content after HTML blocks as plain text).
+    // Pattern 1: Dual links for methods with npm packages.
+    .replace(/(<h3[^>]*>.*?<\/h3>)\n\[source\]\(([^)]+)\) \[npm package\]\(([^)]+)\)/g, (match, h3, href1, href2) =>
+      `${h3}\n<p><a href="${ href1 }">source</a> <a href="${ href2 }">npm package</a></p>`
+    )
+    // Pattern 2: Standalone [source] links for properties without npm packages.
+    .replace(/(<h3[^>]*>.*?<\/h3>)\n\[source\]\(([^)]+)\)(?! \[npm package\])/g, (match, h3, href) =>
+      `${h3}\n<p><a href="${ href }">source</a></p>`
     );
 
   const $ = cheerio.load(marky(markdown, {


### PR DESCRIPTION
This PR is for the tooling historically used to generate the HTML for the doc site

## Problem

The weirdness we saw in https://github.com/lodash/lodash.com/pull/300#discussion_r2582005308 was related to bugs in the preprocess and postprocess step in this repo when generating the doc site html.

We saw some md links to the source code not being converted into html, and double links in the h3s for some methods (the anchor link, then the h3 content itself wrapped in a link).

## Solution

Change 1: the issue was that the preprocess step was only converting the md links that had both a source and an npm package link. The regexp just was too strict, and didnt match on the API surfaces that had a source link but no npm link (bc there is no npm package for things like `_.VERSION`)

Change 2: exclude headers from the autolinking behavior. The selector there was matching anything in
`.doc-container code` that looked like a reference to a lodash method. But that also caught several headers. 

## Context
The process when running `npm run doc:sitehtml` goes:
* Generate markdown from the JSDoc (using docdown), writes to `doc/README.md`
* Preprocess said generated markdown in the `lib/main/build-site.js` script
  * Change 1 of this PR is at this step, converting md links like `[source](the github source...)` into html links
* Run that markdown through marky-markdown
* Run a postprocess step on the html
  * Change 2 of this PR was here, tweak the autolinking behavior when referencing a lodash method in doc body