### PR TITLE
fix(omit): prevent mutation of nested arrays in deep paths

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5648,7 +5648,7 @@
 
     /**
      * Used by `_.omit` to customize its `_.cloneDeep` use to only clone plain
-     * objects.
+     * objects and arrays.
      *
      * @private
      * @param {*} value The value to inspect.
@@ -5656,7 +5656,7 @@
      * @returns {*} Returns the uncloned value or `undefined` to defer cloning to `_.cloneDeep`.
      */
     function customOmitClone(value) {
-      return isPlainObject(value) ? undefined : value;
+      return isPlainObject(value) || isArray(value) ? undefined : value;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -16573,6 +16573,18 @@
         assert.deepEqual(object, { 'a': { 'b': 2 } });
       });
     });
+
+    QUnit.test('should not mutate `object` when using deep paths with arrays (issue #5610)', function(assert) {
+      assert.expect(2);
+
+      var object = { 'foo': [{ 'bar': 1 }] };
+      _.omit(object, 'foo.0.bar');
+      assert.deepEqual(object, { 'foo': [{ 'bar': 1 }] }, 'original object should not be mutated');
+
+      var object2 = { 'foo': [{ 'bar': 1 }] };
+      _.omit(object2, ['foo[0].bar']);
+      assert.deepEqual(object2, { 'foo': [{ 'bar': 1 }] }, 'original object should not be mutated with bracket notation');
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
## Summary

Fixes #5610

## Problem

When using `_.omit` with deep property paths that traverse arrays (e.g., `'foo.0.bar'`), the original input object was being mutated. This also affected `lodash/fp.omit`.

\`\`\`javascript
const obj = { foo: [{ bar: 1 }] };
_.omit(obj, 'foo.0.bar');
console.log(obj.foo[0]); // {} - original object was mutated!
\`\`\`

## Cause

The `customOmitClone` function was only configured to deep clone plain objects, not arrays. When `baseClone` encountered an array in the path, it returned the original array reference instead of cloning it.

## Solution

Added `isArray(value)` check to `customOmitClone` so arrays are also deep cloned before modification:

\`\`\`javascript
function customOmitClone(value) {
  return isPlainObject(value) || isArray(value) ? undefined : value;
}
\`\`\`

## Testing

- Added test case for deep paths with arrays
- Verified both `_.omit` and `lodash/fp.omit` now preserve immutability