### PR TITLE
Docs: Add -0 and BigInt zeros to _.compact falsey values list

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6961,7 +6961,7 @@
 
     /**
      * Creates an array with all falsey values removed. The values `false`, `null`,
-     * `0`, `""`, `undefined`, and `NaN` are falsey.
+     * `0`, `-0', '0n`, `""`, `undefined`, and `NaN` are falsey.
      *
      * @static
      * @memberOf _

--- a/lodash.js
+++ b/lodash.js
@@ -6961,7 +6961,7 @@
 
     /**
      * Creates an array with all falsey values removed. The values `false`, `null`,
-     * `0`, `-0', '0n`, `""`, `undefined`, and `NaN` are falsey.
+     * `0`, `-0', '0n`, `""`, `undefined`, and `NaN` are falsy.
      *
      * @static
      * @memberOf _

--- a/test/test.js
+++ b/test/test.js
@@ -163,9 +163,6 @@
   /** Used to provide falsey values to methods. */
   var falsey = [, null, undefined, false, 0, NaN, ''];
 
-  /** Used to provide extended falsey values including negative zero and BigInt zeros. */
-  var falseyWithBigInt = falsey.concat(-0, BigInt(0));
-
   /** Used to specify the emoji style glyph variant of characters. */
   var emojiVar = '\ufe0f';
 
@@ -3174,17 +3171,17 @@
       assert.expect(1);
 
       var array = ['0', '1', '2'];
-      assert.deepEqual(_.compact(falseyWithBigInt.concat(array)), array);
+      assert.deepEqual(_.compact(falsey.concat(array)), array);
     });
 
     QUnit.test('should work when in-between lazy operators', function(assert) {
       assert.expect(2);
 
       if (!isNpm) {
-        var actual = _(falseyWithBigInt).thru(_.slice).compact().thru(_.slice).value();
+        var actual = _(falsey).thru(_.slice).compact().thru(_.slice).value();
         assert.deepEqual(actual, []);
 
-        actual = _(falseyWithBigInt).thru(_.slice).push(true, 1).compact().push('a').value();
+        actual = _(falsey).thru(_.slice).push(true, 1).compact().push('a').value();
         assert.deepEqual(actual, [true, 1, 'a']);
       }
       else {

--- a/test/test.js
+++ b/test/test.js
@@ -163,6 +163,9 @@
   /** Used to provide falsey values to methods. */
   var falsey = [, null, undefined, false, 0, NaN, ''];
 
+  /** Used to provide extended falsey values including negative zero and BigInt zeros. */
+  var falseyWithBigInt = falsey.concat(-0, BigInt(0));
+
   /** Used to specify the emoji style glyph variant of characters. */
   var emojiVar = '\ufe0f';
 
@@ -3171,17 +3174,17 @@
       assert.expect(1);
 
       var array = ['0', '1', '2'];
-      assert.deepEqual(_.compact(falsey.concat(array)), array);
+      assert.deepEqual(_.compact(falseyWithBigInt.concat(array)), array);
     });
 
     QUnit.test('should work when in-between lazy operators', function(assert) {
       assert.expect(2);
 
       if (!isNpm) {
-        var actual = _(falsey).thru(_.slice).compact().thru(_.slice).value();
+        var actual = _(falseyWithBigInt).thru(_.slice).compact().thru(_.slice).value();
         assert.deepEqual(actual, []);
 
-        actual = _(falsey).thru(_.slice).push(true, 1).compact().push('a').value();
+        actual = _(falseyWithBigInt).thru(_.slice).push(true, 1).compact().push('a').value();
         assert.deepEqual(actual, [true, 1, 'a']);
       }
       else {


### PR DESCRIPTION
## Summary

Updates `_.compact` documentation to include `-0` and `0n` in the list of falsey values.

Closes #5779 

## Changes

- Updated `_.compact` documentation to include `-0` and `0n` as falsey values

## Background

JavaScript has additional falsey values that were not previously documented:

- `-0` (negative zero) - `Boolean(-0)` returns `false`
- `0n` (BigInt zero) - `Boolean(0n)` returns `false`  

The `_.compact` function already filters these values correctly since it uses truthiness checks internally, but the documentation did not reflect this behavior.