### PR TITLE
jsdoc(internal): setCacheHas JSDoc return type should be boolean

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -2300,7 +2300,7 @@
      * @name has
      * @memberOf SetCache
      * @param {*} value The value to search for.
-     * @returns {number} Returns `true` if `value` is found, else `false`.
+     * @returns {boolean} Returns `true` if `value` is found, else `false`.
      */
     function setCacheHas(value) {
       return this.__data__.has(value);

--- a/lodash.js
+++ b/lodash.js
@@ -2300,7 +2300,7 @@
      * @name has
      * @memberOf SetCache
      * @param {*} value The value to search for.
-     * @returns {number} Returns `true` if `value` is found, else `false`.
+     * @returns {boolean} Returns `true` if `value` is found, else `false`.
      */
     function setCacheHas(value) {
       return this.__data__.has(value);


### PR DESCRIPTION
setCacheHas JSDoc return type should be boolean

this is a private method of the also private `SetCache`, so impact is minimal but it was caught and fixed in #6069 to the amd distribution branch.

Opened against main to capture it, as main is source of truth for other distributions