### PR TITLE
Fix sumBy to return NaN for non-numeric values (fixes #5818)

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -967,6 +967,9 @@
     while (++index < length) {
       var current = iteratee(array[index]);
       if (current !== undefined) {
+        if (typeof current != 'number') {
+          return NaN;
+        }
         result = result === undefined ? current : (result + current);
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -21529,6 +21529,14 @@
       assert.strictEqual(_.sumBy(arrays, 0), 6);
       assert.strictEqual(_.sumBy(objects, 'a'), 6);
     });
+
+    QUnit.test('should return NaN when non-numeric values are encountered', function(assert) {
+      assert.expect(3);
+
+      assert.ok(isNaN(_.sumBy([{ 'a': 1 }, { 'a': 'f' }, { 'a': null }], 'a')));
+      assert.ok(isNaN(_.sumBy([{ 'a': 1 }, { 'a': 'string' }], 'a')));
+      assert.ok(isNaN(_.sumBy([{ 'a': 1 }, { 'a': {} }], 'a')));
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
## Description
Fixes issue #5818 where `sumBy` was returning a string concatenation instead of `NaN` when encountering non-numeric values.

## Changes
- Modified `baseSum` function to check if values are numbers before addition
- Returns `NaN` immediately when a non-numeric value is encountered
- Added test cases to verify the fix

## Testing
- ✅ Normal numeric sums still work correctly
- ✅ Non-numeric values (strings, null, objects) now return `NaN`
- ✅ Edge cases like `Infinity`, `-Infinity`, and `undefined` are handled correctly

## Example
Before: `_.sumBy([{ a: 1 }, { a: 'f' }, { a: null }], 'a')` → `'1fnull'`
After: `_.sumBy([{ a: 1 }, { a: 'f' }, { a: null }], 'a')` → `NaN`

Fixes #5818