### PR TITLE
fix(isPlainObject): return true for objects with nested null prototype

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -12149,8 +12149,18 @@
         return true;
       }
       var Ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor;
-      return typeof Ctor == 'function' && Ctor instanceof Ctor &&
-        funcToString.call(Ctor) == objectCtorString;
+      if (typeof Ctor == 'function' && Ctor instanceof Ctor &&
+          funcToString.call(Ctor) == objectCtorString) {
+        return true;
+      }
+      // Handle nested null prototype chain
+      while (proto !== null) {
+        if (hasOwnProperty.call(proto, 'constructor')) {
+          return false;
+        }
+        proto = getPrototype(proto);
+      }
+      return true;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -11489,6 +11489,14 @@
       assert.strictEqual(_.isPlainObject(object), true);
     });
 
+    QUnit.test('should return `true` for objects with nested null prototype', function(assert) {
+      assert.expect(1);
+
+      var object = create(create(null));
+      object.a = 1;
+      assert.strictEqual(_.isPlainObject(object), true);
+    });
+
     QUnit.test('should return `true` for objects with a `valueOf` property', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Objects created via Object.create(Object.create(null)) should be considered plain objects since their prototype chain consists only of null-prototype objects and eventually ends in null, without any custom constructors.

This fix was made in Zod here https://github.com/colinhacks/zod/pull/4574/changes