### PR TITLE
doc: fix quotes in _.compact jsdoc

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6961,7 +6961,7 @@
 
     /**
      * Creates an array with all falsey values removed. The values `false`, `null`,
-     * `0`, `-0', '0n`, `""`, `undefined`, and `NaN` are falsy.
+     * `0`, `-0`, `0n`, `""`, `undefined`, and `NaN` are falsy.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
the jsdoc was updated in https://github.com/lodash/lodash/pull/6062, but it used some straight quotes where backticks were desired