### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/browser-testing.yml
+++ b/.github/workflows/browser-testing.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js (latest)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'node' # Use 'node' for the latest version
           cache: 'npm'

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v44.0.0
         with:


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/browser-testing.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/ci-docs.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/ci-node.yml`
- Updated `actions/checkout` from `v5.0.0` to `v6` in `.github/workflows/renovate.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci-docs.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci-node.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci-bun.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/browser-testing.yml`
