### PR TITLE
Fix: Ensure numeric addition in baseSum to prevent string concatenation

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -967,7 +967,7 @@
     while (++index < length) {
       var current = iteratee(array[index]);
       if (current !== undefined) {
-        result = result === undefined ? current : (result + current);
+        result = result === undefined ? +current : (result + +current); // Use unary + to ensure numeric addition
       }
     }
     return result;


### PR DESCRIPTION
Fixes issue where _.sumBy returns a string instead of NaN when array contains mixed types. Uses unary + operator to coerce values to numbers before addition.