### PR TITLE
docs(reject): cross-reference filter/reject

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9239,10 +9239,9 @@
     }
 
     /**
-     * The opposite of `_.reject`; this method iterates over elements of
-     * `collection`, returning an array of all elements `predicate` returns
-     * truthy for. The predicate is invoked with three arguments:
-     * (value, index|key, collection).
+     * Iterates over elements of `collection`, returning an array of all elements
+     * `predicate` returns truthy for. The predicate is invoked with three
+     * arguments: (value, index|key, collection). The opposite of `_.reject`.
      *
      * **Note:** Unlike `_.remove`, this method returns a new array.
      *
@@ -15257,7 +15256,7 @@
     }
 
     /**
-     * The opposite of `_.escape`; this method converts the HTML entities
+     * The inverse of `_.escape`; this method converts the HTML entities
      * `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;` in `string` to
      * their corresponding characters.
      *

--- a/lodash.js
+++ b/lodash.js
@@ -9239,9 +9239,10 @@
     }
 
     /**
-     * Iterates over elements of `collection`, returning an array of all elements
-     * `predicate` returns truthy for. The predicate is invoked with three
-     * arguments: (value, index|key, collection).
+     * The opposite of `_.reject`; this method iterates over elements of
+     * `collection`, returning an array of all elements `predicate` returns
+     * truthy for. The predicate is invoked with three arguments:
+     * (value, index|key, collection).
      *
      * **Note:** Unlike `_.remove`, this method returns a new array.
      *
@@ -15247,7 +15248,7 @@
     }
 
     /**
-     * The inverse of `_.escape`; this method converts the HTML entities
+     * The opposite of `_.escape`; this method converts the HTML entities
      * `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;` in `string` to
      * their corresponding characters.
      *


### PR DESCRIPTION
Closes #5940

This docs-only PR addresses the wording inconsistency and discoverability concern in #5940:

- Updates `_.filter` docs to explicitly reference it as the opposite of `_.reject`
- ~Changes `_.unescape` wording from "inverse" to "opposite" for consistency with nearby docs~

No runtime code changes; comments/documentation only.