### PR TITLE
`_.random` document lower > upper value swap

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14164,6 +14164,8 @@
      * **Note:** JavaScript follows the IEEE-754 standard for resolving
      * floating-point values which can produce unexpected results.
      *
+     * **Note:** If `lower` is greater than `upper`, the values are swapped.
+     *
      * @static
      * @memberOf _
      * @since 0.7.0
@@ -14177,8 +14179,15 @@
      * _.random(0, 5);
      * // => an integer between 0 and 5
      *
+     * // when lower is greater than upper the values are swapped
+     * _.random(5, 0);
+     * // => an integer between 0 and 5
+     *
      * _.random(5);
      * // => also an integer between 0 and 5
+     *
+     * _.random(-5);
+     * // => an integer between -5 and 0
      *
      * _.random(5, true);
      * // => a floating-point number between 0 and 5


### PR DESCRIPTION
Closes #6113 

tldr; `_.random(lower, upper)` takes positional lower and upper args, but it is undocumented that it will shuffle the args into lower and upper despite position.

> If `lower` is greater than `upper`, the values are swapped.

