### PR TITLE
fix: prevent string concatenation in sumBy with non-numeric values

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -966,11 +966,11 @@
 
     while (++index < length) {
       var current = iteratee(array[index]);
-      if (current !== undefined) {
-        result = result === undefined ? current : (result + current);
+      if (current !== undefined && current !== null && !isSymbol(current)) {
+        result = result === undefined ? +current : (result + current);
       }
     }
-    return result;
+    return result || 0;
   }
 
   /**


### PR DESCRIPTION
Fixes issue where sumBy returns string when array contains null/string values. Now properly handles non-numeric values by treating them as 0.