### PR TITLE
docs: reference _.reject in _.filter description

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9239,9 +9239,10 @@
     }
 
     /**
-     * Iterates over elements of `collection`, returning an array of all elements
-     * `predicate` returns truthy for. The predicate is invoked with three
-     * arguments: (value, index|key, collection).
+     * The opposite of `_.reject`; this method iterates over elements of
+     * `collection`, returning an array of all elements `predicate` returns
+     * truthy for. The predicate is invoked with three arguments:
+     * (value, index|key, collection).
      *
      * **Note:** Unlike `_.remove`, this method returns a new array.
      *


### PR DESCRIPTION
### Summary
- update `_.filter` JSDoc intro to explicitly mirror `_.reject`
- keep wording consistent with existing opposite/inverse phrasing across docs

Fixes #5940
