### PR TITLE
Fix clone/cloneDeep for shadowed keys with non-writable inherited props

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2594,7 +2594,8 @@
      * @param {*} value The value to assign.
      */
     function baseAssignValue(object, key, value) {
-      if (key == '__proto__' && defineProperty) {
+      if (defineProperty && (key == '__proto__' ||
+            (key in objectProto && !hasOwnProperty.call(object, key)))) {
         defineProperty(object, key, {
           'configurable': true,
           'enumerable': true,

--- a/test/test.js
+++ b/test/test.js
@@ -2924,6 +2924,26 @@
         assert.notStrictEqual(actual, object);
       });
 
+      QUnit.test('`_.' + methodName + '` should clone own shadow properties when inherited keys are non-writable', function(assert) {
+        assert.expect(2);
+
+        var proto = Object.freeze({
+          'hasOwnProperty': objectProto.hasOwnProperty
+        });
+        var object = Object.create(proto);
+        Object.defineProperty(object, 'hasOwnProperty', {
+          'configurable': true,
+          'enumerable': true,
+          'value': 'shadowed',
+          'writable': true
+        });
+
+        var actual = func(object);
+
+        assert.strictEqual(actual.hasOwnProperty, 'shadowed');
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(actual, 'hasOwnProperty'), true);
+      });
+
       QUnit.test('`_.' + methodName + '` should clone symbol properties', function(assert) {
         assert.expect(7);
 


### PR DESCRIPTION
## Summary
Fixes cloning of own properties that shadow inherited keys when the inherited property is non-writable (for example when a prototype is frozen).

`baseAssignValue` now uses `defineProperty` not only for `__proto__`, but also when assigning a key inherited from `Object.prototype` and missing as an own property on the target object.

## Tests
- Added a regression test in clone methods suite for objects whose prototype has a frozen `hasOwnProperty` and whose own `hasOwnProperty` should be preserved after cloning.
- Ran: `node test/test.js` (PASS: 6804, FAIL: 0)

Fixes #6112
