### PR TITLE
docs(range): clarify inferred default step direction

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -16068,9 +16068,9 @@
 
     /**
      * Creates an array of numbers (positive and/or negative) progressing from
-     * `start` up to, but not including, `end`. A step of `-1` is used if a negative
-     * `start` is specified without an `end` or `step`. If `end` is not specified,
-     * it's set to `start` with `start` then set to `0`.
+     * `start` up to, but not including, `end`. If `end` is not specified,
+     * it's set to `start` with `start` then set to `0`. If `step` is not
+     * specified, it is inferred from the start/end direction.
      *
      * **Note:** JavaScript follows the IEEE-754 standard for resolving
      * floating-point values which can produce unexpected results.
@@ -16094,6 +16094,9 @@
      *
      * _.range(1, 5);
      * // => [1, 2, 3, 4]
+     *
+     * _.range(10, 0);
+     * // => [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
      *
      * _.range(0, 20, 5);
      * // => [0, 5, 10, 15]


### PR DESCRIPTION
## Summary
- clarify `_.range` docs to state that omitted `step` is inferred from start/end direction
- add an explicit descending example for `_.range(10, 0)`

Fixes #6057.

## Testing
- `npm run test:main` *(fails locally before execution because dev deps are not installed: missing module `qunit-extras`)*
