### PR TITLE
docs(unescape): use opposite wording to match _.reject docs

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -15256,7 +15256,7 @@
     }
 
     /**
-     * The inverse of `_.escape`; this method converts the HTML entities
+     * The opposite of `_.escape`; this method converts the HTML entities
      * `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;` in `string` to
      * their corresponding characters.
      *


### PR DESCRIPTION
## Summary\n- replace `_.unescape` description wording from "inverse" to "opposite"\n- aligns wording with `_.reject` docs for consistency\n\nCloses #5940\n\n## Testing\n- not run (docs-only comment change in `lodash.js`)