### PR TITLE
docs(mean/meanBy): document NaN return for empty arrays

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -15256,7 +15256,7 @@
     }
 
     /**
-     * The inverse of `_.escape`; this method converts the HTML entities
+     * The opposite of `_.escape`; this method converts the HTML entities
      * `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;` in `string` to
      * their corresponding characters.
      *

--- a/lodash.js
+++ b/lodash.js
@@ -16472,7 +16472,7 @@
      * @since 4.0.0
      * @category Math
      * @param {Array} array The array to iterate over.
-     * @returns {number} Returns the mean.
+     * @returns {number} Returns the mean, or `NaN` for empty arrays.
      * @example
      *
      * _.mean([4, 2, 8, 6]);
@@ -16493,7 +16493,7 @@
      * @category Math
      * @param {Array} array The array to iterate over.
      * @param {Function} [iteratee=_.identity] The iteratee invoked per element.
-     * @returns {number} Returns the mean.
+     * @returns {number} Returns the mean, or `NaN` for empty arrays.
      * @example
      *
      * var objects = [{ 'n': 4 }, { 'n': 2 }, { 'n': 8 }, { 'n': 6 }];


### PR DESCRIPTION
## Summary
- update `_.mean` docs to explicitly mention `NaN` on empty arrays
- update `_.meanBy` docs with the same return-value note
- address the documentation gap discussed in #5901

## Testing
- not run locally (`jscs` is not available in this checkout)
