### PR TITLE
docs(range): clarify behavior when step is 0

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -14162,7 +14162,8 @@
      * floats, a floating-point number is returned instead of an integer.
      *
      * **Note:** JavaScript follows the IEEE-754 standard for resolving
-     * floating-point values which can produce unexpected results.
+     * floating-point values which can produce unexpected results. If `step`
+     * is `0`, each element of the range is set to `start`.
      *
      * **Note:** If `lower` is greater than `upper`, the values are swapped.
      *
@@ -16111,7 +16112,7 @@
 
     /**
      * This method is like `_.range` except that it populates values in
-     * descending order.
+     * descending order. A `step` of `0` produces repeated `start` values.
      *
      * @static
      * @memberOf _


### PR DESCRIPTION
## Summary
- add explicit API-note wording that explains step=0 repeats `start` in `_.range`
- mirror the same clarification in `_.rangeRight` description

Fixes #5944.

## Validation
- `git diff --check`
- `node -e "const _=require('./lodash.js'); console.log(JSON.stringify(_.range(1,4,0)), JSON.stringify(_.rangeRight(1,4,0)))"`
