### PR TITLE
fix(unescape): decode &#38; HTML entity

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -131,7 +131,7 @@
       reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g;
 
   /** Used to match HTML entities and HTML characters. */
-  var reEscapedHtml = /&(?:amp|lt|gt|quot|#39);/g,
+  var reEscapedHtml = /&(?:amp|lt|gt|quot|#39|#38);/g,
       reUnescapedHtml = /[&<>"']/g,
       reHasEscapedHtml = RegExp(reEscapedHtml.source),
       reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
@@ -409,7 +409,8 @@
     '&lt;': '<',
     '&gt;': '>',
     '&quot;': '"',
-    '&#39;': "'"
+    '&#39;': "'",
+    '&#38;': '&'
   };
 
   /** Used to escape characters for inclusion in compiled string literals. */

--- a/test/test.js
+++ b/test/test.js
@@ -24676,9 +24676,10 @@
     });
 
     QUnit.test('should unescape the proper entities', function(assert) {
-      assert.expect(1);
+      assert.expect(2);
 
       assert.strictEqual(_.unescape(escaped), unescaped);
+      assert.strictEqual(_.unescape('Couples Therapy Naked &#38; Afraid'), 'Couples Therapy Naked & Afraid');
     });
 
     QUnit.test('should handle strings with nothing to unescape', function(assert) {


### PR DESCRIPTION
## Summary
- add `&#38;` to the list of HTML entities decoded by `_.unescape`
- include a regression test for `_.unescape('Couples Therapy Naked &#38; Afraid')`

## Testing
- `node -e "const assert=require('assert'); const _=require('./lodash'); assert.strictEqual(_.unescape('Couples Therapy Naked &#38; Afraid'),'Couples Therapy Naked & Afraid'); assert.strictEqual(_.unescape('&amp;lt;'),'&lt;');"`
- `git diff --check`

Fixes #5952
