### PR TITLE
docs(range): clarify default descending step behavior

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10893,9 +10893,9 @@ _.map([['a', '2'], ['c', '0']], _.propertyOf(object));
 [&#x24C8;](https://github.com/lodash/lodash/blob/4.17.23/lodash.js#L16054 "View in source") [&#x24C3;](https://www.npmjs.com/package/lodash.range "See the npm package") [&#x24C9;][1]
 
 Creates an array of numbers *(positive and/or negative)* progressing from
-`start` up to, but not including, `end`. A step of `-1` is used if a negative
-`start` is specified without an `end` or `step`. If `end` is not specified,
-it's set to `start` with `start` then set to `0`.
+`start` up to, but not including, `end`. If `step` is not specified, it
+defaults to `-1` when `start` is greater than `end`, otherwise `1`.
+If `end` is not specified, it's set to `start` with `start` then set to `0`.
 <br>
 <br>
 **Note:** JavaScript follows the IEEE-754 standard for resolving
@@ -10922,6 +10922,9 @@ _.range(-4);
 
 _.range(1, 5);
 // => [1, 2, 3, 4]
+
+_.range(10, 0);
+// => [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
 
 _.range(0, 20, 5);
 // => [0, 5, 10, 15]


### PR DESCRIPTION
## Summary
- clarify that `_.range(start, end)` defaults to a `-1` step when `start > end`
- add a concrete `_.range(10, 0)` example to match current runtime behavior

## Validation
- `git diff --check`
- `node -e "const assert=require('assert'); const _=require('./lodash'); assert.deepStrictEqual(_.range(10,0),[10,9,8,7,6,5,4,3,2,1]);"`

Refs #6057
