### PR TITLE
fix: clone() should work when Object.prototype is frozen

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2692,7 +2692,7 @@
           return cloneBuffer(value, isDeep);
         }
         if (tag == objectTag || tag == argsTag || (isFunc && !object)) {
-          result = (isFlat || isFunc) ? {} : initCloneObject(value);
+          result = (isFlat || isFunc) ? Object.create(null) : initCloneObject(value);
           if (!isDeep) {
             return isFlat
               ? copySymbolsIn(value, baseAssignIn(result, value))


### PR DESCRIPTION
When Object.prototype is frozen, using {} for shallow clones can cause issues with own properties like 'hasOwnProperty'. Using Object.create(null) creates a truly empty object without prototype inheritance.

Fixes #6112