### PR TITLE
fix(fp): avoid mutating global functions when adding convert

### DIFF
--- a/fp/_baseConvert.js
+++ b/fp/_baseConvert.js
@@ -543,8 +543,7 @@ function baseConvert(util, name, func, options) {
           return;
         }
       }
-      func.convert = createConverter(key, func);
-      pairs.push([key, func]);
+      pairs.push([key, wrap(key, func, _)]);
     }
   });
 

--- a/test/test-fp.js
+++ b/test/test-fp.js
@@ -263,6 +263,14 @@
       assert.strictEqual(isArray()(array), true);
     });
 
+    QUnit.test('should not mutate globals when adding `.convert`', function(assert) {
+      assert.expect(2);
+
+      assert.strictEqual(Array.isArray.convert, undefined);
+      fp.convert({ 'isArray': Array.isArray });
+      assert.strictEqual(Array.isArray.convert, undefined);
+    });
+
     QUnit.test('should convert method aliases', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
## Summary
- avoid mutating original function objects in `baseConvert` when wiring unconverted methods
- wrap remaining methods the same way as ary-capped methods so `.convert` is attached to wrappers only
- add a regression test to ensure `Array.isArray` is not polluted with a `.convert` property

Fixes #6105

## Validation
- `git diff --check`
- `node -e "const assert=require('assert'); assert.strictEqual(Array.isArray.convert, undefined); require('./dist/lodash.fp'); assert.strictEqual(Array.isArray.convert, undefined); console.log('ok')"`
- `node test/test-fp` *(fails in this environment on pre-existing shortcut-fusion expectations unrelated to this change)*
