### PR TITLE
fix(debounce/throttle): treat undefined options as missing

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -10430,9 +10430,9 @@
       wait = toNumber(wait) || 0;
       if (isObject(options)) {
         leading = !!options.leading;
-        maxing = 'maxWait' in options;
+        maxing = options.maxWait !== undefined;
         maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        trailing = options.trailing !== undefined ? !!options.trailing : trailing;
       }
 
       function invokeFunc(time) {
@@ -11013,8 +11013,8 @@
         throw new TypeError(FUNC_ERROR_TEXT);
       }
       if (isObject(options)) {
-        leading = 'leading' in options ? !!options.leading : leading;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        leading = options.leading !== undefined ? !!options.leading : leading;
+        trailing = options.trailing !== undefined ? !!options.trailing : trailing;
       }
       return debounce(func, wait, {
         'leading': leading,


### PR DESCRIPTION
## Problem

When `debounce` or `throttle` options are explicitly set to `undefined` (e.g., `{ leading: undefined, maxWait: undefined, trailing: undefined }`), the `'key' in options` check returns `true`, causing options to fall back to unexpected default values instead of the function's actual defaults.

## Root Cause

The `'key' in options` operator returns `true` for properties explicitly set to `undefined`, unlike `key !== undefined`.

**Debounce** (lodash.js:10433, 10435):
- `'maxWait' in options` returns `true` when `options.maxWait = undefined`, triggering `maxWait = 0` instead of keeping default
- `'trailing' in options` returns `true` when `options.trailing = undefined`, falling back to `false` instead of default `true`

**Throttle** (lodash.js:11016, 11017):
- `'leading' in options` returns `true` when `options.leading = undefined`, falling back to `false` instead of default `true`
- `'trailing' in options` returns `true` when `options.trailing = undefined`, falling back to `false` instead of default `true`

## Fix

Replace `'key' in options` checks with `options.key !== undefined`:

```js
// debounce
maxing = options.maxWait !== undefined;
trailing = options.trailing !== undefined ? !!options.trailing : trailing;

// throttle
leading = options.leading !== undefined ? !!options.leading : leading;
trailing = options.trailing !== undefined ? !!options.trailing : trailing;
```

## Testing

Manual verification confirms fix:
```js
const db = _.debounce(fn, 50, { maxWait: undefined, trailing: undefined });
// Now correctly uses defaults instead of falling back to 0/false
```

## Risk & Rollback

Risk: Low — only changes the condition for detecting whether an option was provided; defaults remain unchanged.
Rollback: Revert the 4 line changes in lodash.js.

Fixes #5857