### PR TITLE
fix(unescape): decode &#38; HTML entity to &

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -131,7 +131,7 @@
       reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g;
 
   /** Used to match HTML entities and HTML characters. */
-  var reEscapedHtml = /&(?:amp|lt|gt|quot|#39);/g,
+  var reEscapedHtml = /&(?:amp|lt|gt|quot|#38|#39);/g,
       reUnescapedHtml = /[&<>"']/g,
       reHasEscapedHtml = RegExp(reEscapedHtml.source),
       reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
@@ -409,6 +409,7 @@
     '&lt;': '<',
     '&gt;': '>',
     '&quot;': '"',
+    '&#38;': '&',
     '&#39;': "'"
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -24693,6 +24693,12 @@
       assert.strictEqual(_.unescape(_.escape(unescaped)), unescaped);
     });
 
+    QUnit.test('should unescape the "&#38;" entity', function(assert) {
+      assert.expect(1);
+
+      assert.strictEqual(_.unescape('&#38;'), '&');
+    });
+
     lodashStable.each(['&#96;', '&#x2F;'], function(entity) {
       QUnit.test('should not unescape the "' + entity + '" entity', function(assert) {
         assert.expect(1);


### PR DESCRIPTION
## Summary
&#38; is the decimal HTML entity for ampersand ("&").
Previously, `_.unescape('&#38;')` returned '&#38;' instead of '&'.

## Root Cause
`reEscapedHtml` regex only matched `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;`.
The `htmlUnescapes` map was missing the `&#38;` entry.

## Fix
1. `reEscapedHtml` regex: add `#38` to match &#38; in input
2. `htmlUnescapes`: add `'&#38;': '&'` mapping

## Testing
```
$.unescape('Couples Therapy Naked &#38; Afraid')
→ 'Couples Therapy Naked & Afraid' ✅

$.unescape('&#38;') === '&' ✅
$.unescape('&#39;') === "'"  ✅ (existing)
$.unescape('&amp;') === '&'   ✅ (existing)

Roundtrip: _.escape('a&<>"\'z') → _.unescape(result) ✅
```

Regression test added to `test/test.js`.

## Risk & Rollback
Risk: Low — additive fix, no breaking change (no existing code depends on &#38; remaining unescaped)
Rollback: Revert two-line change in lodash.js

Fixes #5952