### PR TITLE
fix(baseAssignValue): use defineProperty fallback when assignment is blocked by frozen prototype

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2602,7 +2602,27 @@
           'writable': true
         });
       } else {
-        object[key] = value;
+        // In strict mode, assigning to a property whose name shadows a
+        // non-writable property on a frozen prototype (e.g. a frozen
+        // Object.prototype) throws a TypeError.  In sloppy mode the same
+        // assignment silently fails, leaving no own property on `object`.
+        // Fall back to Object.defineProperty so that own properties with
+        // prototype-shadowing names are correctly set in both modes.
+        var succeeded;
+        try {
+          object[key] = value;
+          succeeded = hasOwnProperty.call(object, key);
+        } catch (e) {
+          succeeded = false;
+        }
+        if (!succeeded && defineProperty) {
+          defineProperty(object, key, {
+            'configurable': true,
+            'enumerable': true,
+            'value': value,
+            'writable': true
+          });
+        }
       }
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2924,6 +2924,33 @@
         assert.notStrictEqual(actual, object);
       });
 
+      QUnit.test('`_.' + methodName + '` should clone own properties that shadow frozen `Object.prototype` properties', function(assert) {
+        assert.expect(2);
+
+        // Object.freeze(Object.prototype) is irreversible so run in an isolated
+        // vm context to avoid contaminating the global prototype for other tests.
+        var _vm = (function() { try { return require('vm'); } catch(e) { return null; } }());
+        if (!_vm || !Object.freeze) {
+          assert.ok(true, 'test skipped: requires Node.js vm module and Object.freeze');
+          assert.ok(true, 'test skipped: requires Node.js vm module and Object.freeze');
+          return;
+        }
+
+        var context = _vm.createContext({ _: _, JSON: JSON, Object: Object });
+        var result = JSON.parse(_vm.runInContext([
+          'Object.freeze(Object.prototype);',
+          'var orig = { foo: "bar", hasOwnProperty: "custom" };',
+          'var cloned = _.clone(orig);',
+          'JSON.stringify({',
+          '  hasOwn: Object.prototype.hasOwnProperty.call(cloned, "hasOwnProperty"),',
+          '  value: cloned.hasOwnProperty',
+          '})'
+        ].join('\n'), context));
+
+        assert.ok(result.hasOwn, 'cloned object should have `hasOwnProperty` as an own property');
+        assert.strictEqual(result.value, 'custom', 'cloned `hasOwnProperty` should equal "custom"');
+      });
+
       QUnit.test('`_.' + methodName + '` should clone symbol properties', function(assert) {
         assert.expect(7);
 


### PR DESCRIPTION
## Summary

Fixes #6112

When `Object.prototype` (or any prototype in the prototype chain) is frozen, assigning a property whose name matches a non-writable property on that frozen prototype fails silently in sloppy mode or throws a `TypeError` in strict mode. This caused `_.clone` and `_.cloneDeep` to silently drop own properties whose names collide with frozen prototype properties (e.g. `hasOwnProperty`).

### Root cause

`baseAssignValue` used a bare assignment for all keys except `__proto__`:

```js
object[key] = value;  // silently drops the value when proto is frozen
```

### Fix

Wrap the assignment in a `try/catch` and verify the own property was actually created via `hasOwnProperty.call()`. If the assignment threw (strict mode) or the own property is still absent (sloppy mode), fall back to `Object.defineProperty` — matching the existing handling already in place for `__proto__`.

```js
// Before
object[key] = value;

// After
try {
  object[key] = value;
  succeeded = hasOwnProperty.call(object, key);
} catch (e) {
  succeeded = false;
}
if (!succeeded && defineProperty) {
  defineProperty(object, key, { configurable: true, enumerable: true, value: value, writable: true });
}
```

### Reproduction (from the issue)

```js
const _ = require('lodash');
Object.freeze(Object.prototype);

const orig = { foo: 'bar', hasOwnProperty: 'a string' };
const cloned = _.clone(orig);

// Before fix:
console.log(cloned.hasOwnProperty); // [Function: hasOwnProperty] ← WRONG
// After fix:
console.log(cloned.hasOwnProperty); // 'a string' ✅
```

### Test

Added a QUnit test using `vm.createContext` to safely isolate the irreversible `Object.freeze(Object.prototype)` call so it does not contaminate the shared test globals.