### PR TITLE
release(minor): bump lodash-es to 4.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lodash-es v4.17.23
+# lodash-es v4.18.0
 
 The [Lodash](https://lodash.com/) library exported as [ES](http://www.ecma-international.org/ecma-262/6.0/) modules.
 
@@ -7,4 +7,4 @@ Generated using [lodash-cli](https://www.npmjs.com/package/lodash-cli):
 $ lodash modularize exports=es -o ./
 ```
 
-See the [package source](https://github.com/lodash/lodash/tree/4.17.23-es) for more details.
+See the [package source](https://github.com/lodash/lodash/tree/4.18.0-es) for more details.

--- a/lodash.default.js
+++ b/lodash.default.js
@@ -45,7 +45,7 @@ import toInteger from './toInteger.js';
 import lodash from './wrapperLodash.js';
 
 /** Used as the semantic version number. */
-var VERSION = '4.17.23';
+var VERSION = '4.18.0';
 
 /** Used to compose bitmasks for function metadata. */
 var WRAP_BIND_KEY_FLAG = 2;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lodash-es",
-  "version": "4.17.23",
+  "version": "4.18.0",
   "description": "Lodash exported as ES modules.",
   "keywords": "es6, modules, stdlib, util",
   "homepage": "https://lodash.com/custom-builds",


### PR DESCRIPTION
see changelog in https://github.com/lodash/lodash/pull/6161