### PR TITLE
docs: remove n_ Node.js < 6 REPL note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ var at = require('lodash/at');
 var curryN = require('lodash/fp/curryN');
 ```
 
-**Note:**<br>
-Install [n_](https://www.npmjs.com/package/n_) for Lodash use in the Node.js < 6 REPL.
-
 ## Why Lodash?
 
 Lodash makes JavaScript easier by taking the hassle out of working with arrays,<br>


### PR DESCRIPTION
Removes the outdated note about installing `n_` for Lodash use in the Node.js < 6 REPL, as Node.js < 6 is long past end-of-life.