### PR TITLE
`lodash-amd` release(patch): bump lodash-amd to 4.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lodash-amd v4.18.0
+# lodash-amd v4.18.1
 
 The [Lodash](https://lodash.com/) library exported as [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules.
 
@@ -27,4 +27,4 @@ require({
 });
 ```
 
-See the [package source](https://github.com/lodash/lodash/tree/4.18.0-amd) for more details.
+See the [package source](https://github.com/lodash/lodash/tree/4.18.1-amd) for more details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lodash-amd",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Lodash exported as AMD modules.",
   "keywords": "amd, modules, stdlib, util",
   "homepage": "https://lodash.com/custom-builds",
@@ -13,5 +13,7 @@
     "John-David Dalton <john.david.dalton@gmail.com>",
     "Mathias Bynens <mathias@qiwi.be>"
   ],
-  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\""
+  }
 }


### PR DESCRIPTION
Fixes an issue where `lodash/template` and `lodash/fromPairs` files had ReferenceError defects in 4.18.0

ref #6167 