### PR TITLE
`lodash-es` release(patch): bump lodash-es to 4.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lodash-es v4.18.0
+# lodash-es v4.18.1
 
 The [Lodash](https://lodash.com/) library exported as [ES](http://www.ecma-international.org/ecma-262/6.0/) modules.
 
@@ -7,4 +7,4 @@ Generated using [lodash-cli](https://www.npmjs.com/package/lodash-cli):
 $ lodash modularize exports=es -o ./
 ```
 
-See the [package source](https://github.com/lodash/lodash/tree/4.18.0-es) for more details.
+See the [package source](https://github.com/lodash/lodash/tree/4.18.1-es) for more details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lodash-es",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Lodash exported as ES modules.",
   "keywords": "es6, modules, stdlib, util",
   "homepage": "https://lodash.com/custom-builds",
@@ -17,5 +17,7 @@
     "John-David Dalton <john.david.dalton@gmail.com>",
     "Mathias Bynens <mathias@qiwi.be>"
   ],
-  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\""
+  }
 }


### PR DESCRIPTION
Fixes an issue where `template` and `fromPairs` files had ReferenceError defects in 4.18.0

ref #6167 