### PR TITLE
`lodash` release(patch): bump lodash npm package to 4.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lodash v4.18.0
+# lodash v4.18.1
 
 The [Lodash](https://lodash.com/) library exported as [Node.js](https://nodejs.org/) modules.
 
@@ -28,7 +28,7 @@ var at = require('lodash/at');
 var curryN = require('lodash/fp/curryN');
 ```
 
-See the [package source](https://github.com/lodash/lodash/tree/4.18.0-npm) for more details.
+See the [package source](https://github.com/lodash/lodash/tree/4.18.1-npm) for more details.
 
 **Note:**<br>
 Install [n_](https://www.npmjs.com/package/n_) for Lodash use in the Node.js < 6 REPL.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lodash",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Lodash modular utilities.",
   "keywords": "modules, stdlib, util",
   "homepage": "https://lodash.com/",
@@ -13,5 +13,7 @@
     "John-David Dalton <john.david.dalton@gmail.com>",
     "Mathias Bynens <mathias@qiwi.be>"
   ],
-  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\""
+  }
 }


### PR DESCRIPTION
Fixes an issue where `lodash/template` and `lodash/fromPairs` files had ReferenceError defects in 4.18.0

ref #6167 