### PR TITLE
docs: add threat model exclusions for common report patterns

### DIFF
--- a/threat-model.md
+++ b/threat-model.md
@@ -81,6 +81,12 @@ JavaScript's prototype chain is a language-level feature. If a report demonstrat
 
 Lodash guards against writing to built-in prototypes (e.g., blocking `__proto__` and `constructor.prototype` keys in `_.set`, `_.merge`, etc.), but it does not and cannot prevent reading inherited properties. Operations like reading `obj.constructor`, traversing `__proto__`, or accessing `Object.prototype` through normal property resolution are expected runtime behavior, not Lodash vulnerabilities.
 
+### Vulnerability Chaining and Gadgets
+
+If a report demonstrates impact only by combining a Lodash behavior with a separate, independent vulnerability in another library or application component, the vulnerability lies in the downstream consumer, not in Lodash. Each reported vulnerability must be independently exploitable through Lodash alone.
+
+If a Lodash function produces a specific object shape that, when later passed to a different library's vulnerable function, leads to code execution or other impact, the root cause is in the downstream library, not Lodash.
+
 ### Vulnerabilities in the JavaScript Runtime or Platform
 
 If a Lodash method triggers a bug in the JavaScript engine (e.g., V8, SpiderMonkey, JavaScriptCore) that leads to memory corruption or incorrect behavior, the vulnerability lies in the engine, not Lodash.

--- a/threat-model.md
+++ b/threat-model.md
@@ -69,6 +69,12 @@ Applications using Lodash are responsible for input validation. Passing attacker
 
 If a developer intentionally merges user input into global objects or fails to isolate data structures, that is a misuse of Lodash’s documented API, not a Lodash defect.
 
+### Stateful or Accessor-Backed Path Arguments
+
+Lodash functions that accept path arguments (e.g., `_.get`, `_.set`, `_.pick`, `_.unset`, `_.omit`) expect paths to be plain data: strings, or arrays of strings and numbers. If a report relies on path arguments that use accessor properties (getters/setters), Proxy objects, or other stateful mechanisms that change value between reads, it is out of scope.
+
+Constructing such objects requires executing JavaScript code (e.g., `Object.defineProperty`), which cannot be expressed in JSON or any serialization format. If an attacker can execute `Object.defineProperty`, they already have arbitrary code execution in the runtime. This falls under the "code that invokes Lodash" trust boundary (see Elements Lodash Trusts, item 3).
+
 ### Vulnerabilities in the JavaScript Runtime or Platform
 
 If a Lodash method triggers a bug in the JavaScript engine (e.g., V8, SpiderMonkey, JavaScriptCore) that leads to memory corruption or incorrect behavior, the vulnerability lies in the engine, not Lodash.

--- a/threat-model.md
+++ b/threat-model.md
@@ -71,9 +71,11 @@ If a developer intentionally merges user input into global objects or fails to i
 
 ### Stateful or Accessor-Backed Path Arguments
 
-Lodash functions that accept path arguments (e.g., `_.get`, `_.set`, `_.pick`, `_.unset`, `_.omit`) expect paths to be plain data: strings, or arrays of strings and numbers. If a report relies on path arguments that use accessor properties (getters/setters), Proxy objects, or other stateful mechanisms that change value between reads, it is out of scope.
+Path arguments to Lodash functions are expected (and documented) to be data, not code. Functions like `_.get`, `_.set`, `_.pick`, `_.unset`, and `_.omit` take paths as strings or arrays of strings and numbers.
 
-Constructing such objects requires executing JavaScript code (e.g., `Object.defineProperty`), which cannot be expressed in JSON or any serialization format. If an attacker can execute `Object.defineProperty`, they already have arbitrary code execution in the runtime. This falls under the "code that invokes Lodash" trust boundary (see Elements Lodash Trusts, item 3).
+Getters, setters, and Proxies are code, not data. They run JavaScript code when a property is read, and they can't be serialized as JSON or sent over the wire. Something has to call `Object.defineProperty` (or equivalent) from inside the process to set them up.
+
+If a report relies on a path element returning different values on different reads (a check/use mismatch), the attack needs code running inside the process, not just attacker-supplied data. That puts it outside Lodash's trust boundary; see "code that invokes Lodash" under [Elements Lodash Trusts](#elements-lodash-trusts).
 
 ### Inherent JavaScript Prototype Behavior
 

--- a/threat-model.md
+++ b/threat-model.md
@@ -75,6 +75,12 @@ Lodash functions that accept path arguments (e.g., `_.get`, `_.set`, `_.pick`, `
 
 Constructing such objects requires executing JavaScript code (e.g., `Object.defineProperty`), which cannot be expressed in JSON or any serialization format. If an attacker can execute `Object.defineProperty`, they already have arbitrary code execution in the runtime. This falls under the "code that invokes Lodash" trust boundary (see Elements Lodash Trusts, item 3).
 
+### Inherent JavaScript Prototype Behavior
+
+JavaScript's prototype chain is a language-level feature. If a report demonstrates read-only prototype access (e.g., `_.get(obj, 'constructor.prototype')` returning `Object.prototype`), that describes standard JavaScript semantics, not a security flaw.
+
+Lodash guards against writing to built-in prototypes (e.g., blocking `__proto__` and `constructor.prototype` keys in `_.set`, `_.merge`, etc.), but it does not and cannot prevent reading inherited properties. Operations like reading `obj.constructor`, traversing `__proto__`, or accessing `Object.prototype` through normal property resolution are expected runtime behavior, not Lodash vulnerabilities.
+
 ### Vulnerabilities in the JavaScript Runtime or Platform
 
 If a Lodash method triggers a bug in the JavaScript engine (e.g., V8, SpiderMonkey, JavaScriptCore) that leads to memory corruption or incorrect behavior, the vulnerability lies in the engine, not Lodash.

--- a/threat-model.md
+++ b/threat-model.md
@@ -83,9 +83,9 @@ Lodash guards against writing to built-in prototypes (e.g., blocking `__proto__`
 
 ### Vulnerability Chaining and Gadgets
 
-If a report demonstrates impact only by combining a Lodash behavior with a separate, independent vulnerability in another library or application component, the vulnerability lies in the downstream consumer, not in Lodash. Each reported vulnerability must be independently exploitable through Lodash alone.
+A Lodash vulnerability has to be exploitable through Lodash alone. If a report's impact depends on combining Lodash behavior with a separate bug in another library or application component, the bug is in the downstream code, not Lodash.
 
-If a Lodash function produces a specific object shape that, when later passed to a different library's vulnerable function, leads to code execution or other impact, the root cause is in the downstream library, not Lodash.
+Gadget reports fall under this too. If a Lodash function produces an object shape that later causes a vulnerable function in some other library to execute code, the root cause is that library accepting the shape, not Lodash producing it.
 
 ### Vulnerabilities in the JavaScript Runtime or Platform
 

--- a/threat-model.md
+++ b/threat-model.md
@@ -79,9 +79,11 @@ If a report relies on a path element returning different values on different rea
 
 ### Inherent JavaScript Prototype Behavior
 
-JavaScript's prototype chain is a language-level feature. If a report demonstrates read-only prototype access (e.g., `_.get(obj, 'constructor.prototype')` returning `Object.prototype`), that describes standard JavaScript semantics, not a security flaw.
+Lodash blocks writes to built-in prototypes. Keys like `__proto__` and `constructor.prototype` are filtered in `_.set`, `_.merge`, and similar functions. It does not and cannot block reads.
 
-Lodash guards against writing to built-in prototypes (e.g., blocking `__proto__` and `constructor.prototype` keys in `_.set`, `_.merge`, etc.), but it does not and cannot prevent reading inherited properties. Operations like reading `obj.constructor`, traversing `__proto__`, or accessing `Object.prototype` through normal property resolution are expected runtime behavior, not Lodash vulnerabilities.
+Reading inherited properties is how JavaScript works. `obj.constructor`, traversing `__proto__`, or reaching `Object.prototype` through normal property resolution are language semantics, not Lodash behavior.
+
+If a report shows only read-only prototype access (e.g. `_.get(obj, 'constructor.prototype')` returning `Object.prototype`), it's describing JavaScript, not a Lodash vulnerability.
 
 ### Vulnerability Chaining and Gadgets
 


### PR DESCRIPTION
Adds three new out-of-scope sections to the threat model based on recurring report patterns:

- **Stateful/accessor-backed path arguments**: paths with getters/proxies require code execution, not data
- **Inherent JS prototype behavior**: read-only prototype access is standard JS, not a vuln
- **Vulnerability chaining and gadgets**: must be independently exploitable through Lodash alone