### PR TITLE
fix(math): guard createRound against missing context.isFinite

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -1533,7 +1533,7 @@
         nativeFloor = Math.floor,
         nativeGetSymbols = Object.getOwnPropertySymbols,
         nativeIsBuffer = Buffer ? Buffer.isBuffer : undefined,
-        nativeIsFinite = context.isFinite,
+        nativeIsFinite = context.isFinite || isFinite,
         nativeJoin = arrayProto.join,
         nativeKeys = overArg(Object.keys, Object),
         nativeMax = Math.max,

--- a/test/test.js
+++ b/test/test.js
@@ -19940,6 +19940,19 @@
       actual = func(NaN, 2);
       assert.deepEqual(actual, isCeil ? NaN : NaN);
     });
+
+    QUnit.test('`_.' + methodName + '` should not throw when context lacks `isFinite` (issue #5746)', function(assert) {
+      assert.expect(2);
+
+      if (!isModularize) {
+        var lodash = _.runInContext({});
+        assert.strictEqual(lodash[methodName](4.006), isCeil ? 5 : 4);
+        assert.strictEqual(lodash[methodName](4.016, 2), isFloor ? 4.01 : 4.02);
+      }
+      else {
+        skipAssert(assert, 2);
+      }
+    });
   });
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Closes #5746

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
lodash/lodash

## Issue
https://github.com/lodash/lodash/issues/5746

## Root cause
`createRound` (used by `_.ceil`, `_.floor`, `_.round`) reads `nativeIsFinite = context.isFinite` once at module-init time. In hosts where the global object lacks an `isFinite` property (notably WeChat Mini Program), this resolves to `undefined`, so calling any rounding helper with a non-zero precision throws `TypeError: nativeIsFinite is not a function`.

## Fix
Fall back to the lexically-scoped global `isFinite` when `context.isFinite` is missing: `nativeIsFinite = context.isFinite || isFinite`. The lexical reference resolves to the ECMAScript built-in that exists even when the host's global object does not expose it as an own property.

## Regression test
`test/test.js` — added a test inside the `round methods` module that runs for `ceil`, `floor`, and `round`: `'\`_.<name>\` should not throw when context lacks \`isFinite\` (issue #5746)`. It builds a lodash via `_.runInContext({})` and asserts that `<name>(4.006)` and `<name>(4.016, 2)` return the expected rounded values without throwing.

## Risk
low

## Verification
Reproduced the original error with `node -e "delete global.isFinite; require('./lodash.js').round(4.016, 2)"` (threw `nativeIsFinite is not a function` on HEAD). After the fix, `_.round(4.016, 2)` returns `4.02` and the standard `_.round`/`_.ceil`/`_.floor` smoke calls (basic, precision 0, Infinity, NaN) all return the expected values. Full QUnit suite (`node test/test.js`) skipped: requires `npm install` for `qunit-extras` and other dev deps not present in the shallow clone.
