### PR TITLE
Fix `_.omit` mutating objects with `Array`s

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5687,7 +5687,7 @@
      * @returns {*} Returns the uncloned value or `undefined` to defer cloning to `_.cloneDeep`.
      */
     function customOmitClone(value) {
-      return isPlainObject(value) ? undefined : value;
+      return isPlainObject(value) || isArray(value) ? undefined : value;
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -16566,12 +16566,12 @@
     });
 
     QUnit.test('should not mutate `object`', function(assert) {
-      assert.expect(4);
+      assert.expect(5);
 
-      lodashStable.each(['a', ['a'], 'a.b', ['a.b']], function(path) {
-        var object = { 'a': { 'b': 2 } };
+      lodashStable.each(['a', ['a'], 'a.b', ['a.b'], 'c[0]'], function(path) {
+        var object = { 'a': { 'b': 2 }, c: [{ 'd': 0 }, { 'd': 1 }] };
         _.omit(object, path);
-        assert.deepEqual(object, { 'a': { 'b': 2 } });
+        assert.deepEqual(object, { 'a': { 'b': 2 }, c: [{ 'd': 0 }, { 'd': 1 }] });
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/lodash/lodash/issues/4007

The culprit was the private function `customOmitClone`, which would be
used to customize `_.cloneDeep` by specifically requesting all non-plain
Objects to not be cloned.

Turns out that Arrays don't pass the `_.isPlainObject` test.