### PR TITLE
fix(clone): preserve sparse-array holes

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2683,7 +2683,16 @@
       if (isArr) {
         result = initCloneArray(value);
         if (!isDeep) {
-          return copyArray(value, result);
+          // Copy preserving sparse-array holes so cloned arrays match
+          // the original's `in` semantics (mirrors `structuredClone`).
+          var index = -1,
+              length = value.length;
+          while (++index < length) {
+            if (index in value) {
+              result[index] = value[index];
+            }
+          }
+          return result;
         }
       } else {
         var tag = getTag(value),
@@ -2733,6 +2742,10 @@
         if (props) {
           key = subValue;
           subValue = value[key];
+        } else if (!(key in value)) {
+          // Preserve sparse array holes instead of materializing them as
+          // `undefined` entries (matches `structuredClone` semantics).
+          return;
         }
         // Recursively populate clone (susceptible to call stack limits).
         assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack));

--- a/test/test.js
+++ b/test/test.js
@@ -3111,6 +3111,25 @@
           }
         });
       });
+
+      QUnit.test('`_.' + methodName + '` should preserve sparse-array holes', function(assert) {
+        assert.expect(8);
+
+        var sparse = Array(5);
+        sparse[3] = 42;
+
+        var actual = func(sparse);
+        assert.strictEqual(actual.length, 5);
+        assert.notOk(0 in actual);
+        assert.notOk(2 in actual);
+        assert.ok(3 in actual);
+        assert.strictEqual(actual[3], 42);
+
+        var nested = func({ 'arr': sparse }).arr;
+        assert.notOk(0 in nested);
+        assert.ok(3 in nested);
+        assert.strictEqual(nested[3], 42);
+      });
     });
 
     lodashStable.each(['cloneWith', 'cloneDeepWith'], function(methodName) {


### PR DESCRIPTION
Closes #6191

## Summary

`_.clone` and `_.cloneDeep` materialize sparse-array holes as real `undefined` entries today: an array like `let x = Array(5); x[3] = 42` clones into one where `0 in clone === true` and `clone.forEach` visits every index. `structuredClone` does the right thing on the same input (preserves the holes), and that mismatch has been the user-visible report on #6191.

Two paths are responsible:

- **Shallow path** — `baseClone` returns `copyArray(value, result)`, and `copyArray` unconditionally writes `array[i] = source[i]`, which densifies. `copyArray` itself can't be changed because `_.concat`, `_.slice`, and `_.toArray` deliberately densify (see "should treat sparse arrays as dense" / "should return a dense array" tests). So I inlined a sparse-aware copy in `baseClone`'s shallow branch only.
- **Deep path** — the `arrayEach` recursion still iterates every index, and `assignValue` happily writes `undefined` when the key is missing. Added an `if (!(key in value)) return;` guard so we skip absent indices, leaving the corresponding hole in the freshly initialized `result` array.

Both changes are scoped to the array branch of `baseClone`. `cloneWith` / `cloneDeepWith` go through the same path, so they pick up the fix automatically.

## Tests

Added a single test inside the existing `each(['clone', 'cloneDeep'])` block, so it runs against both methods plus the shallow/deep matrix:

```js
QUnit.test('`_.' + methodName + '` should preserve sparse-array holes', function (assert) {
  var sparse = Array(5);
  sparse[3] = 42;

  var actual = func(sparse);
  assert.strictEqual(actual.length, 5);
  assert.notOk(0 in actual);
  assert.notOk(2 in actual);
  assert.ok(3 in actual);
  assert.strictEqual(actual[3], 42);

  var nested = func({ 'arr': sparse }).arr;
  assert.notOk(0 in nested);
  assert.ok(3 in nested);
  assert.strictEqual(nested[3], 42);
});
```

- Without the fix: 5 assertions fail (the `notOk(0 in ...)` checks).
- With the fix: full suite passes (`PASS: 6841 FAIL: 0`), including the existing `concat` / `slice` / `toArray` "treat sparse as dense" tests (left untouched on purpose).