### PR TITLE
chore(ci): sha pin the actions

### DIFF
--- a/.github/workflows/browser-testing.yml
+++ b/.github/workflows/browser-testing.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
 

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: ${{ matrix.bun-version }}
 

--- a/.github/workflows/ci-dist-sync.yml
+++ b/.github/workflows/ci-dist-sync.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js (latest)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 'node' # Use 'node' for the latest version
           cache: 'npm'

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-      
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v44.0.0
+        uses: renovatebot/github-action@4ebebabcd582dddea1692b05c3d5279f8e372b53 # v44.0.0
         with:
           configurationFile: renovate.json
         env:


### PR DESCRIPTION
We had a few unpinned actions still, PR pins them.

```sh
# The five lookups for this PR:
gh api repos/actions/checkout/commits/v4 --jq .sha
# 34e114876b0b11c390a56381ad16ebd13914f8d5  (v4.3.1)

gh api repos/actions/setup-node/commits/v4 --jq .sha
# 49933ea5288caeca8642d1e84afbd3f7d6820020  (v4.4.0)

gh api repos/actions/checkout/commits/v5.0.0 --jq .sha
# 08c6903cd8c0fde910a37f88322edcfb5dd907a8

gh api repos/renovatebot/github-action/commits/v44.0.0 --jq .sha
# 4ebebabcd582dddea1692b05c3d5279f8e372b53

gh api repos/oven-sh/setup-bun/commits/v1 --jq .sha
# f4d14e03ff726c06358e5557344e1da148b56cf7  (v1.2.2)
```

### aside

renovate seems misconfigured btw, no failures but the log indicates the config we have gives us a no op in the self hosted version

noticed when I went to set perm blocks there, but didnt touch it in this PR since I wanna land the sha pins without having to make a decision about fixing or removing renovate
