### PR TITLE
fix: enforce strict identifier whitelist for _.template options

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -169,16 +169,12 @@
   var reAsciiWord = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g;
 
   /**
-   * Used to validate the `validate` option in `_.template` variable.
-   *
-   * Forbids characters which could potentially change the meaning of the function argument definition:
-   * - "()," (modification of function parameters)
-   * - "=" (default value)
-   * - "[]{}" (destructuring of function parameters)
-   * - "/" (beginning of a comment)
-   * - whitespace
-   */
-  var reForbiddenIdentifierChars = /[()=,{}\[\]\/\s]/;
+    * Used to validate the `variable` and `imports` options in `_.template`.
+    *
+    * Enforces a strict whitelist of valid JavaScript identifier characters
+    * to prevent code injection via structural or ES6 syntax bypasses.
+    */
+  var reIsPlainIdentifier = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
 
   /** Used to match backslashes in property paths. */
   var reEscapeChar = /\\(\\)?/g;
@@ -14896,7 +14892,7 @@
           importsValues = baseValues(imports, importsKeys);
 
       arrayEach(importsKeys, function(key) {
-        if (reForbiddenIdentifierChars.test(key)) {
+        if (!reIsPlainIdentifier.test(key)) {
           throw new Error(INVALID_TEMPL_IMPORTS_ERROR_TEXT);
         }
       });
@@ -14958,9 +14954,9 @@
       if (!variable) {
         source = 'with (obj) {\n' + source + '\n}\n';
       }
-      // Throw an error if a forbidden character was found in `variable`, to prevent
-      // potential command injection attacks.
-      else if (reForbiddenIdentifierChars.test(variable)) {
+      // Throw an error if `variable` is not a valid identifier, to prevent
+      // potential code injection attacks.
+      else if (!reIsPlainIdentifier.test(variable)) {
         throw new Error(INVALID_TEMPL_VAR_ERROR_TEXT);
       }
 

--- a/test/test.js
+++ b/test/test.js
@@ -22315,10 +22315,14 @@
     });
 
     QUnit.test('should forbid code injection through the "variable" options', function(assert) {
-      assert.expect(1);
+      assert.expect(2);
 
       assert.raises(function() {
         _.template('', { 'variable': '){console.log(process.env)}; with(obj' });
+      });
+
+      assert.raises(function() {
+        _.template('', { 'variable': 'eval`42`' });
       });
     });
 


### PR DESCRIPTION
The blacklist (reForbiddenIdentifierChars) used to patch CVE-2021-23337 (`variable`) and CVE-2026-4800 (`importsKeys`) is brittle against evolving language specs.

Currently, ES6 syntax like Tagged Template Literals (e.g., eval`42`) evades the regex filter entirely. While execution is currently halted by V8's native SyntaxError, relying on engine-specific grammar rather than explicit library validation is fragile.

This patch removes the blacklist and enforces a strict structural whitelist (reIsPlainIdentifier) to provide robust defense-in-depth against future ECMAScript additions, ensuring only valid identifiers reach the Function constructor.

Ref: CVE-2021-23337
Ref: CVE-2026-4800


Why is this necessary?
The previous blacklist (/[()=,{}\[\]\/\s]/) successfully mitigated the original context breakouts in CVE-2021-23337 and the recent importsKeys bypass in CVE-2026-4800. However, a blacklist strategy is fundamentally brittle against an evolving language specification.

During security review, it was identified that ES6 syntax (such as Tagged Template Literals like eval`42```) evades the regex filter entirely. While the V8 engine currently halts execution by throwing a native SyntaxError (expecting a BindingIdentifier), relying on the JavaScript engine's grammar quirks rather than explicit library validation leaves the door open for future ECMAScript additions.

Moving to a strict whitelist (/^[a-zA-Z_$][0-9a-zA-Z_$]*$/) provides mathematically sound Defense-in-Depth.