### PR TITLE
test: cover array-wrapped prototype paths

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -16578,7 +16578,7 @@
     // Prevent regression for
     // https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg
     QUnit.test('Security: _.omit should not allow modifying prototype or constructor properties', function(assert) {
-      assert.expect(3);
+      assert.expect(5);
 
       var testObj1 = {};
       assert.strictEqual(typeof testObj1.toString, 'function', 'Object.toString should work before omit');
@@ -16586,6 +16586,17 @@
       _.omit({}, ['__proto__.toString']);
       _.omit({}, ['constructor.prototype.toString']);
       _.omit({}, [['constructor'], ['prototype'], ['toString']]);
+
+      try {
+        objectProto.foo = 'bar';
+        _.omit({}, [[['__proto__'], ['foo']]]);
+        assert.strictEqual(objectProto.foo, 'bar', '__proto__ access via array-wrapped segments should be blocked');
+
+        _.omit({}, [[['constructor'], ['prototype'], ['foo']]]);
+        assert.strictEqual(objectProto.foo, 'bar', 'constructor.prototype access via array-wrapped segments should be blocked');
+      } finally {
+        delete objectProto.foo;
+      }
 
       var testObj2 = {};
       assert.strictEqual(typeof testObj2.toString, 'function', 'Object.toString should still work after omit');
@@ -25308,7 +25319,7 @@
     // https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg
     // https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh
     QUnit.test('Security: _.unset should not allow modifying prototype or constructor properties', function(assert) {
-      assert.expect(6);
+      assert.expect(7);
 
       var testStr1 = 'ABC';
       assert.strictEqual(typeof testStr1.toLowerCase, 'function', 'String.toLowerCase should exist before unset');
@@ -25323,10 +25334,16 @@
       assert.strictEqual(typeof testStr2.toLowerCase, 'function', 'String.toLowerCase should still exist after unset');
       assert.strictEqual(testStr2.toLowerCase(), 'abc', 'String.toLowerCase should work as expected');
 
-      objectProto.foo = 'bar';
-      _.unset({}, [['__proto__'], ['foo']]);
-      assert.strictEqual(objectProto.foo, 'bar', '__proto__ access via array-wrapped segments should be blocked');
-      delete objectProto.foo;
+      try {
+        objectProto.foo = 'bar';
+        _.unset({}, [['__proto__'], ['foo']]);
+        assert.strictEqual(objectProto.foo, 'bar', '__proto__ access via array-wrapped segments should be blocked');
+
+        _.unset({}, [['constructor'], ['prototype'], ['foo']]);
+        assert.strictEqual(objectProto.foo, 'bar', 'constructor.prototype access via array-wrapped segments should be blocked');
+      } finally {
+        delete objectProto.foo;
+      }
 
       assert.strictEqual(typeof funcProto.apply, 'function', 'Function.prototype.apply should exist before unset');
 


### PR DESCRIPTION
## Summary

- Add regression coverage for array-wrapped `__proto__` and `constructor.prototype` paths in `_.omit`.
- Add a plain-object `constructor.prototype` array-wrapped path regression check for `_.unset`.
- Keep the change test-only; no implementation behavior is changed.

Closes #6183

## Testing

- `npm test`
  - `test:main`: `PASS: 6828  FAIL: 0  TOTAL: 6828`
  - `test:fp`: `PASS: 327  FAIL: 0  TOTAL: 327`
- `node --check test/test.js`
- `git diff --check`

## Notes

- `npm test` ran the documented build/test flow and left no generated file changes.
- `npm run style:test` and `./node_modules/.bin/jscs test/test.js` both hung under Node 22 after a JSCS circular dependency warning, so I terminated those processes.
- `npm ci` completed using the existing `package-lock.json`; npm reported deprecated packages and audit findings from existing old dev dependencies, but no dependency files changed.