### PR TITLE
fix(baseSum): prevent string concatenation by coercing values to numbers

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -968,7 +968,7 @@
     while (++index < length) {
       var current = iteratee(array[index]);
       if (current !== undefined) {
-        result = result === undefined ? current : (result + current);
+        result = result === undefined ? (+current) : (result + (+current));
       }
     }
     return result;


### PR DESCRIPTION
### Description

When non-numeric values (e.g. strings, null) are passed to `_.sumBy` or `_.sum`, the internal `baseSum` function uses the `+` operator for accumulation, which causes string concatenation instead of numeric addition:

```js
_.sumBy([{ a: 1 }, { a: 'f' }, { a: null }], 'a');
// Current: '1fnull' (string)
// Expected: NaN (number)
```

### Related Issue

Fixes #5818

### Changes

Added a unary `+` coercion to convert each value to a number before adding. This ensures the return type is always `number` as documented, even when non-numeric values are encountered.

The coercion is already implicitly used when the result starts as 0, but when the first value is assigned directly (line 971), a non-numeric value would retain its type. Using `+current` handles this edge case.

### Impact

- Normal numeric usage is unaffected (e.g., `sum([1, 2, 3])` still returns `6`)
- `undefined` values are still skipped
- Mixed non-numeric input now returns `NaN` instead of a concatenated string, per the documented return type
