### PR TITLE
Preserve __proto__ values in invert outputs

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -13312,7 +13312,7 @@
         value = nativeObjectToString.call(value);
       }
 
-      result[value] = key;
+      baseAssignValue(result, value, key);
     }, constant(identity));
 
     /**
@@ -13350,7 +13350,7 @@
       if (hasOwnProperty.call(result, value)) {
         result[value].push(key);
       } else {
-        result[value] = [key];
+        baseAssignValue(result, value, [key]);
       }
     }, getIteratee);
 

--- a/test/test.js
+++ b/test/test.js
@@ -8634,6 +8634,15 @@
       assert.deepEqual(_.invert(object), { 'hasOwnProperty': 'a', 'constructor': 'b' });
     });
 
+    QUnit.test('should treat "__proto__" values as regular keys', function(assert) {
+      assert.expect(2);
+
+      var actual = _.invert({ 'a': '__proto__' });
+
+      assert.strictEqual(actual.__proto__, 'a');
+      assert.strictEqual(Object.getPrototypeOf(actual), objectProto);
+    });
+
     QUnit.test('should work with an object that has a `length` property', function(assert) {
       assert.expect(1);
 
@@ -8696,6 +8705,15 @@
           expected = { 'hasOwnProperty': ['a'], 'constructor': ['b'] };
 
       assert.ok(lodashStable.isEqual(_.invertBy(object), expected));
+    });
+
+    QUnit.test('should treat "__proto__" values as regular keys', function(assert) {
+      assert.expect(2);
+
+      var actual = _.invertBy({ 'a': '__proto__' });
+
+      assert.deepEqual(actual.__proto__, ['a']);
+      assert.strictEqual(Object.getPrototypeOf(actual), objectProto);
     });
 
     QUnit.test('should return a wrapped value when chaining', function(assert) {


### PR DESCRIPTION
## Problem
`_.invert` and `_.invertBy` currently drop entries when an input value becomes the output key `__proto__`.

## Root cause
Both functions assign inverted entries with direct property writes. For `__proto__`, that goes through the prototype accessor instead of defining an own enumerable key, so the entry is not preserved as normal output data.

## Fix
Use Lodash's existing `baseAssignValue` helper for newly-created inverted keys. This keeps `__proto__` as a regular own property while preserving the existing prototype-pollution safeguards already used elsewhere in the codebase.

## Testing
- Added regression coverage for `_.invert({ a: '__proto__' })`.
- Added regression coverage for `_.invertBy({ a: '__proto__' })`.
- Ran `git diff --check` successfully.

Fixes #6195