### PR TITLE
fix(sum): prevent string concatenation in baseSum for numeric accumulation

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -968,7 +968,7 @@
     while (++index < length) {
       var current = iteratee(array[index]);
       if (current !== undefined) {
-        result = result === undefined ? current : (result + current);
+        result = result === undefined ? +current : (result + +current);
       }
     }
     return result;


### PR DESCRIPTION
## Problem

`_.sumBy([{n:'1'},{n:'2'}], 'n')` returns `"12"` (string concatenation) instead of `3` (numeric sum). This breaks numeric accumulation when the iteratee returns string-typed values.

## Root cause

In `baseSum`, `result = result === undefined ? current : (result + current)` — the `+` operator does string concatenation when either operand is a string. After the first string result, all subsequent iterations concatenate.

## Changes

- `lodash.js` in `baseSum`: Added unary `+` coercion: `result = result === undefined ? (+current) : (result + (+current))`. The unary `+` coerces strings to numbers, ensuring numeric addition.

## Why

The unary `+` operator is JavaScript's standard numeric coercion idiom. It handles numeric strings (`+"1"` → `1`), booleans (`+true` → `1`), and null (`+null` → `0`) consistently.

Closes #5818