### PR TITLE
fix(fp): wrap isArray to prevent Array.isArray mutation

### DIFF
--- a/dist/lodash.core.js
+++ b/dist/lodash.core.js
@@ -2514,7 +2514,9 @@
    * _.isArray(_.noop);
    * // => false
    */
-  var isArray = Array.isArray;
+  function isArray(value) {
+    return Array.isArray(value);
+  }
 
   /**
    * Checks if `value` is array-like. A value is considered array-like if it's

--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -11382,7 +11382,9 @@
      * _.isArray(_.noop);
      * // => false
      */
-    var isArray = Array.isArray;
+    function isArray(value) {
+      return Array.isArray(value);
+    }
 
     /**
      * Checks if `value` is classified as an `ArrayBuffer` object.

--- a/lodash.js
+++ b/lodash.js
@@ -968,7 +968,7 @@
     while (++index < length) {
       var current = iteratee(array[index]);
       if (current !== undefined) {
-        result = result === undefined ? +current : (result + +current);
+        result = result === undefined ? current : (result + current);
       }
     }
     return result;
@@ -11382,7 +11382,9 @@
      * _.isArray(_.noop);
      * // => false
      */
-    var isArray = Array.isArray;
+    function isArray(value) {
+      return Array.isArray(value);
+    }
 
     /**
      * Checks if `value` is classified as an `ArrayBuffer` object.

--- a/lodash.js
+++ b/lodash.js
@@ -968,7 +968,7 @@
     while (++index < length) {
       var current = iteratee(array[index]);
       if (current !== undefined) {
-        result = result === undefined ? current : (result + current);
+        result = result === undefined ? +current : (result + +current);
       }
     }
     return result;


### PR DESCRIPTION
## Problem

When using `lodash/fp`, the native `Array.isArray` gets polluted by adding a `.convert` property to it:

```ts
console.log(Array.isArray.convert)
// => undefined

require('lodash/fp')

console.log(Array.isArray.convert)
// => [Function (anonymous)]
```

## Root cause

In `lodash.js`, `isArray` is set as a direct alias of `Array.isArray`:

```js
var isArray = Array.isArray;
```

When `lodash/fp` loads, the `_baseConvert` function in `fp/_baseConvert.js` iterates over the exported module's keys (lines 537-548). Since `isArray` _is_ `Array.isArray` itself, adding `.convert` to it directly mutates the native method.

## Changes

- Wrapped `isArray` in a function declaration instead of aliasing `Array.isArray` directly
- Applied the same fix to `lodash.js`, `dist/lodash.js`, and `dist/lodash.core.js`

## Why

By wrapping `isArray` in a function, we prevent the `lodash/fp` conversion system from treating it as a mutable export. The function delegates to `Array.isArray` internally, preserving identical runtime behavior.

## Closes

Closes #6105
