### PR TITLE
docs: clarify number-word behavior in startCase examples

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -9609,6 +9609,10 @@ _.startCase('fooBar');
 
 _.startCase('__FOO_BAR__');
 // => 'FOO BAR'
+
+// Numbers are treated as separate words.
+_.startCase('abc123def');
+// => 'Abc 123 Def'
 ```
 ---
 

--- a/test/test.js
+++ b/test/test.js
@@ -21245,11 +21245,12 @@
 
   (function() {
     QUnit.test('should uppercase only the first character of each word', function(assert) {
-      assert.expect(3);
+      assert.expect(4);
 
       assert.strictEqual(_.startCase('--foo-bar--'), 'Foo Bar');
       assert.strictEqual(_.startCase('fooBar'), 'Foo Bar');
       assert.strictEqual(_.startCase('__FOO_BAR__'), 'FOO BAR');
+      assert.strictEqual(_.startCase('foo123bar345'), 'Foo 123 Bar 345');
     });
   }());
 


### PR DESCRIPTION
This PR adds additional examples to clarify how _.startCase handles alphanumeric strings, especially when numbers appear adjacent to letters.

The current documentation only shows basic string and separator-based examples, which can lead to confusion about how numeric boundaries are treated during word tokenization.