### PR TITLE
fix(merge): block 'prototype' key in safeGet to prevent class-prototype pollution

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -6706,7 +6706,7 @@
         return;
       }
 
-      if (key == '__proto__') {
+      if (key == '__proto__' || key == 'prototype') {
         return;
       }
 

--- a/test/test.js
+++ b/test/test.js
@@ -7595,6 +7595,36 @@
 
       assert.notOk(actual);
     });
+
+    QUnit.test('should not pollute prototype when target is a function/class', function(assert) {
+      assert.expect(3);
+
+      // Plain-object target prototype-pollution is covered by the two
+      // tests above. This test covers the function/class target case —
+      // the `safeGet` helper used by `baseMerge` historically filtered
+      // `__proto__` and `constructor` but not `prototype`, so a payload
+      // like `{ "prototype": { "x": 1 } }` would write through to
+      // `Class.prototype.x` (and to `Object.prototype.x` if the target
+      // is `Object` itself).
+
+      function MyCtor() {}
+      _.merge(MyCtor, JSON.parse('{"prototype":{"polluted":"X"}}'));
+      var instanceLeaked = 'polluted' in new MyCtor();
+      delete MyCtor.prototype.polluted;
+      assert.notOk(instanceLeaked);
+
+      _.merge(Object, JSON.parse('{"prototype":{"polluted":"GLOBAL"}}'));
+      var globalLeaked = 'polluted' in {};
+      delete objectProto.polluted;
+      assert.notOk(globalLeaked);
+
+      // `mergeWith` and `defaultsDeep` share the same code path and
+      // must also be guarded.
+      _.defaultsDeep(Object, JSON.parse('{"prototype":{"defaulted":"D"}}'));
+      var defaultsLeaked = 'defaulted' in {};
+      delete objectProto.defaulted;
+      assert.notOk(defaultsLeaked);
+    });
   }());
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
### Summary

`safeGet` (line 6704) is used by `baseMergeDeep` and `baseMerge`'s
customizer branch to fetch each property when merging a source into
a target. It currently blocks `__proto__` and `constructor` (the
latter only when its value is a function), but **not** `prototype`.

For plain-object merge targets this is benign — writing
`obj['prototype'] = ...` creates an own property named "prototype"
rather than walking the prototype chain. But for **function/class
targets**, `fn.prototype` IS the prototype every `new fn()` instance
inherits from. A `{ "prototype": { … } }` payload merged into a
class therefore pollutes that class's prototype, and merging into
`Object` itself yields full global `Object.prototype` pollution.

This PR adds `prototype` to `safeGet`'s filter list, matching the
filter `baseSet` already applies (line 4040: `if (key === '__proto__' || key === 'constructor' || key === 'prototype')`).
The change is one line; full test suite goes from 6825 → 6828 passing
(the 3 new assertions in the test below).

### Reproduction (current behavior, on `main`)

```js
const _ = require('lodash');

// Class-target case — pollutes the class's prototype:
class MyCtor {}
_.merge(MyCtor, JSON.parse('{"prototype":{"polluted":"X"}}'));
console.log(new MyCtor().polluted);  // → "X"

// Object-target case — pollutes Object.prototype globally:
_.merge(Object, JSON.parse('{"prototype":{"polluted":"GLOBAL"}}'));
console.log(({}).polluted);           // → "GLOBAL"

// Same primitive via mergeWith and defaultsDeep.
```

The realistic attack pattern is a dynamic-target merge like
`_.merge(handlerRegistry[type], req.body.config)` where `type` lets
the attacker steer the merge target onto a class constructor. Plain
default-merge usage (`_.merge({}, userInput)`) is unaffected and
remains the dominant safe use case.

### Why this is a defensive change rather than a security advisory

The asymmetry in `safeGet` looks intentional: the docstring says
"Gets the value at `key`, unless `key` is `__proto__` or `constructor`",
which arguably puts `prototype` outside the helper's stated
guarantee. Real-world exploitability requires attacker influence
over the merge **target**, not just the source — a much more
constrained threat model than the classic `_.merge({}, userInput)`
PP CVEs.

The fix, though, is uncontroversial: `prototype` is already in the
filter list of `baseSet` (the analogous helper for `_.set` /
`_.setWith`), so adding it here brings the merge family into line
with the setter family. Filed as a regular hardening PR rather than
via the security advisories flow.

### Patch

```diff
     function safeGet(object, key) {
       if (key === 'constructor' && typeof object[key] === 'function') {
         return;
       }

-      if (key == '__proto__') {
+      if (key == '__proto__' || key == 'prototype') {
         return;
       }

       return object[key];
     }
```

### Test

A new test under `QUnit.module('lodash.merge')` covering the three
affected APIs (`_.merge`, `_.mergeWith`, `_.defaultsDeep`) and the
two target shapes (application class + `Object`):

```js
QUnit.test('should not pollute prototype when target is a function/class', function(assert) {
  assert.expect(3);

  function MyCtor() {}
  _.merge(MyCtor, JSON.parse('{"prototype":{"polluted":"X"}}'));
  var instanceLeaked = 'polluted' in new MyCtor();
  delete MyCtor.prototype.polluted;
  assert.notOk(instanceLeaked);

  _.merge(Object, JSON.parse('{"prototype":{"polluted":"GLOBAL"}}'));
  var globalLeaked = 'polluted' in {};
  delete objectProto.polluted;
  assert.notOk(globalLeaked);

  _.defaultsDeep(Object, JSON.parse('{"prototype":{"defaulted":"D"}}'));
  var defaultsLeaked = 'defaulted' in {};
  delete objectProto.defaulted;
  assert.notOk(defaultsLeaked);
});
```

(Sits next to the existing
`'should not indirectly merge builtin prototype properties'` and
`'should not indirectly merge `Object` properties'` tests, in the
same `lodash.merge` module.)

### Test results

```
$ node test/test
Running lodash tests.
...
PASS: 6828  FAIL: 0  TOTAL: 6828
```

Was 6825 on `main`; +3 new assertions from the added test. No
regressions in any existing test.

### Notes

* Build artifacts (`dist/lodash.js`, `dist/lodash.min.js`) are not
  modified in this PR — happy to regenerate them via `npm run build`
  if you'd like that in the same PR, or leave that to release time.
* `lodash-es` mirrors `lodash.js` per the build pipeline; this fix
  should propagate automatically.
* No `fp/` changes — the function-target merge case isn't reachable
  through the FP entry points (they curry around plain-object targets).