### PR TITLE
fix: prevent _.invert and _.invertBy from dropping __proto__ keys

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -5298,7 +5298,7 @@
      */
     function createInverter(setter, toIteratee) {
       return function(object, iteratee) {
-        return baseInverter(object, setter, toIteratee(iteratee), {});
+        return baseInverter(object, setter, toIteratee(iteratee), Object.create(null));
       };
     }
 


### PR DESCRIPTION
Fixes lodash/lodash#6195

When a value in the input object is , both  and  silently dropped the entry. This happened because the result object was created with  which has a prototype chain. Setting  modifies the prototype instead of creating a data property.

**Fix:** Use  for the result accumulator in , so  is treated as a regular property key.



Same fix applies to .

One-line change:  ->  in .