### PR TITLE
Fix cloneDeep Map key cloning

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -2720,7 +2720,10 @@
         });
       } else if (isMap(value)) {
         value.forEach(function(subValue, key) {
-          result.set(key, baseClone(subValue, bitmask, customizer, key, value, stack));
+          result.set(
+            baseClone(key, bitmask, customizer, key, value, stack),
+            baseClone(subValue, bitmask, customizer, key, value, stack)
+          );
         });
       }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2772,6 +2772,31 @@
       assert.notStrictEqual(actual, cyclical['v' + (LARGE_ARRAY_SIZE - 1)]);
     });
 
+    QUnit.test('`_.cloneDeep` should deep clone map keys', function(assert) {
+      assert.expect(3);
+
+      if (Map) {
+        var actual,
+            actualKey,
+            key = { 'a': { 'b': 1 } },
+            map = new Map;
+
+        map.set(key, 'value');
+
+        actual = _.cloneDeep(map);
+        actualKey = actual.keys().next().value;
+
+        assert.notStrictEqual(actualKey, key);
+        assert.notStrictEqual(actualKey.a, key.a);
+
+        key.a.b = 2;
+        assert.strictEqual(actualKey.a.b, 1);
+      }
+      else {
+        skipAssert(assert, 3);
+      }
+    });
+
     QUnit.test('`_.cloneDeepWith` should provide `stack` to `customizer`', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Fixes #6228.

## Summary
- clone Map keys through the same deep-clone path used for Set entries and Map values
- keep the existing stack so shared and circular references are preserved while cloning Map entries
- add regression coverage for object Map keys with nested objects

## Checks
- direct Node regression: current `HEAD` reused the Map key/nested object (`true true`), patched build clones both and preserves the old nested value (`false false 1`)
- `npm run style:main`
- `npm run test:main` (6,828 passing, 0 failing)
- `git diff --check`

## Notes
- `npm run style:test` and direct `jscs test/test.js` were attempted, but the legacy JSCS process did not complete locally under Node v24.15.0.