### PR TITLE
fix(invert): use baseAssignValue for __proto__ key support

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -13312,7 +13312,7 @@
         value = nativeObjectToString.call(value);
       }
 
-      result[value] = key;
+      baseAssignValue(result, value, key);
     }, constant(identity));
 
     /**
@@ -13350,7 +13350,7 @@
       if (hasOwnProperty.call(result, value)) {
         result[value].push(key);
       } else {
-        result[value] = [key];
+        baseAssignValue(result, value, [key]);
       }
     }, getIteratee);
 


### PR DESCRIPTION
## Description

Fixes #6195

## Problem

`_.invert` and `_.invertBy` silently drop keys when the inverted value is `__proto__`:

```js
_.invert({ userId: "alice", role: "__proto__", team: "eng" })
// Actual:   { alice: "userId", eng: "team" }
// Expected: { alice: "userId", __proto__: "role", eng: "team" }
```

The root cause is `result[value] = key` — when `value` is `"__proto__"`, this triggers the `__proto__` accessor on `Object.prototype`, setting the prototype instead of a data property.

## Fix

Changed both `invert` and `invertBy` to use `baseAssignValue` instead of direct property assignment. `baseAssignValue` already has correct `__proto__` handling via `Object.defineProperty`, consistent with the rest of lodash (e.g., `mapKeys`, `merge`, `assign`).

- `invert`: `result[value] = key` → `baseAssignValue(result, value, key)`
- `invertBy`: `result[value] = [key]` → `baseAssignValue(result, value, [key])`

The `hasOwnProperty.call(result, value)` check in `invertBy` already works correctly for `__proto__` (it checks own properties), so only the else branch needed changing.

## Verification

```js
_.invert({ userId: "alice", role: "__proto__", team: "eng" })
// => { alice: "userId", __proto__: "role", eng: "team" } ✅

_.invertBy({ a: "x", b: "__proto__", c: "x" })
// => { x: ["a", "c"], __proto__: ["b"] } ✅
```