### PR TITLE
docs: cross-reference filter and reject

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -9227,9 +9227,10 @@
     }
 
     /**
-     * Iterates over elements of `collection`, returning an array of all elements
-     * `predicate` returns truthy for. The predicate is invoked with three
-     * arguments: (value, index|key, collection).
+     * The opposite of `_.reject`; this method iterates over elements of
+     * `collection`, returning an array of all elements `predicate` returns
+     * truthy for. The predicate is invoked with three arguments:
+     * (value, index|key, collection).
      *
      * **Note:** Unlike `_.remove`, this method returns a new array.
      *


### PR DESCRIPTION
﻿## Summary

Updates the `_.filter` JSDoc to explicitly describe it as the opposite of `_.reject`.

## Why

Fixes #5940. `_.reject` already describes itself as the opposite of `_.filter`, while `_.filter` only referenced `_.reject` through `@see`. Adding the reverse relationship to the main help text makes the pair easier to discover and keeps the wording consistent.

## Validation

- Ran `git diff --check`

## Notes

This is a documentation-only JSDoc change, so I did not run the full test suite.

## AI assistance disclosure

This PR was prepared with assistance from OpenAI Codex. The change was reviewed locally and kept to a focused documentation update.
