### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ $ npm i -g npm
 $ npm i --save lodash
 ```
 
+Using Deno:
+```shell
+$ deno install lodash
+```
+
 In Node.js:
 ```js
 // Load the full build.


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install lodash
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install lodash`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
