### PR TITLE
fix: treat undefined options as missing in debounce and throttle

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -10418,9 +10418,9 @@
       wait = toNumber(wait) || 0;
       if (isObject(options)) {
         leading = !!options.leading;
-        maxing = 'maxWait' in options;
+        maxing = options.maxWait !== undefined;
         maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        trailing = options.trailing !== undefined ? !!options.trailing : trailing;
       }
 
       function invokeFunc(time) {
@@ -11001,8 +11001,8 @@
         throw new TypeError(FUNC_ERROR_TEXT);
       }
       if (isObject(options)) {
-        leading = 'leading' in options ? !!options.leading : leading;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        leading = options.leading !== undefined ? !!options.leading : leading;
+        trailing = options.trailing !== undefined ? !!options.trailing : trailing;
       }
       return debounce(func, wait, {
         'leading': leading,

--- a/lodash.js
+++ b/lodash.js
@@ -10418,9 +10418,9 @@
       wait = toNumber(wait) || 0;
       if (isObject(options)) {
         leading = !!options.leading;
-        maxing = 'maxWait' in options;
+        maxing = options.maxWait !== undefined;
         maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        trailing = options.trailing !== undefined ? !!options.trailing : trailing;
       }
 
       function invokeFunc(time) {
@@ -11001,8 +11001,8 @@
         throw new TypeError(FUNC_ERROR_TEXT);
       }
       if (isObject(options)) {
-        leading = 'leading' in options ? !!options.leading : leading;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        leading = options.leading !== undefined ? !!options.leading : leading;
+        trailing = options.trailing !== undefined ? !!options.trailing : trailing;
       }
       return debounce(func, wait, {
         'leading': leading,


### PR DESCRIPTION
## Description

When `debounce` or `throttle` options objects have properties explicitly set to `undefined`, the `in` operator returns `true` and the `undefined` value gets coerced (via `!!`) or used directly, overriding the function's sensible defaults.

For example:
```js
debounce(fn, 100, { trailing: undefined })  // trailing becomes false instead of true
throttle(fn, 100, { leading: undefined })    // leading becomes false instead of true
```

### Changes

- **debounce**: Changed `maxing = 'maxWait' in options` → `maxing = options.maxWait !== undefined` and `trailing` check similarly.
- **throttle**: Changed `leading` and `trailing` from `'key' in options` to `options.key !== undefined`.

This aligns with the JavaScript convention that missing properties and `undefined` properties should be treated the same way.

Fixes #5857
