### PR TITLE
Fix omit reading omitted getters

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -13597,13 +13597,18 @@
       if (object == null) {
         return result;
       }
-      var isDeep = false;
+      var isDeep = false,
+          omitKeys = [];
+
       paths = arrayMap(paths, function(path) {
         path = castPath(path, object);
+        if (path.length == 1) {
+          omitKeys.push(toKey(path[0]));
+        }
         isDeep || (isDeep = path.length > 1);
         return path;
       });
-      copyObject(object, getAllKeysIn(object), result);
+      copyObject(object, baseDifference(getAllKeysIn(object), omitKeys), result);
       if (isDeep) {
         result = baseClone(result, CLONE_DEEP_FLAG | CLONE_FLAT_FLAG | CLONE_SYMBOLS_FLAG, customOmitClone);
       }

--- a/test/test.js
+++ b/test/test.js
@@ -16516,6 +16516,21 @@
       assert.deepEqual(_.omit(object, ['a', 'd'], 'c'), { 'b': 2 });
     });
 
+    QUnit.test('should not get omitted properties', function(assert) {
+      assert.expect(1);
+
+      var object = { 'a': 1 };
+      defineProperty(object, 'b', {
+        'configurable': true,
+        'enumerable': true,
+        'get': function() {
+          throw new Error('omitted property should not be read');
+        }
+      });
+
+      assert.deepEqual(_.omit(object, 'b'), { 'a': 1 });
+    });
+
     QUnit.test('should support deep paths', function(assert) {
       assert.expect(1);
 


### PR DESCRIPTION
## Summary

Fixes #5881.

`_.omit()` copied all enumerable properties before unsetting omitted paths, so an accessor for a directly omitted property was still invoked. This skips direct omitted keys during the initial copy, while preserving the existing deep-path clone/unset behavior.

## Validation

- `npm run test:main` (`PASS: 6832  FAIL: 0  TOTAL: 6832`)
- `npm run style:main`
- `node node_modules\jscs\bin\jscs <Windows-expanded test JS file list>`
- `git diff --check`

## Originality check

Before opening this PR, I searched existing lodash PRs for #5881, `omit getter`, `omitted properties getter`, and the regression test name. I did not find an existing PR covering this fix.