### PR TITLE
fix: treat undefined debounce/throttle options as defaults

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -10417,10 +10417,14 @@
       }
       wait = toNumber(wait) || 0;
       if (isObject(options)) {
-        leading = !!options.leading;
-        maxing = 'maxWait' in options;
+        leading = 'leading' in options && options.leading !== undefined
+          ? !!options.leading
+          : leading;
+        maxing = 'maxWait' in options && options.maxWait !== undefined;
         maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        trailing = 'trailing' in options && options.trailing !== undefined
+          ? !!options.trailing
+          : trailing;
       }
 
       function invokeFunc(time) {
@@ -11001,8 +11005,12 @@
         throw new TypeError(FUNC_ERROR_TEXT);
       }
       if (isObject(options)) {
-        leading = 'leading' in options ? !!options.leading : leading;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        leading = 'leading' in options && options.leading !== undefined
+          ? !!options.leading
+          : leading;
+        trailing = 'trailing' in options && options.trailing !== undefined
+          ? !!options.trailing
+          : trailing;
       }
       return debounce(func, wait, {
         'leading': leading,


### PR DESCRIPTION
When `debounce` or `throttle` options like `leading`, `trailing`, or `maxWait` are explicitly set to `undefined` in the options object, the `in` operator detects them but the `undefined` values incorrectly override defaults. For example:

```js
_.debounce(fn, 100, { trailing: undefined })
// trailing is set to false instead of the default true
```

**Fix**: Added an explicit `!== undefined` check alongside the `in` operator so that `undefined` option values fall back to their defaults.

Also applied the same fix in the `throttle` function.

Closes #5857