### PR TITLE
Fix _.invert and _.invertBy dropping `__proto__` keys

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -5298,7 +5298,7 @@
      */
     function createInverter(setter, toIteratee) {
       return function(object, iteratee) {
-        return baseInverter(object, setter, toIteratee(iteratee), {});
+        return baseInverter(object, setter, toIteratee(iteratee), Object.create(null));
       };
     }
 

--- a/lodash.js
+++ b/lodash.js
@@ -5298,7 +5298,7 @@
      */
     function createInverter(setter, toIteratee) {
       return function(object, iteratee) {
-        return baseInverter(object, setter, toIteratee(iteratee), {});
+        return baseInverter(object, setter, toIteratee(iteratee), Object.create(null));
       };
     }
 


### PR DESCRIPTION
This fixes #6195.

## Problem

When the value being inverted is `__proto__`, the property assignment `result[value] = key` in the `createInverter` function would set the prototype of the result object instead of creating a regular property, causing the key to be silently dropped.

## Reproduction

```js
_.invert({userId: 'alice', role: '__proto__', team: 'eng'});
// Expected: {alice: 'userId', __proto__: 'role', eng: 'team'}
// Actual:   {alice: 'userId', eng: 'team'}
```

## Fix

Changed the accumulator in `createInverter` from `{}` to `Object.create(null)`. Since null-prototype objects have no `__proto__` setter, `__proto__` is treated as a regular property name.

This is consistent with how other lodash methods (like `_.assign`, `_.merge`, etc.) handle `__proto__`.