### PR TITLE
Fix cloneDeep and clone filling sparse array holes with undefined

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -2735,7 +2735,9 @@
           subValue = value[key];
         }
         // Recursively populate clone (susceptible to call stack limits).
-        assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack));
+        if (!isArr || hasOwnProperty.call(value, key)) {
+          assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack));
+        }
       });
       return result;
     }
@@ -4835,7 +4837,9 @@
 
       array || (array = Array(length));
       while (++index < length) {
-        array[index] = source[index];
+        if (index in source) {
+          array[index] = source[index];
+        }
       }
       return array;
     }

--- a/lodash.js
+++ b/lodash.js
@@ -2735,7 +2735,9 @@
           subValue = value[key];
         }
         // Recursively populate clone (susceptible to call stack limits).
-        assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack));
+        if (!isArr || hasOwnProperty.call(value, key)) {
+          assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack));
+        }
       });
       return result;
     }
@@ -4835,7 +4837,9 @@
 
       array || (array = Array(length));
       while (++index < length) {
-        array[index] = source[index];
+        if (index in source) {
+          array[index] = source[index];
+        }
       }
       return array;
     }


### PR DESCRIPTION
This fixes #6191.

## Problem

When cloning sparse arrays (arrays with empty slots, e.g., `new Array(5); arr[3] = 42`), lodash methods `cloneDeep` and `clone` would fill holes with `undefined` values instead of preserving them as empty slots.

## Root Cause

1. In `baseClone`, the `arrayEach` iterator visits all indices from 0 to length-1, including holes. For holes, `assignValue` is called with `undefined`, converting the hole into a defined `undefined` property.

2. In `copyArray` (used by shallow `clone`), the same pattern of assigning `source[index]` for all indices converts holes to `undefined`.

## Fix

1. In `baseClone`, added a guard `!isArr || hasOwnProperty.call(value, key)` to only assign array elements that exist on the source.

2. In `copyArray`, added an `if (index in source)` guard to only copy existing indices.