### PR TITLE
docs(escape): add @see cross-links between escape and unescape

### DIFF
--- a/dist/lodash.js
+++ b/dist/lodash.js
@@ -14351,6 +14351,7 @@
      * @category String
      * @param {string} [string=''] The string to escape.
      * @returns {string} Returns the escaped string.
+     * @see _.unescape
      * @example
      *
      * _.escape('fred, barney, & pebbles');
@@ -15263,6 +15264,7 @@
      * @category String
      * @param {string} [string=''] The string to unescape.
      * @returns {string} Returns the unescaped string.
+     * @see _.escape
      * @example
      *
      * _.unescape('fred, barney, &amp; pebbles');

--- a/lodash.js
+++ b/lodash.js
@@ -14351,6 +14351,7 @@
      * @category String
      * @param {string} [string=''] The string to escape.
      * @returns {string} Returns the escaped string.
+     * @see _.unescape
      * @example
      *
      * _.escape('fred, barney, & pebbles');
@@ -15263,6 +15264,7 @@
      * @category String
      * @param {string} [string=''] The string to unescape.
      * @returns {string} Returns the unescaped string.
+     * @see _.escape
      * @example
      *
      * _.unescape('fred, barney, &amp; pebbles');


### PR DESCRIPTION
Addresses the discoverability half of #5940.

`_.filter` and `_.reject` already cross-reference each other via `@see`, but `_.escape` and `_.unescape` did not. This adds the reciprocal `@see` so each is reachable from the other in the docs.

On the wording half of the issue ("opposite of" vs "inverse of"): I left it as-is on purpose. The library uses them for two different relationships — "inverse of" for round-trip transforms (`escape`/`unescape`, `toPairs`/`fromPairs`) and "opposite of" for predicate/function complements (`filter`/`reject`, `before`, `pick`/`pickBy`). Flattening them to one word would lose that distinction. Flagging here in case you'd still prefer a single term — happy to follow up either way.

Refs #5940.
